### PR TITLE
Asset API - Extension Streamlining

### DIFF
--- a/Mutagen.Bethesda.Core.UnitTests/Plugins/Assets/TestAssetType.cs
+++ b/Mutagen.Bethesda.Core.UnitTests/Plugins/Assets/TestAssetType.cs
@@ -6,5 +6,5 @@ public class TestAssetType : IAssetType
 {
     public static readonly TestAssetType Instance = new();
     public string BaseFolder => "Meshes";
-    public IEnumerable<string> FileExtensions => new []{"nif"};
+    public IEnumerable<string> FileExtensions => new []{".nif"};
 }

--- a/Mutagen.Bethesda.Core/Plugins/Assets/AssetLink.cs
+++ b/Mutagen.Bethesda.Core/Plugins/Assets/AssetLink.cs
@@ -45,7 +45,7 @@ public class AssetLinkGetter<TAssetType> : IComparable<AssetLinkGetter<TAssetTyp
 
     public string DataRelativePath => ConvertToDataRelativePath(RawPath);
 
-    public string Extension => Path.GetExtension(RawPath).TrimStart('.');
+    public string Extension => Path.GetExtension(RawPath);
 
     public IAssetType Type => AssetInstance;
 

--- a/Mutagen.Bethesda.Skyrim/Assets/SkyrimBehaviorAssetType.cs
+++ b/Mutagen.Bethesda.Skyrim/Assets/SkyrimBehaviorAssetType.cs
@@ -1,10 +1,8 @@
-using System.Collections.Generic;
-
 namespace Mutagen.Bethesda.Skyrim.Assets;
 
 public class SkyrimBehaviorAssetType : SkyrimModelAssetType
 {
     public static readonly SkyrimBehaviorAssetType Instance = new();
     public string BaseFolder => "Meshes";
-    public IEnumerable<string> FileExtensions => new []{ "hkx" };
+    public IEnumerable<string> FileExtensions => new []{ ".hkx" };
 }

--- a/Mutagen.Bethesda.Skyrim/Assets/SkyrimBodyTextureAssetType.cs
+++ b/Mutagen.Bethesda.Skyrim/Assets/SkyrimBodyTextureAssetType.cs
@@ -1,10 +1,8 @@
-using System.Collections.Generic;
-
 namespace Mutagen.Bethesda.Skyrim.Assets;
 
 public class SkyrimBodyTextureAssetType : SkyrimModelAssetType
 {
     public static readonly SkyrimBodyTextureAssetType Instance = new();
     public string BaseFolder => "Meshes";
-    public IEnumerable<string> FileExtensions => new []{ "egt" };
+    public IEnumerable<string> FileExtensions => new []{ ".egt" };
 }

--- a/Mutagen.Bethesda.Skyrim/Assets/SkyrimDeformedModelAssetType.cs
+++ b/Mutagen.Bethesda.Skyrim/Assets/SkyrimDeformedModelAssetType.cs
@@ -7,5 +7,5 @@ public class SkyrimDeformedModelAssetType : IAssetType
 {
     public static readonly SkyrimDeformedModelAssetType Instance = new();
     public string BaseFolder => "Meshes";
-    public IEnumerable<string> FileExtensions => new []{"tri"};
+    public IEnumerable<string> FileExtensions => new []{".tri"};
 }

--- a/Mutagen.Bethesda.Skyrim/Assets/SkyrimModelAssetType.cs
+++ b/Mutagen.Bethesda.Skyrim/Assets/SkyrimModelAssetType.cs
@@ -6,5 +6,5 @@ public class SkyrimModelAssetType : IAssetType
 {
     public static readonly SkyrimModelAssetType Instance = new();
     public string BaseFolder => "Meshes";
-    public IEnumerable<string> FileExtensions => new []{"nif"};
+    public IEnumerable<string> FileExtensions => new []{".nif"};
 }

--- a/Mutagen.Bethesda.Skyrim/Assets/SkyrimMusicAssetType.cs
+++ b/Mutagen.Bethesda.Skyrim/Assets/SkyrimMusicAssetType.cs
@@ -1,4 +1,3 @@
-using System.Collections.Generic;
 using Mutagen.Bethesda.Assets;
 
 namespace Mutagen.Bethesda.Skyrim.Assets;
@@ -7,5 +6,5 @@ public class SkyrimMusicAssetType : IAssetType
 {
     public static readonly SkyrimMusicAssetType Instance = new();
     public string BaseFolder => "Music";
-    public IEnumerable<string> FileExtensions => new []{ "wav", "xwm" };
+    public IEnumerable<string> FileExtensions => new []{ ".wav", ".xwm" };
 }

--- a/Mutagen.Bethesda.Skyrim/Assets/SkyrimScriptCompiledAssetType.cs
+++ b/Mutagen.Bethesda.Skyrim/Assets/SkyrimScriptCompiledAssetType.cs
@@ -1,4 +1,3 @@
-using System.Collections.Generic;
 using Mutagen.Bethesda.Assets;
 
 namespace Mutagen.Bethesda.Skyrim.Assets;
@@ -6,7 +5,7 @@ namespace Mutagen.Bethesda.Skyrim.Assets;
 public class SkyrimScriptCompiledAssetType : IAssetType
 {
     public static readonly SkyrimScriptCompiledAssetType Instance = new();
-    public const string PexExtension = "pex";
+    public const string PexExtension = ".pex";
     public string BaseFolder => "Scripts";
     public IEnumerable<string> FileExtensions => new []{ PexExtension };
 }

--- a/Mutagen.Bethesda.Skyrim/Assets/SkyrimScriptSourceAssetType.cs
+++ b/Mutagen.Bethesda.Skyrim/Assets/SkyrimScriptSourceAssetType.cs
@@ -1,5 +1,3 @@
-using System.Collections.Generic;
-using System.IO;
 using Mutagen.Bethesda.Assets;
 
 namespace Mutagen.Bethesda.Skyrim.Assets;
@@ -7,7 +5,7 @@ namespace Mutagen.Bethesda.Skyrim.Assets;
 public class SkyrimScriptSourceAssetType : IAssetType
 {
     public static readonly SkyrimScriptSourceAssetType Instance = new();
-    public const string PscExtension = "psc";
+    public const string PscExtension = ".psc";
     public string BaseFolder => Path.Combine("Scripts", "Source");
     public IEnumerable<string> FileExtensions => new []{ PscExtension };
 }

--- a/Mutagen.Bethesda.Skyrim/Assets/SkyrimSeqAssetType.cs
+++ b/Mutagen.Bethesda.Skyrim/Assets/SkyrimSeqAssetType.cs
@@ -7,5 +7,5 @@ public class SkyrimSeqAssetType : IAssetType
 {
     public static readonly SkyrimSeqAssetType Instance = new();
     public string BaseFolder => "Seq";
-    public IEnumerable<string> FileExtensions => new []{ "seq" };
+    public IEnumerable<string> FileExtensions => new []{ ".seq" };
 }

--- a/Mutagen.Bethesda.Skyrim/Assets/SkyrimSoundAssetType.cs
+++ b/Mutagen.Bethesda.Skyrim/Assets/SkyrimSoundAssetType.cs
@@ -7,5 +7,5 @@ public class SkyrimSoundAssetType : IAssetType
 {
     public static readonly SkyrimSoundAssetType Instance = new();
     public string BaseFolder => "Sound";
-    public IEnumerable<string> FileExtensions => new []{ "wav", "xwm" };
+    public IEnumerable<string> FileExtensions => new []{ ".wav", ".xwm" };
 }

--- a/Mutagen.Bethesda.Skyrim/Assets/SkyrimTextureAssetType.cs
+++ b/Mutagen.Bethesda.Skyrim/Assets/SkyrimTextureAssetType.cs
@@ -1,4 +1,3 @@
-using System.Collections.Generic;
 using Mutagen.Bethesda.Assets;
 
 namespace Mutagen.Bethesda.Skyrim.Assets;
@@ -7,5 +6,5 @@ public class SkyrimTextureAssetType : IAssetType
 {
     public static readonly SkyrimTextureAssetType Instance = new();
     public string BaseFolder => "Textures";
-    public IEnumerable<string> FileExtensions => new []{ "dds", "png" };
+    public IEnumerable<string> FileExtensions => new []{ ".dds", ".png" };
 }

--- a/Mutagen.Bethesda.Skyrim/Assets/SkyrimTranslationAssetType.cs
+++ b/Mutagen.Bethesda.Skyrim/Assets/SkyrimTranslationAssetType.cs
@@ -7,7 +7,7 @@ public class SkyrimTranslationAssetType : IAssetType
 {
     public static readonly SkyrimTranslationAssetType Instance = new();
     public string BaseFolder => "Strings";
-    public IEnumerable<string> FileExtensions => new []{ "dlstrings", "ilstrings", "strings" };
+    public IEnumerable<string> FileExtensions => new []{ ".dlstrings", ".ilstrings", ".strings" };
     
     public static IEnumerable<string> Languages => new []{ 
         "english",

--- a/Mutagen.Bethesda.Skyrim/Records/Common Subrecords/ScriptEntry.cs
+++ b/Mutagen.Bethesda.Skyrim/Records/Common Subrecords/ScriptEntry.cs
@@ -22,8 +22,8 @@ partial class ScriptEntryCommon
     {
         if (string.IsNullOrWhiteSpace(obj.Name)) yield break;
 
-        yield return new AssetLink<SkyrimScriptCompiledAssetType>($"{obj.Name}.{SkyrimScriptCompiledAssetType.PexExtension}");
-        yield return new AssetLink<SkyrimScriptSourceAssetType>($"{obj.Name}.{SkyrimScriptSourceAssetType.PscExtension}");
+        yield return new AssetLink<SkyrimScriptCompiledAssetType>(obj.Name + SkyrimScriptCompiledAssetType.PexExtension);
+        yield return new AssetLink<SkyrimScriptSourceAssetType>(obj.Name + SkyrimScriptSourceAssetType.PscExtension);
     }
 }
 


### PR DESCRIPTION
Make asset type use the conventional extension format that doesn't omit the dot.
Omitting the dot can create a lot of confusion when using the current format in combination any other conventional library.
It's a breaking change, but I think it's good to make at this point where there is a limited user base of this feature.