### PR TITLE
IAssetType static abstract instance fix

### DIFF
--- a/Mutagen.Bethesda.Core/Assets/IAssetType.cs
+++ b/Mutagen.Bethesda.Core/Assets/IAssetType.cs
@@ -9,7 +9,7 @@ namespace Mutagen.Bethesda.Assets;
 public interface IAssetType
 {
 #if NET7_0_OR_GREATER
-    static abstract IAssetType Instance { get; }
+    static virtual IAssetType Instance => null!;
 #endif
 
     /// <summary>

--- a/Mutagen.Bethesda.Skyrim/Assets/SkyrimBehaviorAssetType.cs
+++ b/Mutagen.Bethesda.Skyrim/Assets/SkyrimBehaviorAssetType.cs
@@ -1,7 +1,7 @@
 using Mutagen.Bethesda.Assets;
 namespace Mutagen.Bethesda.Skyrim.Assets;
 
-public class SkyrimBehaviorAssetType : SkyrimModelAssetType
+public class SkyrimBehaviorAssetType : IAssetType
 {
 #if NET7_0_OR_GREATER
     public static IAssetType Instance { get; } = new SkyrimBehaviorAssetType();

--- a/Mutagen.Bethesda.Skyrim/Assets/SkyrimBodyTextureAssetType.cs
+++ b/Mutagen.Bethesda.Skyrim/Assets/SkyrimBodyTextureAssetType.cs
@@ -1,7 +1,7 @@
 using Mutagen.Bethesda.Assets;
 namespace Mutagen.Bethesda.Skyrim.Assets;
 
-public class SkyrimBodyTextureAssetType : SkyrimModelAssetType
+public class SkyrimBodyTextureAssetType : IAssetType
 {
 #if NET7_0_OR_GREATER
     public static IAssetType Instance { get; } = new SkyrimBodyTextureAssetType();

--- a/Mutagen.Bethesda.UnitTests/Skyrim/Assets/AssetTypeTests.cs
+++ b/Mutagen.Bethesda.UnitTests/Skyrim/Assets/AssetTypeTests.cs
@@ -1,0 +1,44 @@
+﻿using FluentAssertions;
+using Mutagen.Bethesda.Assets;
+using Noggog;
+using Xunit;
+
+namespace Mutagen.Bethesda.UnitTests.Skyrim.Assets;
+
+public class AssetTypeTests
+{
+#if NET7_0_OR_GREATER
+    public IAssetType GetInstance<TAssetType>()
+        where TAssetType : class, IAssetType
+    {
+        return TAssetType.Instance;
+    }
+
+    [Fact]
+    public void TestAllImplementationsAreNotNull()
+    {
+        var methodInfo = typeof(AssetTypeTests).GetMethod("GetInstance");
+
+        foreach (var implementation in typeof(IAssetType).GetInheritingFromInterface())
+        {
+            var method = methodInfo?.MakeGenericMethod(implementation);
+
+            var instance = method?.Invoke(this, null);
+
+            instance.Should().NotBeNull();
+        }
+
+    }
+
+    [Fact]
+    public void TestAllImplementationsHaveNoBaseClass()
+    {
+        var objectType = typeof(object);
+        
+        foreach (var implementation in typeof(IAssetType).GetInheritingFromInterface())
+        {
+            implementation.BaseType.Should().Be(objectType);
+        }
+    }
+#endif
+}


### PR DESCRIPTION
## Bug
The new static abstract IAssetType seems to have an issue I didn't think of before. More details can be found here. https://github.com/dotnet/csharplang/issues/5955

The result is that trying to create any data structure like this is impossible with the static abstract implementation of Instances.
```cs
static abstract IAssetType Instance { get; }

...

List<IAssetType> AssetTypes; // error (CS8920)
```

## PR
This PR is supposed to fix this issue by making IAssetType's Instance (temporarily) virtual and adding tests to ensure everyone implements a valid Instance.