### PR TITLE
Fixes and tests for subrecord length overflow in mod headers

### DIFF
--- a/Mutagen.Bethesda.Core.UnitTests/Plugins/Binary/Headers/HeaderExtTests.cs
+++ b/Mutagen.Bethesda.Core.UnitTests/Plugins/Binary/Headers/HeaderExtTests.cs
@@ -4,6 +4,7 @@ using FluentAssertions;
 using Mutagen.Bethesda.Plugins;
 using Mutagen.Bethesda.Plugins.Binary.Headers;
 using Mutagen.Bethesda.Plugins.Meta;
+using Mutagen.Bethesda.Strings.DI;
 using Mutagen.Bethesda.Testing;
 using Mutagen.Bethesda.UnitTests.Placeholders;
 using Xunit;
@@ -116,9 +117,9 @@ public class HeaderExtTests
     }
 
     [Fact]
-    public void ModHeaderOverflow()
+    public void ModHeaderFrameOverflow()
     {
-        byte[] b = TestDataPathing.GetBytes("Plugins/Binary/Headers/ModHeaderOverflow");
+        byte[] b = TestDataPathing.GetBytes(TestDataPathing.HeaderOverflow);
         var modHeader = new ModHeaderFrame(GameConstants.SkyrimSE, b);
         var recs = modHeader.ToList();
         recs.Should().HaveCount(3);
@@ -129,5 +130,14 @@ public class HeaderExtTests
         recs[1].ContentLength.Should().Be(0x08);
         recs[2].ContentLength.Should().Be(0x04);
         recs[2].AsInt32().Should().Be(0x04030201);
+    }
+
+    [Fact]
+    public void MastersEnumerationWithOverflow()
+    {
+        byte[] b = TestDataPathing.GetBytes(TestDataPathing.HeaderOverflow);
+        var modHeader = new ModHeaderFrame(GameConstants.SkyrimSE, b);
+        modHeader.Masters().Select(x => x.AsString(MutagenEncodingProvider._1252))
+            .Should().Equal("Dawnguard.esm");
     }
 }

--- a/Mutagen.Bethesda.Core/Plugins/Binary/Headers/HeaderExt.cs
+++ b/Mutagen.Bethesda.Core/Plugins/Binary/Headers/HeaderExt.cs
@@ -617,9 +617,9 @@ public static class HeaderExt
         return EnumerateSubrecords(modHeader.HeaderAndContentData, modHeader.Meta, modHeader.HeaderLength, lengthOverflowTypes ?? _headerOverflow);
     }
 
-    public static IEnumerable<SubrecordPinFrame> Masters(this ModHeaderFrame modHeader)
+    public static IEnumerable<SubrecordPinFrame> Masters(this ModHeaderFrame modHeader, ICollection<RecordType>? lengthOverflowTypes = null)
     {
-        foreach (var pin in EnumerateSubrecords(modHeader, lengthOverflowTypes: Array.Empty<RecordType>()))
+        foreach (var pin in EnumerateSubrecords(modHeader, lengthOverflowTypes: lengthOverflowTypes ?? _headerOverflow))
         {
             if (pin.RecordType == RecordTypes.MAST)
             {

--- a/Mutagen.Bethesda.Core/Plugins/Binary/Overlay/PluginBinaryOverlay.cs
+++ b/Mutagen.Bethesda.Core/Plugins/Binary/Overlay/PluginBinaryOverlay.cs
@@ -191,7 +191,15 @@ internal abstract class PluginBinaryOverlay : ILoquiObject
             {
                 SubrecordHeader subMeta = stream.GetSubrecord();
                 lastParsedType = subMeta.RecordType;
-                var minimumFinalPos = stream.Position + subMeta.TotalLength;
+                var minimumFinalPos = stream.Position;
+                if (lastParsed.LengthOverride.HasValue)
+                {
+                    minimumFinalPos += lastParsed.LengthOverride.Value + subMeta.HeaderLength;
+                }
+                else
+                {
+                    minimumFinalPos += subMeta.TotalLength;
+                }
                 var parsed = fill(
                     stream: stream,
                     finalPos: minimumFinalPos,
@@ -262,7 +270,7 @@ internal abstract class PluginBinaryOverlay : ILoquiObject
             var minimumFinalPos = stream.Position + subMeta.TotalLength;
             var parsed = fill(
                 stream: stream,
-                finalPos: finalPos,
+                finalPos: minimumFinalPos,
                 offset: offset,
                 recordParseCount: recordParseCount,
                 type: subMeta.RecordType,

--- a/Mutagen.Bethesda.Core/Plugins/Binary/Translations/PluginUtilityTranslation.cs
+++ b/Mutagen.Bethesda.Core/Plugins/Binary/Translations/PluginUtilityTranslation.cs
@@ -191,7 +191,7 @@ public static class PluginUtilityTranslation
                 lastParsed: previousParse,
                 recordParseCount: recordParseCount,
                 nextRecordType: subMeta.RecordType,
-                contentLength: subMeta.ContentLength,
+                contentLength: previousParse.LengthOverride ?? subMeta.ContentLength,
                 translationParams: translationParams);
             if (!parsed.KeepParsing) break;
             if (parsed.DuplicateParseMarker != null)

--- a/Mutagen.Bethesda.Fallout4/Records/Common Subrecords/Bone_Generated.cs
+++ b/Mutagen.Bethesda.Fallout4/Records/Common Subrecords/Bone_Generated.cs
@@ -1473,7 +1473,7 @@ namespace Mutagen.Bethesda.Fallout4
                 {
                     if (lastParsed.ParsedIndex.HasValue && lastParsed.ParsedIndex.Value >= (int)Bone_FieldIndex.Values) return ParseResult.Stop;
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.Values = BinaryOverlayList.FactoryByStartIndex<Single>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,

--- a/Mutagen.Bethesda.Fallout4/Records/Common Subrecords/Destructible_Generated.cs
+++ b/Mutagen.Bethesda.Fallout4/Records/Common Subrecords/Destructible_Generated.cs
@@ -1648,7 +1648,7 @@ namespace Mutagen.Bethesda.Fallout4
                 {
                     if (lastParsed.ParsedIndex.HasValue && lastParsed.ParsedIndex.Value >= (int)Destructible_FieldIndex.Resistances) return ParseResult.Stop;
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.Resistances = BinaryOverlayList.FactoryByStartIndex<ResistanceDestructibleBinaryOverlay>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,

--- a/Mutagen.Bethesda.Fallout4/Records/Fallout4ModHeader_Generated.cs
+++ b/Mutagen.Bethesda.Fallout4/Records/Fallout4ModHeader_Generated.cs
@@ -2681,16 +2681,7 @@ namespace Mutagen.Bethesda.Fallout4
                 case RecordTypeInts.ONAM:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    int subLen;
-                    if (subMeta.RecordType == RecordTypes.XXXX)
-                    {
-                        subLen = checked((int)stream.ReadUInt32());
-                        stream.ReadSubrecord();
-                    }
-                    else
-                    {
-                        subLen = subMeta.ContentLength;
-                    }
+                    var subLen = finalPos - stream.Position;
                     this.OverriddenForms = BinaryOverlayList.FactoryByStartIndex<IFormLinkGetter<IFallout4MajorRecordGetter>>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,

--- a/Mutagen.Bethesda.Fallout4/Records/Major Records/Activator_Generated.cs
+++ b/Mutagen.Bethesda.Fallout4/Records/Major Records/Activator_Generated.cs
@@ -3902,7 +3902,7 @@ namespace Mutagen.Bethesda.Fallout4
                 case RecordTypeInts.PRPS:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.Properties = BinaryOverlayList.FactoryByStartIndex<ObjectPropertyBinaryOverlay>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,

--- a/Mutagen.Bethesda.Fallout4/Records/Major Records/Armor_Generated.cs
+++ b/Mutagen.Bethesda.Fallout4/Records/Major Records/Armor_Generated.cs
@@ -4809,7 +4809,7 @@ namespace Mutagen.Bethesda.Fallout4
                 case RecordTypeInts.DAMA:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.Resistances = BinaryOverlayList.FactoryByStartIndex<ArmorResistanceBinaryOverlay>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,
@@ -4826,7 +4826,7 @@ namespace Mutagen.Bethesda.Fallout4
                 case RecordTypeInts.APPR:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.AttachParentSlots = BinaryOverlayList.FactoryByStartIndex<IFormLinkGetter<IKeywordGetter>>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,

--- a/Mutagen.Bethesda.Fallout4/Records/Major Records/Class_Generated.cs
+++ b/Mutagen.Bethesda.Fallout4/Records/Major Records/Class_Generated.cs
@@ -2107,7 +2107,7 @@ namespace Mutagen.Bethesda.Fallout4
                 case RecordTypeInts.PRPS:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.Properties = BinaryOverlayList.FactoryByStartIndex<ObjectPropertyBinaryOverlay>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,

--- a/Mutagen.Bethesda.Fallout4/Records/Major Records/Climate_Generated.cs
+++ b/Mutagen.Bethesda.Fallout4/Records/Major Records/Climate_Generated.cs
@@ -2404,7 +2404,7 @@ namespace Mutagen.Bethesda.Fallout4
                 case RecordTypeInts.WLST:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.Weathers = BinaryOverlayList.FactoryByStartIndex<WeatherTypeBinaryOverlay>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,

--- a/Mutagen.Bethesda.Fallout4/Records/Major Records/Container_Generated.cs
+++ b/Mutagen.Bethesda.Fallout4/Records/Major Records/Container_Generated.cs
@@ -3565,7 +3565,7 @@ namespace Mutagen.Bethesda.Fallout4
                 case RecordTypeInts.PRPS:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.Properties = BinaryOverlayList.FactoryByStartIndex<ObjectPropertyBinaryOverlay>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,

--- a/Mutagen.Bethesda.Fallout4/Records/Major Records/DamageTypeIndexed_Generated.cs
+++ b/Mutagen.Bethesda.Fallout4/Records/Major Records/DamageTypeIndexed_Generated.cs
@@ -1708,7 +1708,7 @@ namespace Mutagen.Bethesda.Fallout4
                 case RecordTypeInts.DNAM:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.DamageTypes = BinaryOverlayList.FactoryByStartIndex<UInt32>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,

--- a/Mutagen.Bethesda.Fallout4/Records/Major Records/DamageType_Generated.cs
+++ b/Mutagen.Bethesda.Fallout4/Records/Major Records/DamageType_Generated.cs
@@ -1728,7 +1728,7 @@ namespace Mutagen.Bethesda.Fallout4
                 case RecordTypeInts.DNAM:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.DamageTypes = BinaryOverlayList.FactoryByStartIndex<IFormLinkGetter<IDamageTypeTargetGetter>>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,

--- a/Mutagen.Bethesda.Fallout4/Records/Major Records/Flora_Generated.cs
+++ b/Mutagen.Bethesda.Fallout4/Records/Major Records/Flora_Generated.cs
@@ -3142,7 +3142,7 @@ namespace Mutagen.Bethesda.Fallout4
                 case RecordTypeInts.PRPS:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.Properties = BinaryOverlayList.FactoryByStartIndex<ObjectPropertyBinaryOverlay>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,

--- a/Mutagen.Bethesda.Fallout4/Records/Major Records/Furniture_Generated.cs
+++ b/Mutagen.Bethesda.Fallout4/Records/Major Records/Furniture_Generated.cs
@@ -5059,7 +5059,7 @@ namespace Mutagen.Bethesda.Fallout4
                 case RecordTypeInts.PRPS:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.Properties = BinaryOverlayList.FactoryByStartIndex<ObjectPropertyBinaryOverlay>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,
@@ -5187,7 +5187,7 @@ namespace Mutagen.Bethesda.Fallout4
                 case RecordTypeInts.APPR:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.AttachParentSlots = BinaryOverlayList.FactoryByStartIndex<IFormLinkGetter<IKeywordGetter>>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,

--- a/Mutagen.Bethesda.Fallout4/Records/Major Records/IdleAnimation_Generated.cs
+++ b/Mutagen.Bethesda.Fallout4/Records/Major Records/IdleAnimation_Generated.cs
@@ -2420,7 +2420,7 @@ namespace Mutagen.Bethesda.Fallout4
                 case RecordTypeInts.ANAM:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.RelatedIdles = BinaryOverlayList.FactoryByStartIndex<IFormLinkGetter<IIdleRelationGetter>>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,

--- a/Mutagen.Bethesda.Fallout4/Records/Major Records/ImageSpaceAdapter_Generated.cs
+++ b/Mutagen.Bethesda.Fallout4/Records/Major Records/ImageSpaceAdapter_Generated.cs
@@ -13156,7 +13156,7 @@ namespace Mutagen.Bethesda.Fallout4
                 case RecordTypeInts.BNAM:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.BlurRadius = BinaryOverlayList.FactoryByStartIndex<KeyFrameBinaryOverlay>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,
@@ -13168,7 +13168,7 @@ namespace Mutagen.Bethesda.Fallout4
                 case RecordTypeInts.VNAM:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.DoubleVisionStrength = BinaryOverlayList.FactoryByStartIndex<KeyFrameBinaryOverlay>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,
@@ -13180,7 +13180,7 @@ namespace Mutagen.Bethesda.Fallout4
                 case RecordTypeInts.TNAM:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.TintColor = BinaryOverlayList.FactoryByStartIndex<ColorFrameBinaryOverlay>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,
@@ -13192,7 +13192,7 @@ namespace Mutagen.Bethesda.Fallout4
                 case RecordTypeInts.NAM3:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.FadeColor = BinaryOverlayList.FactoryByStartIndex<ColorFrameBinaryOverlay>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,
@@ -13204,7 +13204,7 @@ namespace Mutagen.Bethesda.Fallout4
                 case RecordTypeInts.RNAM:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.RadialBlurStrength = BinaryOverlayList.FactoryByStartIndex<KeyFrameBinaryOverlay>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,
@@ -13216,7 +13216,7 @@ namespace Mutagen.Bethesda.Fallout4
                 case RecordTypeInts.SNAM:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.RadialBlurRampUp = BinaryOverlayList.FactoryByStartIndex<KeyFrameBinaryOverlay>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,
@@ -13228,7 +13228,7 @@ namespace Mutagen.Bethesda.Fallout4
                 case RecordTypeInts.UNAM:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.RadialBlurStart = BinaryOverlayList.FactoryByStartIndex<KeyFrameBinaryOverlay>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,
@@ -13240,7 +13240,7 @@ namespace Mutagen.Bethesda.Fallout4
                 case RecordTypeInts.NAM1:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.RadialBlurRampDown = BinaryOverlayList.FactoryByStartIndex<KeyFrameBinaryOverlay>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,
@@ -13252,7 +13252,7 @@ namespace Mutagen.Bethesda.Fallout4
                 case RecordTypeInts.NAM2:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.RadialBlurDownStart = BinaryOverlayList.FactoryByStartIndex<KeyFrameBinaryOverlay>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,
@@ -13264,7 +13264,7 @@ namespace Mutagen.Bethesda.Fallout4
                 case RecordTypeInts.WNAM:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.DepthOfFieldStrength = BinaryOverlayList.FactoryByStartIndex<KeyFrameBinaryOverlay>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,
@@ -13276,7 +13276,7 @@ namespace Mutagen.Bethesda.Fallout4
                 case RecordTypeInts.XNAM:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.DepthOfFieldDistance = BinaryOverlayList.FactoryByStartIndex<KeyFrameBinaryOverlay>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,
@@ -13288,7 +13288,7 @@ namespace Mutagen.Bethesda.Fallout4
                 case RecordTypeInts.YNAM:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.DepthOfFieldRange = BinaryOverlayList.FactoryByStartIndex<KeyFrameBinaryOverlay>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,
@@ -13300,7 +13300,7 @@ namespace Mutagen.Bethesda.Fallout4
                 case RecordTypeInts.NAM4:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.MotionBlurStrength = BinaryOverlayList.FactoryByStartIndex<KeyFrameBinaryOverlay>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,
@@ -13312,7 +13312,7 @@ namespace Mutagen.Bethesda.Fallout4
                 case RecordTypeInts._0_IAD:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.HdrEyeAdaptSpeedMult = BinaryOverlayList.FactoryByStartIndex<KeyFrameBinaryOverlay>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,
@@ -13324,7 +13324,7 @@ namespace Mutagen.Bethesda.Fallout4
                 case RecordTypeInts.@IAD:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.HdrEyeAdaptSpeedAdd = BinaryOverlayList.FactoryByStartIndex<KeyFrameBinaryOverlay>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,
@@ -13336,7 +13336,7 @@ namespace Mutagen.Bethesda.Fallout4
                 case RecordTypeInts._1_IAD:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.HdrBloomBlurRadiusMult = BinaryOverlayList.FactoryByStartIndex<KeyFrameBinaryOverlay>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,
@@ -13348,7 +13348,7 @@ namespace Mutagen.Bethesda.Fallout4
                 case RecordTypeInts.AIAD:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.HdrBloomBlurRadiusAdd = BinaryOverlayList.FactoryByStartIndex<KeyFrameBinaryOverlay>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,
@@ -13360,7 +13360,7 @@ namespace Mutagen.Bethesda.Fallout4
                 case RecordTypeInts._2_IAD:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.HdrBloomThresholdMult = BinaryOverlayList.FactoryByStartIndex<KeyFrameBinaryOverlay>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,
@@ -13372,7 +13372,7 @@ namespace Mutagen.Bethesda.Fallout4
                 case RecordTypeInts.BIAD:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.HdrBloomThresholdAdd = BinaryOverlayList.FactoryByStartIndex<KeyFrameBinaryOverlay>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,
@@ -13384,7 +13384,7 @@ namespace Mutagen.Bethesda.Fallout4
                 case RecordTypeInts._3_IAD:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.HdrBloomScaleMult = BinaryOverlayList.FactoryByStartIndex<KeyFrameBinaryOverlay>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,
@@ -13396,7 +13396,7 @@ namespace Mutagen.Bethesda.Fallout4
                 case RecordTypeInts.CIAD:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.HdrBloomScaleAdd = BinaryOverlayList.FactoryByStartIndex<KeyFrameBinaryOverlay>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,
@@ -13408,7 +13408,7 @@ namespace Mutagen.Bethesda.Fallout4
                 case RecordTypeInts._4_IAD:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.HdrTargetLumMinMult = BinaryOverlayList.FactoryByStartIndex<KeyFrameBinaryOverlay>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,
@@ -13420,7 +13420,7 @@ namespace Mutagen.Bethesda.Fallout4
                 case RecordTypeInts.DIAD:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.HdrTargetLumMinAdd = BinaryOverlayList.FactoryByStartIndex<KeyFrameBinaryOverlay>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,
@@ -13432,7 +13432,7 @@ namespace Mutagen.Bethesda.Fallout4
                 case RecordTypeInts._5_IAD:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.HdrTargetLumMaxMult = BinaryOverlayList.FactoryByStartIndex<KeyFrameBinaryOverlay>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,
@@ -13444,7 +13444,7 @@ namespace Mutagen.Bethesda.Fallout4
                 case RecordTypeInts.EIAD:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.HdrTargetLumMaxAdd = BinaryOverlayList.FactoryByStartIndex<KeyFrameBinaryOverlay>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,
@@ -13456,7 +13456,7 @@ namespace Mutagen.Bethesda.Fallout4
                 case RecordTypeInts._6_IAD:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.HdrSunlightScaleMult = BinaryOverlayList.FactoryByStartIndex<KeyFrameBinaryOverlay>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,
@@ -13468,7 +13468,7 @@ namespace Mutagen.Bethesda.Fallout4
                 case RecordTypeInts.FIAD:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.HdrSunlightScaleAdd = BinaryOverlayList.FactoryByStartIndex<KeyFrameBinaryOverlay>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,
@@ -13480,7 +13480,7 @@ namespace Mutagen.Bethesda.Fallout4
                 case RecordTypeInts._7_IAD:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.HdrSkyScaleMult = BinaryOverlayList.FactoryByStartIndex<KeyFrameBinaryOverlay>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,
@@ -13492,7 +13492,7 @@ namespace Mutagen.Bethesda.Fallout4
                 case RecordTypeInts.GIAD:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.HdrSkyScaleAdd = BinaryOverlayList.FactoryByStartIndex<KeyFrameBinaryOverlay>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,
@@ -13504,7 +13504,7 @@ namespace Mutagen.Bethesda.Fallout4
                 case RecordTypeInts._8_IAD:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.Unknown08 = BinaryOverlayList.FactoryByStartIndex<KeyFrameBinaryOverlay>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,
@@ -13516,7 +13516,7 @@ namespace Mutagen.Bethesda.Fallout4
                 case RecordTypeInts.HIAD:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.Unknown48 = BinaryOverlayList.FactoryByStartIndex<KeyFrameBinaryOverlay>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,
@@ -13528,7 +13528,7 @@ namespace Mutagen.Bethesda.Fallout4
                 case RecordTypeInts._9_IAD:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.Unknown09 = BinaryOverlayList.FactoryByStartIndex<KeyFrameBinaryOverlay>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,
@@ -13540,7 +13540,7 @@ namespace Mutagen.Bethesda.Fallout4
                 case RecordTypeInts.IIAD:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.Unknown49 = BinaryOverlayList.FactoryByStartIndex<KeyFrameBinaryOverlay>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,
@@ -13552,7 +13552,7 @@ namespace Mutagen.Bethesda.Fallout4
                 case RecordTypeInts._A_IAD:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.Unknown0A = BinaryOverlayList.FactoryByStartIndex<KeyFrameBinaryOverlay>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,
@@ -13564,7 +13564,7 @@ namespace Mutagen.Bethesda.Fallout4
                 case RecordTypeInts.JIAD:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.Unknown4A = BinaryOverlayList.FactoryByStartIndex<KeyFrameBinaryOverlay>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,
@@ -13576,7 +13576,7 @@ namespace Mutagen.Bethesda.Fallout4
                 case RecordTypeInts._B_IAD:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.Unknown0B = BinaryOverlayList.FactoryByStartIndex<KeyFrameBinaryOverlay>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,
@@ -13588,7 +13588,7 @@ namespace Mutagen.Bethesda.Fallout4
                 case RecordTypeInts.KIAD:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.Unknown4B = BinaryOverlayList.FactoryByStartIndex<KeyFrameBinaryOverlay>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,
@@ -13600,7 +13600,7 @@ namespace Mutagen.Bethesda.Fallout4
                 case RecordTypeInts._C_IAD:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.Unknown0C = BinaryOverlayList.FactoryByStartIndex<KeyFrameBinaryOverlay>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,
@@ -13612,7 +13612,7 @@ namespace Mutagen.Bethesda.Fallout4
                 case RecordTypeInts.LIAD:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.Unknown4C = BinaryOverlayList.FactoryByStartIndex<KeyFrameBinaryOverlay>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,
@@ -13624,7 +13624,7 @@ namespace Mutagen.Bethesda.Fallout4
                 case RecordTypeInts._D_IAD:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.Unknown0D = BinaryOverlayList.FactoryByStartIndex<KeyFrameBinaryOverlay>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,
@@ -13636,7 +13636,7 @@ namespace Mutagen.Bethesda.Fallout4
                 case RecordTypeInts.MIAD:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.Unknown4D = BinaryOverlayList.FactoryByStartIndex<KeyFrameBinaryOverlay>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,
@@ -13648,7 +13648,7 @@ namespace Mutagen.Bethesda.Fallout4
                 case RecordTypeInts._E_IAD:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.Unknown0E = BinaryOverlayList.FactoryByStartIndex<KeyFrameBinaryOverlay>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,
@@ -13660,7 +13660,7 @@ namespace Mutagen.Bethesda.Fallout4
                 case RecordTypeInts.NIAD:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.Unknown4E = BinaryOverlayList.FactoryByStartIndex<KeyFrameBinaryOverlay>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,
@@ -13672,7 +13672,7 @@ namespace Mutagen.Bethesda.Fallout4
                 case RecordTypeInts._F_IAD:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.Unknown0F = BinaryOverlayList.FactoryByStartIndex<KeyFrameBinaryOverlay>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,
@@ -13684,7 +13684,7 @@ namespace Mutagen.Bethesda.Fallout4
                 case RecordTypeInts.OIAD:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.Unknown4F = BinaryOverlayList.FactoryByStartIndex<KeyFrameBinaryOverlay>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,
@@ -13696,7 +13696,7 @@ namespace Mutagen.Bethesda.Fallout4
                 case RecordTypeInts._10_IAD:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.Unknown10 = BinaryOverlayList.FactoryByStartIndex<KeyFrameBinaryOverlay>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,
@@ -13708,7 +13708,7 @@ namespace Mutagen.Bethesda.Fallout4
                 case RecordTypeInts.PIAD:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.Unknown50 = BinaryOverlayList.FactoryByStartIndex<KeyFrameBinaryOverlay>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,
@@ -13720,7 +13720,7 @@ namespace Mutagen.Bethesda.Fallout4
                 case RecordTypeInts._11_IAD:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.CinematicSaturationMult = BinaryOverlayList.FactoryByStartIndex<KeyFrameBinaryOverlay>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,
@@ -13732,7 +13732,7 @@ namespace Mutagen.Bethesda.Fallout4
                 case RecordTypeInts.QIAD:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.CinematicSaturationAdd = BinaryOverlayList.FactoryByStartIndex<KeyFrameBinaryOverlay>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,
@@ -13744,7 +13744,7 @@ namespace Mutagen.Bethesda.Fallout4
                 case RecordTypeInts._12_IAD:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.CinematicBrightnessMult = BinaryOverlayList.FactoryByStartIndex<KeyFrameBinaryOverlay>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,
@@ -13756,7 +13756,7 @@ namespace Mutagen.Bethesda.Fallout4
                 case RecordTypeInts.RIAD:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.CinematicBrightnessAdd = BinaryOverlayList.FactoryByStartIndex<KeyFrameBinaryOverlay>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,
@@ -13768,7 +13768,7 @@ namespace Mutagen.Bethesda.Fallout4
                 case RecordTypeInts._13_IAD:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.CinematicContrastMult = BinaryOverlayList.FactoryByStartIndex<KeyFrameBinaryOverlay>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,
@@ -13780,7 +13780,7 @@ namespace Mutagen.Bethesda.Fallout4
                 case RecordTypeInts.SIAD:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.CinematicContrastAdd = BinaryOverlayList.FactoryByStartIndex<KeyFrameBinaryOverlay>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,
@@ -13792,7 +13792,7 @@ namespace Mutagen.Bethesda.Fallout4
                 case RecordTypeInts._14_IAD:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.Unknown14 = BinaryOverlayList.FactoryByStartIndex<KeyFrameBinaryOverlay>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,
@@ -13804,7 +13804,7 @@ namespace Mutagen.Bethesda.Fallout4
                 case RecordTypeInts.TIAD:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.Unknown54 = BinaryOverlayList.FactoryByStartIndex<KeyFrameBinaryOverlay>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,

--- a/Mutagen.Bethesda.Fallout4/Records/Major Records/LeveledItem_Generated.cs
+++ b/Mutagen.Bethesda.Fallout4/Records/Major Records/LeveledItem_Generated.cs
@@ -2451,7 +2451,7 @@ namespace Mutagen.Bethesda.Fallout4
                 case RecordTypeInts.LLKC:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.FilterKeywordChances = BinaryOverlayList.FactoryByLazyParse<FilterKeywordChanceBinaryOverlay>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,

--- a/Mutagen.Bethesda.Fallout4/Records/Major Records/LeveledNpc_Generated.cs
+++ b/Mutagen.Bethesda.Fallout4/Records/Major Records/LeveledNpc_Generated.cs
@@ -2428,7 +2428,7 @@ namespace Mutagen.Bethesda.Fallout4
                 case RecordTypeInts.LLKC:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.FilterKeywordChances = BinaryOverlayList.FactoryByLazyParse<FilterKeywordChanceBinaryOverlay>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,

--- a/Mutagen.Bethesda.Fallout4/Records/Major Records/Light_Generated.cs
+++ b/Mutagen.Bethesda.Fallout4/Records/Major Records/Light_Generated.cs
@@ -4231,7 +4231,7 @@ namespace Mutagen.Bethesda.Fallout4
                 case RecordTypeInts.PRPS:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.Properties = BinaryOverlayList.FactoryByStartIndex<ObjectPropertyBinaryOverlay>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,

--- a/Mutagen.Bethesda.Fallout4/Records/Major Records/MagicEffect_Generated.cs
+++ b/Mutagen.Bethesda.Fallout4/Records/Major Records/MagicEffect_Generated.cs
@@ -5210,7 +5210,7 @@ namespace Mutagen.Bethesda.Fallout4
                 case RecordTypeInts.SNDD:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.Sounds = BinaryOverlayList.FactoryByStartIndex<MagicEffectSoundBinaryOverlay>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,

--- a/Mutagen.Bethesda.Fallout4/Records/Major Records/MiscItem_Generated.cs
+++ b/Mutagen.Bethesda.Fallout4/Records/Major Records/MiscItem_Generated.cs
@@ -3445,7 +3445,7 @@ namespace Mutagen.Bethesda.Fallout4
                 case RecordTypeInts.CVPA:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.Components = BinaryOverlayList.FactoryByStartIndex<MiscItemComponentBinaryOverlay>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,
@@ -3457,7 +3457,7 @@ namespace Mutagen.Bethesda.Fallout4
                 case RecordTypeInts.CDIX:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.ComponentDisplayIndices = BinaryOverlayList.FactoryByStartIndex<Byte>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,

--- a/Mutagen.Bethesda.Fallout4/Records/Major Records/MovableStatic_Generated.cs
+++ b/Mutagen.Bethesda.Fallout4/Records/Major Records/MovableStatic_Generated.cs
@@ -2813,7 +2813,7 @@ namespace Mutagen.Bethesda.Fallout4
                 case RecordTypeInts.PRPS:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.Properties = BinaryOverlayList.FactoryByStartIndex<ObjectPropertyBinaryOverlay>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,

--- a/Mutagen.Bethesda.Fallout4/Records/Major Records/MusicTrack_Generated.cs
+++ b/Mutagen.Bethesda.Fallout4/Records/Major Records/MusicTrack_Generated.cs
@@ -2540,7 +2540,7 @@ namespace Mutagen.Bethesda.Fallout4
                 case RecordTypeInts.FNAM:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.CuePoints = BinaryOverlayList.FactoryByStartIndex<Single>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,
@@ -2563,7 +2563,7 @@ namespace Mutagen.Bethesda.Fallout4
                 case RecordTypeInts.SNAM:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.Tracks = BinaryOverlayList.FactoryByStartIndex<IFormLinkGetter<IMusicTrackGetter>>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,

--- a/Mutagen.Bethesda.Fallout4/Records/Major Records/MusicType_Generated.cs
+++ b/Mutagen.Bethesda.Fallout4/Records/Major Records/MusicType_Generated.cs
@@ -1890,7 +1890,7 @@ namespace Mutagen.Bethesda.Fallout4
                 case RecordTypeInts.TNAM:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.Tracks = BinaryOverlayList.FactoryByStartIndex<IFormLinkGetter<IMusicTrackGetter>>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,

--- a/Mutagen.Bethesda.Fallout4/Records/Major Records/Npc_Generated.cs
+++ b/Mutagen.Bethesda.Fallout4/Records/Major Records/Npc_Generated.cs
@@ -10403,7 +10403,7 @@ namespace Mutagen.Bethesda.Fallout4
                 case RecordTypeInts.PRPS:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.Properties = BinaryOverlayList.FactoryByStartIndex<ObjectPropertyBinaryOverlay>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,
@@ -10471,7 +10471,7 @@ namespace Mutagen.Bethesda.Fallout4
                 case RecordTypeInts.APPR:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.AttachParentSlots = BinaryOverlayList.FactoryByStartIndex<IFormLinkGetter<IKeywordGetter>>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,

--- a/Mutagen.Bethesda.Fallout4/Records/Major Records/Race_Generated.cs
+++ b/Mutagen.Bethesda.Fallout4/Records/Major Records/Race_Generated.cs
@@ -9808,7 +9808,7 @@ namespace Mutagen.Bethesda.Fallout4
                 case RecordTypeInts.PRPS:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.Properties = BinaryOverlayList.FactoryByStartIndex<ObjectPropertyBinaryOverlay>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,
@@ -9820,7 +9820,7 @@ namespace Mutagen.Bethesda.Fallout4
                 case RecordTypeInts.APPR:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.AttachParentSlots = BinaryOverlayList.FactoryByStartIndex<IFormLinkGetter<IKeywordGetter>>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,

--- a/Mutagen.Bethesda.Fallout4/Records/Major Records/RegionArea_Generated.cs
+++ b/Mutagen.Bethesda.Fallout4/Records/Major Records/RegionArea_Generated.cs
@@ -1439,7 +1439,7 @@ namespace Mutagen.Bethesda.Fallout4
                 case RecordTypeInts.RPLD:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.RegionPointListData = BinaryOverlayList.FactoryByStartIndex<P2Float>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,

--- a/Mutagen.Bethesda.Fallout4/Records/Major Records/RegionGrasses_Generated.cs
+++ b/Mutagen.Bethesda.Fallout4/Records/Major Records/RegionGrasses_Generated.cs
@@ -1361,7 +1361,7 @@ namespace Mutagen.Bethesda.Fallout4
                 case RecordTypeInts.RDGS:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.Grasses = BinaryOverlayList.FactoryByStartIndex<RegionGrassBinaryOverlay>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,

--- a/Mutagen.Bethesda.Fallout4/Records/Major Records/RegionObjects_Generated.cs
+++ b/Mutagen.Bethesda.Fallout4/Records/Major Records/RegionObjects_Generated.cs
@@ -1361,7 +1361,7 @@ namespace Mutagen.Bethesda.Fallout4
                 case RecordTypeInts.RDOT:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.Objects = BinaryOverlayList.FactoryByStartIndex<RegionObjectBinaryOverlay>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,

--- a/Mutagen.Bethesda.Fallout4/Records/Major Records/RegionSounds_Generated.cs
+++ b/Mutagen.Bethesda.Fallout4/Records/Major Records/RegionSounds_Generated.cs
@@ -1442,7 +1442,7 @@ namespace Mutagen.Bethesda.Fallout4
                 case RecordTypeInts.RDSA:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.Sounds = BinaryOverlayList.FactoryByStartIndex<RegionSoundBinaryOverlay>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,

--- a/Mutagen.Bethesda.Fallout4/Records/Major Records/RegionWeather_Generated.cs
+++ b/Mutagen.Bethesda.Fallout4/Records/Major Records/RegionWeather_Generated.cs
@@ -1361,7 +1361,7 @@ namespace Mutagen.Bethesda.Fallout4
                 case RecordTypeInts.RDWT:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.Weathers = BinaryOverlayList.FactoryByStartIndex<WeatherTypeBinaryOverlay>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,

--- a/Mutagen.Bethesda.Fallout4/Records/Major Records/StaticPart_Generated.cs
+++ b/Mutagen.Bethesda.Fallout4/Records/Major Records/StaticPart_Generated.cs
@@ -1387,7 +1387,7 @@ namespace Mutagen.Bethesda.Fallout4
                 {
                     if (lastParsed.ParsedIndex.HasValue && lastParsed.ParsedIndex.Value >= (int)StaticPart_FieldIndex.Placements) return ParseResult.Stop;
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.Placements = BinaryOverlayList.FactoryByStartIndex<PlacementBinaryOverlay>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,

--- a/Mutagen.Bethesda.Fallout4/Records/Major Records/Static_Generated.cs
+++ b/Mutagen.Bethesda.Fallout4/Records/Major Records/Static_Generated.cs
@@ -3020,7 +3020,7 @@ namespace Mutagen.Bethesda.Fallout4
                 case RecordTypeInts.PRPS:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.Properties = BinaryOverlayList.FactoryByStartIndex<ObjectPropertyBinaryOverlay>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,

--- a/Mutagen.Bethesda.Fallout4/Records/Major Records/Terminal_Generated.cs
+++ b/Mutagen.Bethesda.Fallout4/Records/Major Records/Terminal_Generated.cs
@@ -4072,7 +4072,7 @@ namespace Mutagen.Bethesda.Fallout4
                 case RecordTypeInts.PRPS:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.Properties = BinaryOverlayList.FactoryByStartIndex<ObjectPropertyBinaryOverlay>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,

--- a/Mutagen.Bethesda.Fallout4/Records/Major Records/TintTemplateOption_Generated.cs
+++ b/Mutagen.Bethesda.Fallout4/Records/Major Records/TintTemplateOption_Generated.cs
@@ -2286,7 +2286,7 @@ namespace Mutagen.Bethesda.Fallout4
                 case RecordTypeInts.TTEC:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.TemplateColors = BinaryOverlayList.FactoryByStartIndex<TintTemplateColorBinaryOverlay>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,

--- a/Mutagen.Bethesda.Fallout4/Records/Major Records/Weapon_Generated.cs
+++ b/Mutagen.Bethesda.Fallout4/Records/Major Records/Weapon_Generated.cs
@@ -7468,7 +7468,7 @@ namespace Mutagen.Bethesda.Fallout4
                 case RecordTypeInts.APPR:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.AttachParentSlots = BinaryOverlayList.FactoryByStartIndex<IFormLinkGetter<IKeywordGetter>>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,

--- a/Mutagen.Bethesda.Generation/Modules/Plugin/PluginListBinaryTranslationGeneration.cs
+++ b/Mutagen.Bethesda.Generation/Modules/Plugin/PluginListBinaryTranslationGeneration.cs
@@ -838,27 +838,8 @@ public class PluginListBinaryTranslationGeneration : ListBinaryTranslationGenera
                 }
                 break;
             case ListBinaryType.Trigger:
-                if (data.OverflowRecordType.HasValue)
-                {
-                    fg.AppendLine($"var subMeta = stream.ReadSubrecord();");
-                    fg.AppendLine("int subLen;");
-                    fg.AppendLine($"if (subMeta.RecordType == {objGen.RecordTypeHeaderName(data.OverflowRecordType.Value)})");
-                    using (new BraceWrapper(fg))
-                    {
-                        fg.AppendLine("subLen = checked((int)stream.ReadUInt32());");
-                        fg.AppendLine($"stream.ReadSubrecord();");
-                    }
-                    fg.AppendLine("else");
-                    using (new BraceWrapper(fg))
-                    {
-                        fg.AppendLine("subLen = subMeta.ContentLength;");
-                    }
-                }
-                else
-                {
-                    fg.AppendLine($"var subMeta = stream.ReadSubrecord();");
-                    fg.AppendLine("var subLen = subMeta.ContentLength;");
-                }
+                fg.AppendLine($"var subMeta = stream.ReadSubrecord();");
+                fg.AppendLine("var subLen = finalPos - stream.Position;");
                 if (expectedLen.HasValue)
                 {
                     using (var args = new ArgsWrapper(fg,

--- a/Mutagen.Bethesda.Oblivion/Records/Major Records/Cell_Generated.cs
+++ b/Mutagen.Bethesda.Oblivion/Records/Major Records/Cell_Generated.cs
@@ -4883,7 +4883,7 @@ namespace Mutagen.Bethesda.Oblivion
                 case RecordTypeInts.XCLR:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.Regions = BinaryOverlayList.FactoryByStartIndex<IFormLinkGetter<IRegionGetter>>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,

--- a/Mutagen.Bethesda.Oblivion/Records/Major Records/Climate_Generated.cs
+++ b/Mutagen.Bethesda.Oblivion/Records/Major Records/Climate_Generated.cs
@@ -2010,7 +2010,7 @@ namespace Mutagen.Bethesda.Oblivion
                 case RecordTypeInts.WLST:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.Weathers = BinaryOverlayList.FactoryByStartIndex<WeatherTypeBinaryOverlay>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,

--- a/Mutagen.Bethesda.Oblivion/Records/Major Records/Creature_Generated.cs
+++ b/Mutagen.Bethesda.Oblivion/Records/Major Records/Creature_Generated.cs
@@ -4221,7 +4221,7 @@ namespace Mutagen.Bethesda.Oblivion
                 case RecordTypeInts.NIFZ:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.Models = BinaryOverlayList.FactoryByLazyParse<String>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,
@@ -4285,7 +4285,7 @@ namespace Mutagen.Bethesda.Oblivion
                 case RecordTypeInts.KFFZ:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.Animations = BinaryOverlayList.FactoryByLazyParse<String>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,

--- a/Mutagen.Bethesda.Oblivion/Records/Major Records/IdleAnimation_Generated.cs
+++ b/Mutagen.Bethesda.Oblivion/Records/Major Records/IdleAnimation_Generated.cs
@@ -2038,7 +2038,7 @@ namespace Mutagen.Bethesda.Oblivion
                 case RecordTypeInts.DATA:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.RelatedIdleAnimations = BinaryOverlayList.FactoryByStartIndex<IFormLinkGetter<IIdleAnimationGetter>>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,

--- a/Mutagen.Bethesda.Oblivion/Records/Major Records/Landscape_Generated.cs
+++ b/Mutagen.Bethesda.Oblivion/Records/Major Records/Landscape_Generated.cs
@@ -2204,7 +2204,7 @@ namespace Mutagen.Bethesda.Oblivion
                 case RecordTypeInts.VTEX:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.Textures = BinaryOverlayList.FactoryByStartIndex<IFormLinkGetter<ILandTextureGetter>>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,

--- a/Mutagen.Bethesda.Oblivion/Records/Major Records/MagicEffect_Generated.cs
+++ b/Mutagen.Bethesda.Oblivion/Records/Major Records/MagicEffect_Generated.cs
@@ -2131,7 +2131,7 @@ namespace Mutagen.Bethesda.Oblivion
                 case RecordTypeInts.ESCE:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.CounterEffects = BinaryOverlayList.FactoryByStartIndex<IEDIDLinkGetter<IMagicEffectGetter>>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,

--- a/Mutagen.Bethesda.Oblivion/Records/Major Records/MapMarker_Generated.cs
+++ b/Mutagen.Bethesda.Oblivion/Records/Major Records/MapMarker_Generated.cs
@@ -1480,7 +1480,7 @@ namespace Mutagen.Bethesda.Oblivion
                 {
                     if (lastParsed.ParsedIndex.HasValue && lastParsed.ParsedIndex.Value >= (int)MapMarker_FieldIndex.Types) return ParseResult.Stop;
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.Types = BinaryOverlayList.FactoryByStartIndex<MapMarker.Type>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,

--- a/Mutagen.Bethesda.Oblivion/Records/Major Records/Npc_Generated.cs
+++ b/Mutagen.Bethesda.Oblivion/Records/Major Records/Npc_Generated.cs
@@ -4195,7 +4195,7 @@ namespace Mutagen.Bethesda.Oblivion
                 case RecordTypeInts.KFFZ:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.Animations = BinaryOverlayList.FactoryByLazyParse<String>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,
@@ -4226,7 +4226,7 @@ namespace Mutagen.Bethesda.Oblivion
                 case RecordTypeInts.ENAM:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.Eyes = BinaryOverlayList.FactoryByStartIndex<IFormLinkGetter<IEyeGetter>>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,

--- a/Mutagen.Bethesda.Oblivion/Records/Major Records/PathGrid_Generated.cs
+++ b/Mutagen.Bethesda.Oblivion/Records/Major Records/PathGrid_Generated.cs
@@ -2105,7 +2105,7 @@ namespace Mutagen.Bethesda.Oblivion
                 case RecordTypeInts.PGRI:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.InterCellConnections = BinaryOverlayList.FactoryByStartIndex<InterCellPointBinaryOverlay>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,

--- a/Mutagen.Bethesda.Oblivion/Records/Major Records/Race_Generated.cs
+++ b/Mutagen.Bethesda.Oblivion/Records/Major Records/Race_Generated.cs
@@ -3643,7 +3643,7 @@ namespace Mutagen.Bethesda.Oblivion
                 case RecordTypeInts.HNAM:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.Hairs = BinaryOverlayList.FactoryByStartIndex<IFormLinkGetter<IHairGetter>>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,
@@ -3655,7 +3655,7 @@ namespace Mutagen.Bethesda.Oblivion
                 case RecordTypeInts.ENAM:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.Eyes = BinaryOverlayList.FactoryByStartIndex<IFormLinkGetter<IEyeGetter>>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,

--- a/Mutagen.Bethesda.Oblivion/Records/Major Records/RegionArea_Generated.cs
+++ b/Mutagen.Bethesda.Oblivion/Records/Major Records/RegionArea_Generated.cs
@@ -1356,7 +1356,7 @@ namespace Mutagen.Bethesda.Oblivion
                 {
                     if (lastParsed.ParsedIndex.HasValue && lastParsed.ParsedIndex.Value >= (int)RegionArea_FieldIndex.RegionPoints) return ParseResult.Stop;
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.RegionPoints = BinaryOverlayList.FactoryByStartIndex<P2Float>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,

--- a/Mutagen.Bethesda.Oblivion/Records/Major Records/RegionGrasses_Generated.cs
+++ b/Mutagen.Bethesda.Oblivion/Records/Major Records/RegionGrasses_Generated.cs
@@ -1339,7 +1339,7 @@ namespace Mutagen.Bethesda.Oblivion
                 case RecordTypeInts.RDGS:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.Grasses = BinaryOverlayList.FactoryByStartIndex<IFormLinkGetter<IGrassGetter>>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,

--- a/Mutagen.Bethesda.Oblivion/Records/Major Records/RegionObjects_Generated.cs
+++ b/Mutagen.Bethesda.Oblivion/Records/Major Records/RegionObjects_Generated.cs
@@ -1348,7 +1348,7 @@ namespace Mutagen.Bethesda.Oblivion
                 case RecordTypeInts.RDOT:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.Objects = BinaryOverlayList.FactoryByStartIndex<RegionObjectBinaryOverlay>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,

--- a/Mutagen.Bethesda.Oblivion/Records/Major Records/RegionSounds_Generated.cs
+++ b/Mutagen.Bethesda.Oblivion/Records/Major Records/RegionSounds_Generated.cs
@@ -1426,7 +1426,7 @@ namespace Mutagen.Bethesda.Oblivion
                 case RecordTypeInts.RDSD:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.Sounds = BinaryOverlayList.FactoryByStartIndex<RegionSoundBinaryOverlay>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,

--- a/Mutagen.Bethesda.Oblivion/Records/Major Records/RegionWeather_Generated.cs
+++ b/Mutagen.Bethesda.Oblivion/Records/Major Records/RegionWeather_Generated.cs
@@ -1348,7 +1348,7 @@ namespace Mutagen.Bethesda.Oblivion
                 case RecordTypeInts.RDWT:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.Weathers = BinaryOverlayList.FactoryByStartIndex<WeatherTypeBinaryOverlay>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,

--- a/Mutagen.Bethesda.Oblivion/Records/Major Records/Tree_Generated.cs
+++ b/Mutagen.Bethesda.Oblivion/Records/Major Records/Tree_Generated.cs
@@ -2036,7 +2036,7 @@ namespace Mutagen.Bethesda.Oblivion
                 case RecordTypeInts.SNAM:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.SpeedTreeSeeds = BinaryOverlayList.FactoryByStartIndex<UInt32>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,

--- a/Mutagen.Bethesda.Oblivion/Records/Major Records/Weather_Generated.cs
+++ b/Mutagen.Bethesda.Oblivion/Records/Major Records/Weather_Generated.cs
@@ -2450,7 +2450,7 @@ namespace Mutagen.Bethesda.Oblivion
                 case RecordTypeInts.NAM0:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.Colors = BinaryOverlayList.FactoryByStartIndex<WeatherColorsBinaryOverlay>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,

--- a/Mutagen.Bethesda.Skyrim/Records/Major Records/APlacedTrap_Generated.cs
+++ b/Mutagen.Bethesda.Skyrim/Records/Major Records/APlacedTrap_Generated.cs
@@ -3511,7 +3511,7 @@ namespace Mutagen.Bethesda.Skyrim
                 case RecordTypeInts.XLRT:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.LocationRefTypes = BinaryOverlayList.FactoryByStartIndex<IFormLinkGetter<ILocationReferenceTypeGetter>>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,
@@ -3528,7 +3528,7 @@ namespace Mutagen.Bethesda.Skyrim
                 case RecordTypeInts.XLOD:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.DistantLodData = BinaryOverlayList.FactoryByStartIndex<Single>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,

--- a/Mutagen.Bethesda.Skyrim/Records/Major Records/CameraPath_Generated.cs
+++ b/Mutagen.Bethesda.Skyrim/Records/Major Records/CameraPath_Generated.cs
@@ -2171,7 +2171,7 @@ namespace Mutagen.Bethesda.Skyrim
                 case RecordTypeInts.ANAM:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.RelatedPaths = BinaryOverlayList.FactoryByStartIndex<IFormLinkGetter<ICameraPathGetter>>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,

--- a/Mutagen.Bethesda.Skyrim/Records/Major Records/Cell_Generated.cs
+++ b/Mutagen.Bethesda.Skyrim/Records/Major Records/Cell_Generated.cs
@@ -5763,7 +5763,7 @@ namespace Mutagen.Bethesda.Skyrim
                 case RecordTypeInts.XCLR:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.Regions = BinaryOverlayList.FactoryByStartIndex<IFormLinkGetter<IRegionGetter>>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,

--- a/Mutagen.Bethesda.Skyrim/Records/Major Records/Climate_Generated.cs
+++ b/Mutagen.Bethesda.Skyrim/Records/Major Records/Climate_Generated.cs
@@ -2411,7 +2411,7 @@ namespace Mutagen.Bethesda.Skyrim
                 case RecordTypeInts.WLST:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.WeatherTypes = BinaryOverlayList.FactoryByStartIndex<WeatherTypeBinaryOverlay>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,

--- a/Mutagen.Bethesda.Skyrim/Records/Major Records/DefaultObjectManager_Generated.cs
+++ b/Mutagen.Bethesda.Skyrim/Records/Major Records/DefaultObjectManager_Generated.cs
@@ -1639,7 +1639,7 @@ namespace Mutagen.Bethesda.Skyrim
                 case RecordTypeInts.DNAM:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.Objects = BinaryOverlayList.FactoryByStartIndex<DefaultObjectBinaryOverlay>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,

--- a/Mutagen.Bethesda.Skyrim/Records/Major Records/EquipType_Generated.cs
+++ b/Mutagen.Bethesda.Skyrim/Records/Major Records/EquipType_Generated.cs
@@ -1703,7 +1703,7 @@ namespace Mutagen.Bethesda.Skyrim
                 case RecordTypeInts.PNAM:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.SlotParents = BinaryOverlayList.FactoryByStartIndex<IFormLinkGetter<IEquipTypeGetter>>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,

--- a/Mutagen.Bethesda.Skyrim/Records/Major Records/IdleAnimation_Generated.cs
+++ b/Mutagen.Bethesda.Skyrim/Records/Major Records/IdleAnimation_Generated.cs
@@ -2354,7 +2354,7 @@ namespace Mutagen.Bethesda.Skyrim
                 case RecordTypeInts.ANAM:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.RelatedIdles = BinaryOverlayList.FactoryByStartIndex<IFormLinkGetter<IIdleRelationGetter>>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,

--- a/Mutagen.Bethesda.Skyrim/Records/Major Records/ImageSpaceAdapter_Generated.cs
+++ b/Mutagen.Bethesda.Skyrim/Records/Major Records/ImageSpaceAdapter_Generated.cs
@@ -13163,7 +13163,7 @@ namespace Mutagen.Bethesda.Skyrim
                 case RecordTypeInts.BNAM:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.BlurRadius = BinaryOverlayList.FactoryByStartIndex<KeyFrameBinaryOverlay>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,
@@ -13175,7 +13175,7 @@ namespace Mutagen.Bethesda.Skyrim
                 case RecordTypeInts.VNAM:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.DoubleVisionStrength = BinaryOverlayList.FactoryByStartIndex<KeyFrameBinaryOverlay>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,
@@ -13187,7 +13187,7 @@ namespace Mutagen.Bethesda.Skyrim
                 case RecordTypeInts.TNAM:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.TintColor = BinaryOverlayList.FactoryByStartIndex<ColorFrameBinaryOverlay>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,
@@ -13199,7 +13199,7 @@ namespace Mutagen.Bethesda.Skyrim
                 case RecordTypeInts.NAM3:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.FadeColor = BinaryOverlayList.FactoryByStartIndex<ColorFrameBinaryOverlay>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,
@@ -13211,7 +13211,7 @@ namespace Mutagen.Bethesda.Skyrim
                 case RecordTypeInts.RNAM:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.RadialBlurStrength = BinaryOverlayList.FactoryByStartIndex<KeyFrameBinaryOverlay>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,
@@ -13223,7 +13223,7 @@ namespace Mutagen.Bethesda.Skyrim
                 case RecordTypeInts.SNAM:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.RadialBlurRampUp = BinaryOverlayList.FactoryByStartIndex<KeyFrameBinaryOverlay>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,
@@ -13235,7 +13235,7 @@ namespace Mutagen.Bethesda.Skyrim
                 case RecordTypeInts.UNAM:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.RadialBlurStart = BinaryOverlayList.FactoryByStartIndex<KeyFrameBinaryOverlay>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,
@@ -13247,7 +13247,7 @@ namespace Mutagen.Bethesda.Skyrim
                 case RecordTypeInts.NAM1:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.RadialBlurRampDown = BinaryOverlayList.FactoryByStartIndex<KeyFrameBinaryOverlay>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,
@@ -13259,7 +13259,7 @@ namespace Mutagen.Bethesda.Skyrim
                 case RecordTypeInts.NAM2:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.RadialBlurDownStart = BinaryOverlayList.FactoryByStartIndex<KeyFrameBinaryOverlay>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,
@@ -13271,7 +13271,7 @@ namespace Mutagen.Bethesda.Skyrim
                 case RecordTypeInts.WNAM:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.DepthOfFieldStrength = BinaryOverlayList.FactoryByStartIndex<KeyFrameBinaryOverlay>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,
@@ -13283,7 +13283,7 @@ namespace Mutagen.Bethesda.Skyrim
                 case RecordTypeInts.XNAM:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.DepthOfFieldDistance = BinaryOverlayList.FactoryByStartIndex<KeyFrameBinaryOverlay>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,
@@ -13295,7 +13295,7 @@ namespace Mutagen.Bethesda.Skyrim
                 case RecordTypeInts.YNAM:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.DepthOfFieldRange = BinaryOverlayList.FactoryByStartIndex<KeyFrameBinaryOverlay>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,
@@ -13307,7 +13307,7 @@ namespace Mutagen.Bethesda.Skyrim
                 case RecordTypeInts.NAM4:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.MotionBlurStrength = BinaryOverlayList.FactoryByStartIndex<KeyFrameBinaryOverlay>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,
@@ -13319,7 +13319,7 @@ namespace Mutagen.Bethesda.Skyrim
                 case RecordTypeInts._0_IAD:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.HdrEyeAdaptSpeedMult = BinaryOverlayList.FactoryByStartIndex<KeyFrameBinaryOverlay>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,
@@ -13331,7 +13331,7 @@ namespace Mutagen.Bethesda.Skyrim
                 case RecordTypeInts.@IAD:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.HdrEyeAdaptSpeedAdd = BinaryOverlayList.FactoryByStartIndex<KeyFrameBinaryOverlay>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,
@@ -13343,7 +13343,7 @@ namespace Mutagen.Bethesda.Skyrim
                 case RecordTypeInts._1_IAD:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.HdrBloomBlurRadiusMult = BinaryOverlayList.FactoryByStartIndex<KeyFrameBinaryOverlay>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,
@@ -13355,7 +13355,7 @@ namespace Mutagen.Bethesda.Skyrim
                 case RecordTypeInts.AIAD:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.HdrBloomBlurRadiusAdd = BinaryOverlayList.FactoryByStartIndex<KeyFrameBinaryOverlay>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,
@@ -13367,7 +13367,7 @@ namespace Mutagen.Bethesda.Skyrim
                 case RecordTypeInts._2_IAD:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.HdrBloomThresholdMult = BinaryOverlayList.FactoryByStartIndex<KeyFrameBinaryOverlay>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,
@@ -13379,7 +13379,7 @@ namespace Mutagen.Bethesda.Skyrim
                 case RecordTypeInts.BIAD:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.HdrBloomThresholdAdd = BinaryOverlayList.FactoryByStartIndex<KeyFrameBinaryOverlay>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,
@@ -13391,7 +13391,7 @@ namespace Mutagen.Bethesda.Skyrim
                 case RecordTypeInts._3_IAD:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.HdrBloomScaleMult = BinaryOverlayList.FactoryByStartIndex<KeyFrameBinaryOverlay>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,
@@ -13403,7 +13403,7 @@ namespace Mutagen.Bethesda.Skyrim
                 case RecordTypeInts.CIAD:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.HdrBloomScaleAdd = BinaryOverlayList.FactoryByStartIndex<KeyFrameBinaryOverlay>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,
@@ -13415,7 +13415,7 @@ namespace Mutagen.Bethesda.Skyrim
                 case RecordTypeInts._4_IAD:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.HdrTargetLumMinMult = BinaryOverlayList.FactoryByStartIndex<KeyFrameBinaryOverlay>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,
@@ -13427,7 +13427,7 @@ namespace Mutagen.Bethesda.Skyrim
                 case RecordTypeInts.DIAD:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.HdrTargetLumMinAdd = BinaryOverlayList.FactoryByStartIndex<KeyFrameBinaryOverlay>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,
@@ -13439,7 +13439,7 @@ namespace Mutagen.Bethesda.Skyrim
                 case RecordTypeInts._5_IAD:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.HdrTargetLumMaxMult = BinaryOverlayList.FactoryByStartIndex<KeyFrameBinaryOverlay>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,
@@ -13451,7 +13451,7 @@ namespace Mutagen.Bethesda.Skyrim
                 case RecordTypeInts.EIAD:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.HdrTargetLumMaxAdd = BinaryOverlayList.FactoryByStartIndex<KeyFrameBinaryOverlay>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,
@@ -13463,7 +13463,7 @@ namespace Mutagen.Bethesda.Skyrim
                 case RecordTypeInts._6_IAD:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.HdrSunlightScaleMult = BinaryOverlayList.FactoryByStartIndex<KeyFrameBinaryOverlay>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,
@@ -13475,7 +13475,7 @@ namespace Mutagen.Bethesda.Skyrim
                 case RecordTypeInts.FIAD:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.HdrSunlightScaleAdd = BinaryOverlayList.FactoryByStartIndex<KeyFrameBinaryOverlay>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,
@@ -13487,7 +13487,7 @@ namespace Mutagen.Bethesda.Skyrim
                 case RecordTypeInts._7_IAD:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.HdrSkyScaleMult = BinaryOverlayList.FactoryByStartIndex<KeyFrameBinaryOverlay>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,
@@ -13499,7 +13499,7 @@ namespace Mutagen.Bethesda.Skyrim
                 case RecordTypeInts.GIAD:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.HdrSkyScaleAdd = BinaryOverlayList.FactoryByStartIndex<KeyFrameBinaryOverlay>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,
@@ -13511,7 +13511,7 @@ namespace Mutagen.Bethesda.Skyrim
                 case RecordTypeInts._8_IAD:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.Unknown08 = BinaryOverlayList.FactoryByStartIndex<KeyFrameBinaryOverlay>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,
@@ -13523,7 +13523,7 @@ namespace Mutagen.Bethesda.Skyrim
                 case RecordTypeInts.HIAD:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.Unknown48 = BinaryOverlayList.FactoryByStartIndex<KeyFrameBinaryOverlay>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,
@@ -13535,7 +13535,7 @@ namespace Mutagen.Bethesda.Skyrim
                 case RecordTypeInts._9_IAD:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.Unknown09 = BinaryOverlayList.FactoryByStartIndex<KeyFrameBinaryOverlay>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,
@@ -13547,7 +13547,7 @@ namespace Mutagen.Bethesda.Skyrim
                 case RecordTypeInts.IIAD:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.Unknown49 = BinaryOverlayList.FactoryByStartIndex<KeyFrameBinaryOverlay>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,
@@ -13559,7 +13559,7 @@ namespace Mutagen.Bethesda.Skyrim
                 case RecordTypeInts._A_IAD:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.Unknown0A = BinaryOverlayList.FactoryByStartIndex<KeyFrameBinaryOverlay>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,
@@ -13571,7 +13571,7 @@ namespace Mutagen.Bethesda.Skyrim
                 case RecordTypeInts.JIAD:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.Unknown4A = BinaryOverlayList.FactoryByStartIndex<KeyFrameBinaryOverlay>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,
@@ -13583,7 +13583,7 @@ namespace Mutagen.Bethesda.Skyrim
                 case RecordTypeInts._B_IAD:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.Unknown0B = BinaryOverlayList.FactoryByStartIndex<KeyFrameBinaryOverlay>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,
@@ -13595,7 +13595,7 @@ namespace Mutagen.Bethesda.Skyrim
                 case RecordTypeInts.KIAD:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.Unknown4B = BinaryOverlayList.FactoryByStartIndex<KeyFrameBinaryOverlay>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,
@@ -13607,7 +13607,7 @@ namespace Mutagen.Bethesda.Skyrim
                 case RecordTypeInts._C_IAD:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.Unknown0C = BinaryOverlayList.FactoryByStartIndex<KeyFrameBinaryOverlay>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,
@@ -13619,7 +13619,7 @@ namespace Mutagen.Bethesda.Skyrim
                 case RecordTypeInts.LIAD:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.Unknown4C = BinaryOverlayList.FactoryByStartIndex<KeyFrameBinaryOverlay>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,
@@ -13631,7 +13631,7 @@ namespace Mutagen.Bethesda.Skyrim
                 case RecordTypeInts._D_IAD:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.Unknown0D = BinaryOverlayList.FactoryByStartIndex<KeyFrameBinaryOverlay>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,
@@ -13643,7 +13643,7 @@ namespace Mutagen.Bethesda.Skyrim
                 case RecordTypeInts.MIAD:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.Unknown4D = BinaryOverlayList.FactoryByStartIndex<KeyFrameBinaryOverlay>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,
@@ -13655,7 +13655,7 @@ namespace Mutagen.Bethesda.Skyrim
                 case RecordTypeInts._E_IAD:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.Unknown0E = BinaryOverlayList.FactoryByStartIndex<KeyFrameBinaryOverlay>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,
@@ -13667,7 +13667,7 @@ namespace Mutagen.Bethesda.Skyrim
                 case RecordTypeInts.NIAD:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.Unknown4E = BinaryOverlayList.FactoryByStartIndex<KeyFrameBinaryOverlay>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,
@@ -13679,7 +13679,7 @@ namespace Mutagen.Bethesda.Skyrim
                 case RecordTypeInts._F_IAD:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.Unknown0F = BinaryOverlayList.FactoryByStartIndex<KeyFrameBinaryOverlay>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,
@@ -13691,7 +13691,7 @@ namespace Mutagen.Bethesda.Skyrim
                 case RecordTypeInts.OIAD:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.Unknown4F = BinaryOverlayList.FactoryByStartIndex<KeyFrameBinaryOverlay>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,
@@ -13703,7 +13703,7 @@ namespace Mutagen.Bethesda.Skyrim
                 case RecordTypeInts._10_IAD:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.Unknown10 = BinaryOverlayList.FactoryByStartIndex<KeyFrameBinaryOverlay>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,
@@ -13715,7 +13715,7 @@ namespace Mutagen.Bethesda.Skyrim
                 case RecordTypeInts.PIAD:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.Unknown50 = BinaryOverlayList.FactoryByStartIndex<KeyFrameBinaryOverlay>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,
@@ -13727,7 +13727,7 @@ namespace Mutagen.Bethesda.Skyrim
                 case RecordTypeInts._11_IAD:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.CinematicSaturationMult = BinaryOverlayList.FactoryByStartIndex<KeyFrameBinaryOverlay>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,
@@ -13739,7 +13739,7 @@ namespace Mutagen.Bethesda.Skyrim
                 case RecordTypeInts.QIAD:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.CinematicSaturationAdd = BinaryOverlayList.FactoryByStartIndex<KeyFrameBinaryOverlay>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,
@@ -13751,7 +13751,7 @@ namespace Mutagen.Bethesda.Skyrim
                 case RecordTypeInts._12_IAD:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.CinematicBrightnessMult = BinaryOverlayList.FactoryByStartIndex<KeyFrameBinaryOverlay>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,
@@ -13763,7 +13763,7 @@ namespace Mutagen.Bethesda.Skyrim
                 case RecordTypeInts.RIAD:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.CinematicBrightnessAdd = BinaryOverlayList.FactoryByStartIndex<KeyFrameBinaryOverlay>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,
@@ -13775,7 +13775,7 @@ namespace Mutagen.Bethesda.Skyrim
                 case RecordTypeInts._13_IAD:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.CinematicContrastMult = BinaryOverlayList.FactoryByStartIndex<KeyFrameBinaryOverlay>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,
@@ -13787,7 +13787,7 @@ namespace Mutagen.Bethesda.Skyrim
                 case RecordTypeInts.SIAD:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.CinematicContrastAdd = BinaryOverlayList.FactoryByStartIndex<KeyFrameBinaryOverlay>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,
@@ -13799,7 +13799,7 @@ namespace Mutagen.Bethesda.Skyrim
                 case RecordTypeInts._14_IAD:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.Unknown14 = BinaryOverlayList.FactoryByStartIndex<KeyFrameBinaryOverlay>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,
@@ -13811,7 +13811,7 @@ namespace Mutagen.Bethesda.Skyrim
                 case RecordTypeInts.TIAD:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.Unknown54 = BinaryOverlayList.FactoryByStartIndex<KeyFrameBinaryOverlay>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,

--- a/Mutagen.Bethesda.Skyrim/Records/Major Records/Landscape_Generated.cs
+++ b/Mutagen.Bethesda.Skyrim/Records/Major Records/Landscape_Generated.cs
@@ -2474,7 +2474,7 @@ namespace Mutagen.Bethesda.Skyrim
                 case RecordTypeInts.VTEX:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.Textures = BinaryOverlayList.FactoryByStartIndex<IFormLinkGetter<ILandscapeTextureGetter>>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,

--- a/Mutagen.Bethesda.Skyrim/Records/Major Records/Location_Generated.cs
+++ b/Mutagen.Bethesda.Skyrim/Records/Major Records/Location_Generated.cs
@@ -5647,7 +5647,7 @@ namespace Mutagen.Bethesda.Skyrim
                 case RecordTypeInts.ACPR:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.ActorCellPersistentReferences = BinaryOverlayList.FactoryByStartIndex<LocationReferenceBinaryOverlay>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,
@@ -5659,7 +5659,7 @@ namespace Mutagen.Bethesda.Skyrim
                 case RecordTypeInts.LCPR:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.LocationCellPersistentReferences = BinaryOverlayList.FactoryByStartIndex<LocationReferenceBinaryOverlay>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,
@@ -5671,7 +5671,7 @@ namespace Mutagen.Bethesda.Skyrim
                 case RecordTypeInts.RCPR:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.ReferenceCellPersistentReferences = BinaryOverlayList.FactoryByStartIndex<IFormLinkGetter<IPlacedSimpleGetter>>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,
@@ -5683,7 +5683,7 @@ namespace Mutagen.Bethesda.Skyrim
                 case RecordTypeInts.ACUN:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.ActorCellUniques = BinaryOverlayList.FactoryByStartIndex<LocationCellUniqueBinaryOverlay>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,
@@ -5695,7 +5695,7 @@ namespace Mutagen.Bethesda.Skyrim
                 case RecordTypeInts.LCUN:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.LocationCellUniques = BinaryOverlayList.FactoryByStartIndex<LocationCellUniqueBinaryOverlay>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,
@@ -5707,7 +5707,7 @@ namespace Mutagen.Bethesda.Skyrim
                 case RecordTypeInts.RCUN:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.ReferenceCellUnique = BinaryOverlayList.FactoryByStartIndex<IFormLinkGetter<INpcGetter>>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,
@@ -5719,7 +5719,7 @@ namespace Mutagen.Bethesda.Skyrim
                 case RecordTypeInts.ACSR:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.ActorCellStaticReferences = BinaryOverlayList.FactoryByStartIndex<LocationCellStaticReferenceBinaryOverlay>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,
@@ -5731,7 +5731,7 @@ namespace Mutagen.Bethesda.Skyrim
                 case RecordTypeInts.LCSR:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.LocationCellStaticReferences = BinaryOverlayList.FactoryByStartIndex<LocationCellStaticReferenceBinaryOverlay>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,
@@ -5743,7 +5743,7 @@ namespace Mutagen.Bethesda.Skyrim
                 case RecordTypeInts.RCSR:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.ReferenceCellStaticReferences = BinaryOverlayList.FactoryByStartIndex<IFormLinkGetter<IPlacedSimpleGetter>>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,
@@ -5785,7 +5785,7 @@ namespace Mutagen.Bethesda.Skyrim
                 case RecordTypeInts.ACID:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.ActorCellMarkerReference = BinaryOverlayList.FactoryByStartIndex<IFormLinkGetter<IPlacedGetter>>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,
@@ -5797,7 +5797,7 @@ namespace Mutagen.Bethesda.Skyrim
                 case RecordTypeInts.LCID:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.LocationCellMarkerReference = BinaryOverlayList.FactoryByStartIndex<IFormLinkGetter<IPlacedGetter>>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,
@@ -5809,7 +5809,7 @@ namespace Mutagen.Bethesda.Skyrim
                 case RecordTypeInts.ACEP:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.ActorCellEnablePoint = BinaryOverlayList.FactoryByStartIndex<LocationCellEnablePointBinaryOverlay>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,
@@ -5821,7 +5821,7 @@ namespace Mutagen.Bethesda.Skyrim
                 case RecordTypeInts.LCEP:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.LocationCellEnablePoint = BinaryOverlayList.FactoryByStartIndex<LocationCellEnablePointBinaryOverlay>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,

--- a/Mutagen.Bethesda.Skyrim/Records/Major Records/MagicEffect_Generated.cs
+++ b/Mutagen.Bethesda.Skyrim/Records/Major Records/MagicEffect_Generated.cs
@@ -5171,7 +5171,7 @@ namespace Mutagen.Bethesda.Skyrim
                 case RecordTypeInts.SNDD:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.Sounds = BinaryOverlayList.FactoryByStartIndex<MagicEffectSoundBinaryOverlay>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,

--- a/Mutagen.Bethesda.Skyrim/Records/Major Records/MusicTrack_Generated.cs
+++ b/Mutagen.Bethesda.Skyrim/Records/Major Records/MusicTrack_Generated.cs
@@ -2547,7 +2547,7 @@ namespace Mutagen.Bethesda.Skyrim
                 case RecordTypeInts.FNAM:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.CuePoints = BinaryOverlayList.FactoryByStartIndex<Single>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,
@@ -2570,7 +2570,7 @@ namespace Mutagen.Bethesda.Skyrim
                 case RecordTypeInts.SNAM:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.Tracks = BinaryOverlayList.FactoryByStartIndex<IFormLinkGetter<IMusicTrackGetter>>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,

--- a/Mutagen.Bethesda.Skyrim/Records/Major Records/MusicType_Generated.cs
+++ b/Mutagen.Bethesda.Skyrim/Records/Major Records/MusicType_Generated.cs
@@ -1897,7 +1897,7 @@ namespace Mutagen.Bethesda.Skyrim
                 case RecordTypeInts.TNAM:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.Tracks = BinaryOverlayList.FactoryByStartIndex<IFormLinkGetter<IMusicTrackGetter>>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,

--- a/Mutagen.Bethesda.Skyrim/Records/Major Records/Outfit_Generated.cs
+++ b/Mutagen.Bethesda.Skyrim/Records/Major Records/Outfit_Generated.cs
@@ -1630,7 +1630,7 @@ namespace Mutagen.Bethesda.Skyrim
                 case RecordTypeInts.INAM:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.Items = BinaryOverlayList.FactoryByStartIndex<IFormLinkGetter<IOutfitTargetGetter>>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,

--- a/Mutagen.Bethesda.Skyrim/Records/Major Records/PlacedNpc_Generated.cs
+++ b/Mutagen.Bethesda.Skyrim/Records/Major Records/PlacedNpc_Generated.cs
@@ -4211,7 +4211,7 @@ namespace Mutagen.Bethesda.Skyrim
                 case RecordTypeInts.XLRT:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.LocationRefTypes = BinaryOverlayList.FactoryByStartIndex<IFormLinkGetter<ILocationReferenceTypeGetter>>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,

--- a/Mutagen.Bethesda.Skyrim/Records/Major Records/PlacedObject_Generated.cs
+++ b/Mutagen.Bethesda.Skyrim/Records/Major Records/PlacedObject_Generated.cs
@@ -7260,7 +7260,7 @@ namespace Mutagen.Bethesda.Skyrim
                 case RecordTypeInts.XPOD:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.Portals = BinaryOverlayList.FactoryByStartIndex<PortalBinaryOverlay>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,
@@ -7453,7 +7453,7 @@ namespace Mutagen.Bethesda.Skyrim
                 case RecordTypeInts.XLRT:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.LocationRefTypes = BinaryOverlayList.FactoryByStartIndex<IFormLinkGetter<ILocationReferenceTypeGetter>>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,

--- a/Mutagen.Bethesda.Skyrim/Records/Major Records/Race_Generated.cs
+++ b/Mutagen.Bethesda.Skyrim/Records/Major Records/Race_Generated.cs
@@ -8739,7 +8739,7 @@ namespace Mutagen.Bethesda.Skyrim
                 case RecordTypeInts.HNAM:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.Hairs = BinaryOverlayList.FactoryByStartIndex<IFormLinkGetter<IHairGetter>>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,
@@ -8751,7 +8751,7 @@ namespace Mutagen.Bethesda.Skyrim
                 case RecordTypeInts.ENAM:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.Eyes = BinaryOverlayList.FactoryByStartIndex<IFormLinkGetter<IEyesGetter>>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,

--- a/Mutagen.Bethesda.Skyrim/Records/Major Records/RegionArea_Generated.cs
+++ b/Mutagen.Bethesda.Skyrim/Records/Major Records/RegionArea_Generated.cs
@@ -1356,7 +1356,7 @@ namespace Mutagen.Bethesda.Skyrim
                 {
                     if (lastParsed.ParsedIndex.HasValue && lastParsed.ParsedIndex.Value >= (int)RegionArea_FieldIndex.RegionPointListData) return ParseResult.Stop;
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.RegionPointListData = BinaryOverlayList.FactoryByStartIndex<P2Float>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,

--- a/Mutagen.Bethesda.Skyrim/Records/Major Records/RegionGrasses_Generated.cs
+++ b/Mutagen.Bethesda.Skyrim/Records/Major Records/RegionGrasses_Generated.cs
@@ -1359,7 +1359,7 @@ namespace Mutagen.Bethesda.Skyrim
                 case RecordTypeInts.RDGS:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.Grasses = BinaryOverlayList.FactoryByStartIndex<RegionGrassBinaryOverlay>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,

--- a/Mutagen.Bethesda.Skyrim/Records/Major Records/RegionObjects_Generated.cs
+++ b/Mutagen.Bethesda.Skyrim/Records/Major Records/RegionObjects_Generated.cs
@@ -1359,7 +1359,7 @@ namespace Mutagen.Bethesda.Skyrim
                 case RecordTypeInts.RDOT:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.Objects = BinaryOverlayList.FactoryByStartIndex<RegionObjectBinaryOverlay>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,

--- a/Mutagen.Bethesda.Skyrim/Records/Major Records/RegionSounds_Generated.cs
+++ b/Mutagen.Bethesda.Skyrim/Records/Major Records/RegionSounds_Generated.cs
@@ -1440,7 +1440,7 @@ namespace Mutagen.Bethesda.Skyrim
                 case RecordTypeInts.RDSA:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.Sounds = BinaryOverlayList.FactoryByStartIndex<RegionSoundBinaryOverlay>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,

--- a/Mutagen.Bethesda.Skyrim/Records/Major Records/RegionWeather_Generated.cs
+++ b/Mutagen.Bethesda.Skyrim/Records/Major Records/RegionWeather_Generated.cs
@@ -1359,7 +1359,7 @@ namespace Mutagen.Bethesda.Skyrim
                 case RecordTypeInts.RDWT:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    var subLen = subMeta.ContentLength;
+                    var subLen = finalPos - stream.Position;
                     this.Weathers = BinaryOverlayList.FactoryByStartIndex<WeatherTypeBinaryOverlay>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,

--- a/Mutagen.Bethesda.Skyrim/Records/SkyrimModHeader_Generated.cs
+++ b/Mutagen.Bethesda.Skyrim/Records/SkyrimModHeader_Generated.cs
@@ -2385,16 +2385,7 @@ namespace Mutagen.Bethesda.Skyrim
                 case RecordTypeInts.ONAM:
                 {
                     var subMeta = stream.ReadSubrecord();
-                    int subLen;
-                    if (subMeta.RecordType == RecordTypes.XXXX)
-                    {
-                        subLen = checked((int)stream.ReadUInt32());
-                        stream.ReadSubrecord();
-                    }
-                    else
-                    {
-                        subLen = subMeta.ContentLength;
-                    }
+                    var subLen = finalPos - stream.Position;
                     this.OverriddenForms = BinaryOverlayList.FactoryByStartIndex<IFormLinkGetter<ISkyrimMajorRecordGetter>>(
                         mem: stream.RemainingMemory.Slice(0, subLen),
                         package: _package,

--- a/Mutagen.Bethesda.Testing/TestDataPathing.cs
+++ b/Mutagen.Bethesda.Testing/TestDataPathing.cs
@@ -42,6 +42,7 @@ public class TestDataPathing
     public static string SubgraphOutOfOrder = "Files/Fallout4/SubgraphOutOfOrder.esp";
     public static string SkyrimConditionWithTwoStrings = "Files/Skyrim/ConditionWithTwoStrings.esp";
     public static string CountDisagreesWithReality = "Files/Core/CountDisagreesWithReality.esp";
+    public static string HeaderOverflow = "Plugins/Binary/Headers/ModHeaderOverflow";
 
     public static byte[] GetBytes(FilePath path)
     {

--- a/Mutagen.Bethesda.UnitTests/Plugins/Records/Skyrim/ModHeaderOverflowTests.cs
+++ b/Mutagen.Bethesda.UnitTests/Plugins/Records/Skyrim/ModHeaderOverflowTests.cs
@@ -1,0 +1,37 @@
+﻿using FluentAssertions;
+using Loqui.Generation;
+using Mutagen.Bethesda.Plugins;
+using Mutagen.Bethesda.Skyrim;
+using Mutagen.Bethesda.Testing;
+using Xunit;
+
+namespace Mutagen.Bethesda.UnitTests.Plugins.Records.Skyrim;
+
+public abstract class AModHeaderOverflowTests
+{
+    protected abstract ISkyrimModGetter Get(ModPath modPath);
+
+    [Fact]
+    public void CanParseMasters()
+    {
+        var race = Get(new ModPath(ModKey.Null, TestDataPathing.HeaderOverflow));
+        race.ModHeader.MasterReferences.Select(x => x.Master.ToString())
+            .Should().Equal("Dawnguard.esm");
+    }
+}
+
+public class DirectModHeaderOverflowTests : AModHeaderOverflowTests
+{
+    protected override ISkyrimModGetter Get(ModPath modPath)
+    {
+        return SkyrimMod.CreateFromBinary(modPath, SkyrimRelease.SkyrimSE);
+    }
+}
+
+public class OverlayModHeaderOverflowTests : AModHeaderOverflowTests
+{
+    protected override ISkyrimModGetter Get(ModPath modPath)
+    {
+        return SkyrimMod.CreateFromBinaryOverlay(modPath, SkyrimRelease.SkyrimSE);
+    }
+}


### PR DESCRIPTION
Also were some bugs with general parsing not respecing previousParse.LengthOverride mechanics

close #287 