### PR TITLE
Fix typo in error message

### DIFF
--- a/Mutagen.Bethesda.Core/Load Order/LoadOrder.cs
+++ b/Mutagen.Bethesda.Core/Load Order/LoadOrder.cs
@@ -93,7 +93,7 @@ namespace Mutagen.Bethesda
                 str = str.Trim();
                 if (!ModKey.TryFactory(str, out var key))
                 {
-                    throw new ArgumentException("Load order file had malformed line: {str}");   
+                    throw new ArgumentException($"Load order file had malformed line: {str}");   
                 }
                 ret.Add(key);
             }


### PR DESCRIPTION
Missing the `$` that will let me see why my modlist won't load