### PR TITLE
Fix for cell/worldspace getter overrides. Fallback to existing record in cache if exists.

### DIFF
--- a/Mutagen.Bethesda.Generation/Modules/MajorRecordContextEnumerationModule.cs
+++ b/Mutagen.Bethesda.Generation/Modules/MajorRecordContextEnumerationModule.cs
@@ -519,8 +519,10 @@ namespace Mutagen.Bethesda.Generation
                             subFg.AppendLine($"getter: (m, r) =>");
                             using (new BraceWrapper(subFg))
                             {
+                                subFg.AppendLine($"var baseRec = getter(m, linkCache.Lookup<{obj.Interface(getter: true)}>(obj.FormKey));");
+                                subFg.AppendLine($"if (baseRec.{loqui.Name} != null) return baseRec.{loqui.Name};");
                                 subFg.AppendLine($"var copy = ({loqui.TypeName()})(({loqui.Interface(getter: true)})r).DeepCopy(ModContextExt.{loqui.TargetObjectGeneration.Name}CopyMask);");
-                                subFg.AppendLine($"getter(m, linkCache.Lookup<{obj.Interface(getter: true)}>(obj.FormKey)).{loqui.Name} = copy;");
+                                subFg.AppendLine($"baseRec.{loqui.Name} = copy;");
                                 subFg.AppendLine($"return copy;");
                             }
                         });

--- a/Mutagen.Bethesda.Generation/Program.cs
+++ b/Mutagen.Bethesda.Generation/Program.cs
@@ -13,7 +13,7 @@ namespace Mutagen.Bethesda.Generation
 
         static void AttachDebugInspector()
         {
-            string testString = "public ModKey ModKey { get; }";
+            string testString = "var copy = (Cell)((ICellGetter)r).DeepCopy(ModContextExt.CellCopyMask);";
             FileGeneration.LineAppended
                 .Where(i => i.Contains(testString))
                 .Subscribe(s =>

--- a/Mutagen.Bethesda.Oblivion/Records/Major Records/Cell_Generated.cs
+++ b/Mutagen.Bethesda.Oblivion/Records/Major Records/Cell_Generated.cs
@@ -3053,8 +3053,10 @@ namespace Mutagen.Bethesda.Oblivion.Internals
                                 parent: curContext,
                                 getter: (m, r) =>
                                 {
+                                    var baseRec = getter(m, linkCache.Lookup<ICellGetter>(obj.FormKey));
+                                    if (baseRec.PathGrid != null) return baseRec.PathGrid;
                                     var copy = (PathGrid)((IPathGridGetter)r).DeepCopy(ModContextExt.PathGridCopyMask);
-                                    getter(m, linkCache.Lookup<ICellGetter>(obj.FormKey)).PathGrid = copy;
+                                    baseRec.PathGrid = copy;
                                     return copy;
                                 });
                         }
@@ -3073,8 +3075,10 @@ namespace Mutagen.Bethesda.Oblivion.Internals
                                 parent: curContext,
                                 getter: (m, r) =>
                                 {
+                                    var baseRec = getter(m, linkCache.Lookup<ICellGetter>(obj.FormKey));
+                                    if (baseRec.Landscape != null) return baseRec.Landscape;
                                     var copy = (Landscape)((ILandscapeGetter)r).DeepCopy(ModContextExt.LandscapeCopyMask);
-                                    getter(m, linkCache.Lookup<ICellGetter>(obj.FormKey)).Landscape = copy;
+                                    baseRec.Landscape = copy;
                                     return copy;
                                 });
                         }

--- a/Mutagen.Bethesda.Oblivion/Records/Major Records/Worldspace_Generated.cs
+++ b/Mutagen.Bethesda.Oblivion/Records/Major Records/Worldspace_Generated.cs
@@ -2580,8 +2580,10 @@ namespace Mutagen.Bethesda.Oblivion.Internals
                                 parent: curContext,
                                 getter: (m, r) =>
                                 {
+                                    var baseRec = getter(m, linkCache.Lookup<IWorldspaceGetter>(obj.FormKey));
+                                    if (baseRec.Road != null) return baseRec.Road;
                                     var copy = (Road)((IRoadGetter)r).DeepCopy(ModContextExt.RoadCopyMask);
-                                    getter(m, linkCache.Lookup<IWorldspaceGetter>(obj.FormKey)).Road = copy;
+                                    baseRec.Road = copy;
                                     return copy;
                                 });
                         }
@@ -2600,8 +2602,10 @@ namespace Mutagen.Bethesda.Oblivion.Internals
                                 parent: curContext,
                                 getter: (m, r) =>
                                 {
+                                    var baseRec = getter(m, linkCache.Lookup<IWorldspaceGetter>(obj.FormKey));
+                                    if (baseRec.TopCell != null) return baseRec.TopCell;
                                     var copy = (Cell)((ICellGetter)r).DeepCopy(ModContextExt.CellCopyMask);
-                                    getter(m, linkCache.Lookup<IWorldspaceGetter>(obj.FormKey)).TopCell = copy;
+                                    baseRec.TopCell = copy;
                                     return copy;
                                 });
                             foreach (var item in ((CellCommon)((ICellGetter)WorldspaceTopCellitem).CommonInstance()!).EnumerateMajorRecordContexts(
@@ -2613,8 +2617,10 @@ namespace Mutagen.Bethesda.Oblivion.Internals
                                 throwIfUnknown: false,
                                 getter: (m, r) =>
                                 {
+                                    var baseRec = getter(m, linkCache.Lookup<IWorldspaceGetter>(obj.FormKey));
+                                    if (baseRec.TopCell != null) return baseRec.TopCell;
                                     var copy = (Cell)((ICellGetter)r).DeepCopy(ModContextExt.CellCopyMask);
-                                    getter(m, linkCache.Lookup<IWorldspaceGetter>(obj.FormKey)).TopCell = copy;
+                                    baseRec.TopCell = copy;
                                     return copy;
                                 }))
                             {
@@ -2665,8 +2671,10 @@ namespace Mutagen.Bethesda.Oblivion.Internals
                                 throwIfUnknown: false,
                                 getter: (m, r) =>
                                 {
+                                    var baseRec = getter(m, linkCache.Lookup<IWorldspaceGetter>(obj.FormKey));
+                                    if (baseRec.TopCell != null) return baseRec.TopCell;
                                     var copy = (Cell)((ICellGetter)r).DeepCopy(ModContextExt.CellCopyMask);
-                                    getter(m, linkCache.Lookup<IWorldspaceGetter>(obj.FormKey)).TopCell = copy;
+                                    baseRec.TopCell = copy;
                                     return copy;
                                 }))
                             {
@@ -2702,8 +2710,10 @@ namespace Mutagen.Bethesda.Oblivion.Internals
                                 throwIfUnknown: false,
                                 getter: (m, r) =>
                                 {
+                                    var baseRec = getter(m, linkCache.Lookup<IWorldspaceGetter>(obj.FormKey));
+                                    if (baseRec.TopCell != null) return baseRec.TopCell;
                                     var copy = (Cell)((ICellGetter)r).DeepCopy(ModContextExt.CellCopyMask);
-                                    getter(m, linkCache.Lookup<IWorldspaceGetter>(obj.FormKey)).TopCell = copy;
+                                    baseRec.TopCell = copy;
                                     return copy;
                                 }))
                             {
@@ -2739,8 +2749,10 @@ namespace Mutagen.Bethesda.Oblivion.Internals
                                 throwIfUnknown: false,
                                 getter: (m, r) =>
                                 {
+                                    var baseRec = getter(m, linkCache.Lookup<IWorldspaceGetter>(obj.FormKey));
+                                    if (baseRec.TopCell != null) return baseRec.TopCell;
                                     var copy = (Cell)((ICellGetter)r).DeepCopy(ModContextExt.CellCopyMask);
-                                    getter(m, linkCache.Lookup<IWorldspaceGetter>(obj.FormKey)).TopCell = copy;
+                                    baseRec.TopCell = copy;
                                     return copy;
                                 }))
                             {
@@ -2776,8 +2788,10 @@ namespace Mutagen.Bethesda.Oblivion.Internals
                                 throwIfUnknown: false,
                                 getter: (m, r) =>
                                 {
+                                    var baseRec = getter(m, linkCache.Lookup<IWorldspaceGetter>(obj.FormKey));
+                                    if (baseRec.TopCell != null) return baseRec.TopCell;
                                     var copy = (Cell)((ICellGetter)r).DeepCopy(ModContextExt.CellCopyMask);
-                                    getter(m, linkCache.Lookup<IWorldspaceGetter>(obj.FormKey)).TopCell = copy;
+                                    baseRec.TopCell = copy;
                                     return copy;
                                 }))
                             {
@@ -2813,8 +2827,10 @@ namespace Mutagen.Bethesda.Oblivion.Internals
                                 throwIfUnknown: false,
                                 getter: (m, r) =>
                                 {
+                                    var baseRec = getter(m, linkCache.Lookup<IWorldspaceGetter>(obj.FormKey));
+                                    if (baseRec.TopCell != null) return baseRec.TopCell;
                                     var copy = (Cell)((ICellGetter)r).DeepCopy(ModContextExt.CellCopyMask);
-                                    getter(m, linkCache.Lookup<IWorldspaceGetter>(obj.FormKey)).TopCell = copy;
+                                    baseRec.TopCell = copy;
                                     return copy;
                                 }))
                             {
@@ -2849,8 +2865,10 @@ namespace Mutagen.Bethesda.Oblivion.Internals
                                 throwIfUnknown: false,
                                 getter: (m, r) =>
                                 {
+                                    var baseRec = getter(m, linkCache.Lookup<IWorldspaceGetter>(obj.FormKey));
+                                    if (baseRec.TopCell != null) return baseRec.TopCell;
                                     var copy = (Cell)((ICellGetter)r).DeepCopy(ModContextExt.CellCopyMask);
-                                    getter(m, linkCache.Lookup<IWorldspaceGetter>(obj.FormKey)).TopCell = copy;
+                                    baseRec.TopCell = copy;
                                     return copy;
                                 }))
                             {

--- a/Mutagen.Bethesda.Skyrim/Records/Major Records/Cell_Generated.cs
+++ b/Mutagen.Bethesda.Skyrim/Records/Major Records/Cell_Generated.cs
@@ -3810,8 +3810,10 @@ namespace Mutagen.Bethesda.Skyrim.Internals
                                 parent: curContext,
                                 getter: (m, r) =>
                                 {
+                                    var baseRec = getter(m, linkCache.Lookup<ICellGetter>(obj.FormKey));
+                                    if (baseRec.Landscape != null) return baseRec.Landscape;
                                     var copy = (Landscape)((ILandscapeGetter)r).DeepCopy(ModContextExt.LandscapeCopyMask);
-                                    getter(m, linkCache.Lookup<ICellGetter>(obj.FormKey)).Landscape = copy;
+                                    baseRec.Landscape = copy;
                                     return copy;
                                 });
                         }

--- a/Mutagen.Bethesda.Skyrim/Records/Major Records/Worldspace_Generated.cs
+++ b/Mutagen.Bethesda.Skyrim/Records/Major Records/Worldspace_Generated.cs
@@ -3959,10 +3959,8 @@ namespace Mutagen.Bethesda.Skyrim.Internals
                                 throwIfUnknown: false,
                                 getter: (m, r) =>
                                 {
-                                    var cacheWorldspace = getter(m, linkCache.Lookup<IWorldspaceGetter>(obj.FormKey));
-                                    if (cacheWorldspace.TopCell != null) return cacheWorldspace.TopCell;
                                     var copy = (Cell)((ICellGetter)r).DeepCopy(ModContextExt.CellCopyMask);
-                                    cacheWorldspace.TopCell = copy;
+                                    getter(m, linkCache.Lookup<IWorldspaceGetter>(obj.FormKey)).TopCell = copy;
                                     return copy;
                                 }))
                             {

--- a/Mutagen.Bethesda.Skyrim/Records/Major Records/Worldspace_Generated.cs
+++ b/Mutagen.Bethesda.Skyrim/Records/Major Records/Worldspace_Generated.cs
@@ -3783,8 +3783,10 @@ namespace Mutagen.Bethesda.Skyrim.Internals
                                 parent: curContext,
                                 getter: (m, r) =>
                                 {
+                                    var baseRec = getter(m, linkCache.Lookup<IWorldspaceGetter>(obj.FormKey));
+                                    if (baseRec.TopCell != null) return baseRec.TopCell;
                                     var copy = (Cell)((ICellGetter)r).DeepCopy(ModContextExt.CellCopyMask);
-                                    getter(m, linkCache.Lookup<IWorldspaceGetter>(obj.FormKey)).TopCell = copy;
+                                    baseRec.TopCell = copy;
                                     return copy;
                                 });
                             foreach (var item in ((CellCommon)((ICellGetter)WorldspaceTopCellitem).CommonInstance()!).EnumerateMajorRecordContexts(
@@ -3796,8 +3798,10 @@ namespace Mutagen.Bethesda.Skyrim.Internals
                                 throwIfUnknown: false,
                                 getter: (m, r) =>
                                 {
+                                    var baseRec = getter(m, linkCache.Lookup<IWorldspaceGetter>(obj.FormKey));
+                                    if (baseRec.TopCell != null) return baseRec.TopCell;
                                     var copy = (Cell)((ICellGetter)r).DeepCopy(ModContextExt.CellCopyMask);
-                                    getter(m, linkCache.Lookup<IWorldspaceGetter>(obj.FormKey)).TopCell = copy;
+                                    baseRec.TopCell = copy;
                                     return copy;
                                 }))
                             {
@@ -3848,8 +3852,10 @@ namespace Mutagen.Bethesda.Skyrim.Internals
                                 throwIfUnknown: false,
                                 getter: (m, r) =>
                                 {
+                                    var baseRec = getter(m, linkCache.Lookup<IWorldspaceGetter>(obj.FormKey));
+                                    if (baseRec.TopCell != null) return baseRec.TopCell;
                                     var copy = (Cell)((ICellGetter)r).DeepCopy(ModContextExt.CellCopyMask);
-                                    getter(m, linkCache.Lookup<IWorldspaceGetter>(obj.FormKey)).TopCell = copy;
+                                    baseRec.TopCell = copy;
                                     return copy;
                                 }))
                             {
@@ -3885,8 +3891,10 @@ namespace Mutagen.Bethesda.Skyrim.Internals
                                 throwIfUnknown: false,
                                 getter: (m, r) =>
                                 {
+                                    var baseRec = getter(m, linkCache.Lookup<IWorldspaceGetter>(obj.FormKey));
+                                    if (baseRec.TopCell != null) return baseRec.TopCell;
                                     var copy = (Cell)((ICellGetter)r).DeepCopy(ModContextExt.CellCopyMask);
-                                    getter(m, linkCache.Lookup<IWorldspaceGetter>(obj.FormKey)).TopCell = copy;
+                                    baseRec.TopCell = copy;
                                     return copy;
                                 }))
                             {
@@ -3922,8 +3930,10 @@ namespace Mutagen.Bethesda.Skyrim.Internals
                                 throwIfUnknown: false,
                                 getter: (m, r) =>
                                 {
+                                    var baseRec = getter(m, linkCache.Lookup<IWorldspaceGetter>(obj.FormKey));
+                                    if (baseRec.TopCell != null) return baseRec.TopCell;
                                     var copy = (Cell)((ICellGetter)r).DeepCopy(ModContextExt.CellCopyMask);
-                                    getter(m, linkCache.Lookup<IWorldspaceGetter>(obj.FormKey)).TopCell = copy;
+                                    baseRec.TopCell = copy;
                                     return copy;
                                 }))
                             {
@@ -3959,8 +3969,10 @@ namespace Mutagen.Bethesda.Skyrim.Internals
                                 throwIfUnknown: false,
                                 getter: (m, r) =>
                                 {
+                                    var baseRec = getter(m, linkCache.Lookup<IWorldspaceGetter>(obj.FormKey));
+                                    if (baseRec.TopCell != null) return baseRec.TopCell;
                                     var copy = (Cell)((ICellGetter)r).DeepCopy(ModContextExt.CellCopyMask);
-                                    getter(m, linkCache.Lookup<IWorldspaceGetter>(obj.FormKey)).TopCell = copy;
+                                    baseRec.TopCell = copy;
                                     return copy;
                                 }))
                             {
@@ -3996,8 +4008,10 @@ namespace Mutagen.Bethesda.Skyrim.Internals
                                 throwIfUnknown: false,
                                 getter: (m, r) =>
                                 {
+                                    var baseRec = getter(m, linkCache.Lookup<IWorldspaceGetter>(obj.FormKey));
+                                    if (baseRec.TopCell != null) return baseRec.TopCell;
                                     var copy = (Cell)((ICellGetter)r).DeepCopy(ModContextExt.CellCopyMask);
-                                    getter(m, linkCache.Lookup<IWorldspaceGetter>(obj.FormKey)).TopCell = copy;
+                                    baseRec.TopCell = copy;
                                     return copy;
                                 }))
                             {
@@ -4048,8 +4062,10 @@ namespace Mutagen.Bethesda.Skyrim.Internals
                                 throwIfUnknown: false,
                                 getter: (m, r) =>
                                 {
+                                    var baseRec = getter(m, linkCache.Lookup<IWorldspaceGetter>(obj.FormKey));
+                                    if (baseRec.TopCell != null) return baseRec.TopCell;
                                     var copy = (Cell)((ICellGetter)r).DeepCopy(ModContextExt.CellCopyMask);
-                                    getter(m, linkCache.Lookup<IWorldspaceGetter>(obj.FormKey)).TopCell = copy;
+                                    baseRec.TopCell = copy;
                                     return copy;
                                 }))
                             {
@@ -4085,8 +4101,10 @@ namespace Mutagen.Bethesda.Skyrim.Internals
                                 throwIfUnknown: false,
                                 getter: (m, r) =>
                                 {
+                                    var baseRec = getter(m, linkCache.Lookup<IWorldspaceGetter>(obj.FormKey));
+                                    if (baseRec.TopCell != null) return baseRec.TopCell;
                                     var copy = (Cell)((ICellGetter)r).DeepCopy(ModContextExt.CellCopyMask);
-                                    getter(m, linkCache.Lookup<IWorldspaceGetter>(obj.FormKey)).TopCell = copy;
+                                    baseRec.TopCell = copy;
                                     return copy;
                                 }))
                             {
@@ -4122,8 +4140,10 @@ namespace Mutagen.Bethesda.Skyrim.Internals
                                 throwIfUnknown: false,
                                 getter: (m, r) =>
                                 {
+                                    var baseRec = getter(m, linkCache.Lookup<IWorldspaceGetter>(obj.FormKey));
+                                    if (baseRec.TopCell != null) return baseRec.TopCell;
                                     var copy = (Cell)((ICellGetter)r).DeepCopy(ModContextExt.CellCopyMask);
-                                    getter(m, linkCache.Lookup<IWorldspaceGetter>(obj.FormKey)).TopCell = copy;
+                                    baseRec.TopCell = copy;
                                     return copy;
                                 }))
                             {
@@ -4159,8 +4179,10 @@ namespace Mutagen.Bethesda.Skyrim.Internals
                                 throwIfUnknown: false,
                                 getter: (m, r) =>
                                 {
+                                    var baseRec = getter(m, linkCache.Lookup<IWorldspaceGetter>(obj.FormKey));
+                                    if (baseRec.TopCell != null) return baseRec.TopCell;
                                     var copy = (Cell)((ICellGetter)r).DeepCopy(ModContextExt.CellCopyMask);
-                                    getter(m, linkCache.Lookup<IWorldspaceGetter>(obj.FormKey)).TopCell = copy;
+                                    baseRec.TopCell = copy;
                                     return copy;
                                 }))
                             {
@@ -4196,8 +4218,10 @@ namespace Mutagen.Bethesda.Skyrim.Internals
                                 throwIfUnknown: false,
                                 getter: (m, r) =>
                                 {
+                                    var baseRec = getter(m, linkCache.Lookup<IWorldspaceGetter>(obj.FormKey));
+                                    if (baseRec.TopCell != null) return baseRec.TopCell;
                                     var copy = (Cell)((ICellGetter)r).DeepCopy(ModContextExt.CellCopyMask);
-                                    getter(m, linkCache.Lookup<IWorldspaceGetter>(obj.FormKey)).TopCell = copy;
+                                    baseRec.TopCell = copy;
                                     return copy;
                                 }))
                             {
@@ -4233,8 +4257,10 @@ namespace Mutagen.Bethesda.Skyrim.Internals
                                 throwIfUnknown: false,
                                 getter: (m, r) =>
                                 {
+                                    var baseRec = getter(m, linkCache.Lookup<IWorldspaceGetter>(obj.FormKey));
+                                    if (baseRec.TopCell != null) return baseRec.TopCell;
                                     var copy = (Cell)((ICellGetter)r).DeepCopy(ModContextExt.CellCopyMask);
-                                    getter(m, linkCache.Lookup<IWorldspaceGetter>(obj.FormKey)).TopCell = copy;
+                                    baseRec.TopCell = copy;
                                     return copy;
                                 }))
                             {

--- a/Mutagen.Bethesda.Skyrim/Records/Major Records/Worldspace_Generated.cs
+++ b/Mutagen.Bethesda.Skyrim/Records/Major Records/Worldspace_Generated.cs
@@ -3959,8 +3959,10 @@ namespace Mutagen.Bethesda.Skyrim.Internals
                                 throwIfUnknown: false,
                                 getter: (m, r) =>
                                 {
+                                    var cacheWorldspace = getter(m, linkCache.Lookup<IWorldspaceGetter>(obj.FormKey));
+                                    if (cacheWorldspace.TopCell != null) return cacheWorldspace.TopCell;
                                     var copy = (Cell)((ICellGetter)r).DeepCopy(ModContextExt.CellCopyMask);
-                                    getter(m, linkCache.Lookup<IWorldspaceGetter>(obj.FormKey)).TopCell = copy;
+                                    cacheWorldspace.TopCell = copy;
                                     return copy;
                                 }))
                             {


### PR DESCRIPTION
When calls such as EnumerateMajorRecordContexts was being invoked, always a fresh DeepCopy would be return, regardless of whether there was a existing corresponding entity in the provided cache.
This will simply check the cache for it, and return the found getter entity if it is available. Only resolve to DeepCopy when it is needed. This will cause subsequent overrides of top level records like TopCells to work properly. 
Building up sub-entity changes like Persistent collection of PlacedObjects was impossible before since it would return a new copy of the cell everytime regardless of whether it existed in the cache of not.