### PR TITLE
Add GetAssetType()

### DIFF
--- a/Mutagen.Bethesda.Core/Assets/AssetTypeLocator.cs
+++ b/Mutagen.Bethesda.Core/Assets/AssetTypeLocator.cs
@@ -3,6 +3,7 @@ using Mutagen.Bethesda.Plugins.Assets;
 using Noggog;
 namespace Mutagen.Bethesda.Assets; 
 
+#if NET7_0_OR_GREATER
 public class AssetTypeLocator
 {
 	private static readonly Dictionary<GameCategory, Dictionary<string,Dictionary<string,IAssetType>>> Types;
@@ -87,3 +88,4 @@ public class AssetTypeLocator
 		return null;
 	}
 }
+#endif

--- a/Mutagen.Bethesda.Core/Assets/AssetTypeLocator.cs
+++ b/Mutagen.Bethesda.Core/Assets/AssetTypeLocator.cs
@@ -1,0 +1,72 @@
+﻿using System.Reflection;
+using Mutagen.Bethesda.Plugins.Assets;
+using Noggog;
+namespace Mutagen.Bethesda.Assets; 
+
+public class AssetTypeLocator
+{
+	private static readonly Dictionary<GameCategory, Dictionary<string,Dictionary<string,IAssetType>>> Types;
+
+	static AssetTypeLocator()
+	{
+		Types = new Dictionary<GameCategory, Dictionary<string,Dictionary<string,IAssetType>>>();
+
+		foreach (var type in typeof(IAssetType).GetInheritingFromInterface())
+		{
+			if (type.Namespace == null) continue;
+
+			GameCategory gameCategory;
+			switch (type.Namespace.TrimStart("Mutagen.Bethesda."))
+			{
+				case "Oblivion.Assets":
+					gameCategory = GameCategory.Oblivion;
+					break;
+				case "Skyrim.Assets":
+					gameCategory = GameCategory.Skyrim;
+					break;
+				case "Fallout4.Assets":
+					gameCategory = GameCategory.Fallout4;
+					break;
+				default:
+					continue;
+			}
+
+			var instanceProperty = type.GetProperty("Instance", BindingFlags.Public | BindingFlags.Static);
+			if (instanceProperty?.GetValue(null) is not IAssetType assetType) continue;
+
+			var gameTypes = Types.GetOrAdd(gameCategory);
+			foreach (var extension in assetType.FileExtensions)
+			{
+				var baseFolders = gameTypes.GetOrAdd(extension, () => new Dictionary<string, IAssetType>());
+				baseFolders.TryAdd(assetType.BaseFolder, assetType);
+			}
+		}
+	}
+
+	/// <summary>
+	/// Parse asset type by game release and path
+	/// </summary>
+	/// <param name="gameCategory">Release of the game this asset comes from</param>
+	/// <param name="path">Path of the asset</param>
+	/// <returns>Instance of the parsed asset type or null if no asset type could be determined</returns>
+	public static IAssetType? TryGetGetAssetType(GameCategory gameCategory, string path)
+	{
+		// Get dictionary for game category
+		if (!Types.TryGetValue(gameCategory, out var gameTypes)) return null;
+
+		// Get dictionary for file extension
+		if (!gameTypes.TryGetValue(Path.GetExtension(path), out var folders)) return null;
+
+		// Get asset type from base folder
+		var dataRelativePath = AssetLink.ConvertToDataRelativePath(path);
+		foreach (var (baseFolder, assetType) in folders)
+		{
+			if (dataRelativePath.StartsWith(baseFolder, AssetLink.PathComparison))
+			{
+				return assetType;
+			}
+		}
+
+		return null;
+	}
+}

--- a/Mutagen.Bethesda.Core/Assets/AssetTypeLocator.cs
+++ b/Mutagen.Bethesda.Core/Assets/AssetTypeLocator.cs
@@ -48,6 +48,23 @@ public class AssetTypeLocator
 	/// </summary>
 	/// <param name="gameCategory">Release of the game this asset comes from</param>
 	/// <param name="path">Path of the asset</param>
+	/// <returns>Instance of the parsed asset type</returns>
+	/// <exception cref="ArgumentException">When the asset type couldn't be determined</exception>
+	public static IAssetType GetAssetType(GameCategory gameCategory, string path) {
+		var assetType = TryGetGetAssetType(gameCategory, path);
+
+		if (assetType is null) {
+			throw new ArgumentException($"Could not determine asset type for {path} in {gameCategory}");
+		}
+
+		return assetType;
+	}
+
+	/// <summary>
+	/// Parse asset type by game release and path
+	/// </summary>
+	/// <param name="gameCategory">Release of the game this asset comes from</param>
+	/// <param name="path">Path of the asset</param>
 	/// <returns>Instance of the parsed asset type or null if no asset type could be determined</returns>
 	public static IAssetType? TryGetGetAssetType(GameCategory gameCategory, string path)
 	{

--- a/Mutagen.Bethesda.Core/Assets/IAssetType.cs
+++ b/Mutagen.Bethesda.Core/Assets/IAssetType.cs
@@ -1,6 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-
+﻿using System.Reflection;
+using Mutagen.Bethesda.Plugins.Assets;
+using Noggog;
 namespace Mutagen.Bethesda.Assets;
 
 /// <summary>
@@ -22,36 +22,68 @@ public interface IAssetType
     /// </summary>
     IEnumerable<string> FileExtensions { get; }
 
+    private static readonly Dictionary<GameCategory, Dictionary<string,Dictionary<string,IAssetType>>> Types;
+
+    static IAssetType()
+    {
+        Types = new Dictionary<GameCategory, Dictionary<string,Dictionary<string,IAssetType>>>();
+
+        var assetTypeType = typeof(IAssetType);
+        foreach (var type in assetTypeType.GetInheritingFromInterface())
+        {
+            if (type.Namespace == null) continue;
+
+            GameCategory gameCategory;
+            switch (type.Namespace.TrimStart("Mutagen.Bethesda.")) {
+                case "Oblivion.Assets":
+                    gameCategory = GameCategory.Oblivion;
+                    break;
+                case "Skyrim.Assets":
+                    gameCategory = GameCategory.Skyrim;
+                    break;
+                case "Fallout4.Assets":
+                    gameCategory = GameCategory.Fallout4;
+                    break;
+                default:
+                    continue;
+            }
+
+            var instanceProperty = type.GetProperty("Instance", BindingFlags.Public | BindingFlags.Static);
+            if (instanceProperty?.GetValue(null) is not IAssetType assetType) continue;
+
+            var gameTypes = Types.GetOrAdd(gameCategory);
+            foreach (var extension in assetType.FileExtensions)
+            {
+                var baseFolders = gameTypes.GetOrAdd(extension, () => new Dictionary<string, IAssetType>());
+                baseFolders.TryAdd(assetType.BaseFolder, assetType);
+            }
+        }
+    }
+
     /// <summary>
     /// Parse asset type by game release and path
     /// </summary>
-    /// <param name="gameRelease">Release of the game this asset comes from</param>
+    /// <param name="gameCategory">Release of the game this asset comes from</param>
     /// <param name="path">Path of the asset</param>
     /// <returns>Instance of the parsed asset type or null if no asset type could be determined</returns>
-    public static IAssetType? GetAssetType(GameRelease gameRelease, string path) {
-#if NET7_0_OR_GREATER
-        switch (gameRelease) {
-            case GameRelease.Oblivion:
-                break;
-            case GameRelease.SkyrimLE:
-            case GameRelease.SkyrimSE:
-            case GameRelease.SkyrimSEGog:
-            case GameRelease.SkyrimVR:
-            case GameRelease.EnderalLE:
-            case GameRelease.EnderalSE:
-                
-                break;
-            case GameRelease.Fallout4:
-                break;
-            default:
-                throw new ArgumentOutOfRangeException(nameof(gameRelease), gameRelease, null);
-        }
-#else
-#endif
-        throw new NotImplementedException();
-    }
+    public static IAssetType? GetAssetType(GameCategory gameCategory, string path)
+    {
+        // Get dictionary for game category
+        if (!Types.TryGetValue(gameCategory, out var gameTypes)) return null;
 
-    static IAssetType() {
-        
+        // Get dictionary for file extension
+        if (!gameTypes.TryGetValue(Path.GetExtension(path), out var folders)) return null;
+
+        // Get asset type from base folder
+        var dataRelativePath = AssetLink.ConvertToDataRelativePath(path);
+        foreach (var (baseFolder, assetType) in folders)
+        {
+            if (dataRelativePath.StartsWith(baseFolder, AssetLink.PathComparison))
+            {
+                return assetType;
+            }
+        }
+
+        return null;
     }
 }

--- a/Mutagen.Bethesda.Core/Assets/IAssetType.cs
+++ b/Mutagen.Bethesda.Core/Assets/IAssetType.cs
@@ -1,7 +1,4 @@
-﻿using System.Reflection;
-using Mutagen.Bethesda.Plugins.Assets;
-using Noggog;
-namespace Mutagen.Bethesda.Assets;
+﻿namespace Mutagen.Bethesda.Assets;
 
 /// <summary>
 /// File types that can be associated with Asset type
@@ -21,69 +18,4 @@ public interface IAssetType
     /// File extension this asset type is associated with
     /// </summary>
     IEnumerable<string> FileExtensions { get; }
-
-    private static readonly Dictionary<GameCategory, Dictionary<string,Dictionary<string,IAssetType>>> Types;
-
-    static IAssetType()
-    {
-        Types = new Dictionary<GameCategory, Dictionary<string,Dictionary<string,IAssetType>>>();
-
-        var assetTypeType = typeof(IAssetType);
-        foreach (var type in assetTypeType.GetInheritingFromInterface())
-        {
-            if (type.Namespace == null) continue;
-
-            GameCategory gameCategory;
-            switch (type.Namespace.TrimStart("Mutagen.Bethesda.")) {
-                case "Oblivion.Assets":
-                    gameCategory = GameCategory.Oblivion;
-                    break;
-                case "Skyrim.Assets":
-                    gameCategory = GameCategory.Skyrim;
-                    break;
-                case "Fallout4.Assets":
-                    gameCategory = GameCategory.Fallout4;
-                    break;
-                default:
-                    continue;
-            }
-
-            var instanceProperty = type.GetProperty("Instance", BindingFlags.Public | BindingFlags.Static);
-            if (instanceProperty?.GetValue(null) is not IAssetType assetType) continue;
-
-            var gameTypes = Types.GetOrAdd(gameCategory);
-            foreach (var extension in assetType.FileExtensions)
-            {
-                var baseFolders = gameTypes.GetOrAdd(extension, () => new Dictionary<string, IAssetType>());
-                baseFolders.TryAdd(assetType.BaseFolder, assetType);
-            }
-        }
-    }
-
-    /// <summary>
-    /// Parse asset type by game release and path
-    /// </summary>
-    /// <param name="gameCategory">Release of the game this asset comes from</param>
-    /// <param name="path">Path of the asset</param>
-    /// <returns>Instance of the parsed asset type or null if no asset type could be determined</returns>
-    public static IAssetType? GetAssetType(GameCategory gameCategory, string path)
-    {
-        // Get dictionary for game category
-        if (!Types.TryGetValue(gameCategory, out var gameTypes)) return null;
-
-        // Get dictionary for file extension
-        if (!gameTypes.TryGetValue(Path.GetExtension(path), out var folders)) return null;
-
-        // Get asset type from base folder
-        var dataRelativePath = AssetLink.ConvertToDataRelativePath(path);
-        foreach (var (baseFolder, assetType) in folders)
-        {
-            if (dataRelativePath.StartsWith(baseFolder, AssetLink.PathComparison))
-            {
-                return assetType;
-            }
-        }
-
-        return null;
-    }
 }

--- a/Mutagen.Bethesda.Core/Mutagen.Bethesda.Core.csproj
+++ b/Mutagen.Bethesda.Core/Mutagen.Bethesda.Core.csproj
@@ -85,6 +85,7 @@
     <Compile Include="Archives\IArchiveFile.cs" />
     <Compile Include="Archives\IArchiveFolder.cs" />
     <Compile Include="Archives\IArchiveReader.cs" />
+    <Compile Include="Assets\AssetTypeLocator.cs" />
     <Compile Include="Assets\IAssetType.cs" />
     <Compile Include="Environments\DI\GameEnvironmentProvider.cs" />
     <Compile Include="Environments\DI\IDataDirectoryProvider.cs">

--- a/Mutagen.Bethesda.UnitTests/Skyrim/Assets/AssetTypeTests.cs
+++ b/Mutagen.Bethesda.UnitTests/Skyrim/Assets/AssetTypeTests.cs
@@ -41,7 +41,6 @@ public class AssetTypeTests
             implementation.BaseType.Should().Be(objectType);
         }
     }
-#endif
 
     [Fact]
     public void TestGetAssetType()
@@ -76,4 +75,5 @@ public class AssetTypeTests
         AssetTypeLocator.TryGetGetAssetType(GameCategory.Skyrim, Path.Combine("Script", "HelloWorld.pex")).Should().BeNull();
         AssetTypeLocator.TryGetGetAssetType(GameCategory.Skyrim, Path.Combine("Scripts", "HelloWorld.abc")).Should().BeNull();
     }
+#endif
 }

--- a/Mutagen.Bethesda.UnitTests/Skyrim/Assets/AssetTypeTests.cs
+++ b/Mutagen.Bethesda.UnitTests/Skyrim/Assets/AssetTypeTests.cs
@@ -46,34 +46,34 @@ public class AssetTypeTests
     [Fact]
     public void TestGetAssetType()
     {
-        IAssetType.GetAssetType(GameCategory.Skyrim, Path.Combine("Music", "Special", "Dungeon", "DungeonBoss01.xwm")).Should().BeOfType<SkyrimMusicAssetType>();
-        IAssetType.GetAssetType(GameCategory.Skyrim, Path.Combine("Music", "Special", "Dungeon", "DungeonBoss01.wav")).Should().BeOfType<SkyrimMusicAssetType>();
-        IAssetType.GetAssetType(GameCategory.Skyrim, Path.Combine("XMusic", "Special", "Dungeon", "DungeonBoss01.wav")).Should().BeNull();
-        IAssetType.GetAssetType(GameCategory.Skyrim, Path.Combine("Music", "Special", "Dungeon", "DungeonBoss01.mp3")).Should().BeNull();
+        AssetTypeLocator.TryGetGetAssetType(GameCategory.Skyrim, Path.Combine("Music", "Special", "Dungeon", "DungeonBoss01.xwm")).Should().BeOfType<SkyrimMusicAssetType>();
+        AssetTypeLocator.TryGetGetAssetType(GameCategory.Skyrim, Path.Combine("Music", "Special", "Dungeon", "DungeonBoss01.wav")).Should().BeOfType<SkyrimMusicAssetType>();
+        AssetTypeLocator.TryGetGetAssetType(GameCategory.Skyrim, Path.Combine("XMusic", "Special", "Dungeon", "DungeonBoss01.wav")).Should().BeNull();
+        AssetTypeLocator.TryGetGetAssetType(GameCategory.Skyrim, Path.Combine("Music", "Special", "Dungeon", "DungeonBoss01.mp3")).Should().BeNull();
 
-        IAssetType.GetAssetType(GameCategory.Skyrim, Path.Combine("Meshes", "Armor", "Iron", "IronGauntlets.nif")).Should().BeOfType<SkyrimModelAssetType>();
-        IAssetType.GetAssetType(GameCategory.Skyrim, Path.Combine("XMeshes", "Armor", "Iron", "IronGauntlets.nif")).Should().BeNull();
-        IAssetType.GetAssetType(GameCategory.Skyrim, Path.Combine("Meshes", "Armor", "Iron", "IronGauntlets.abc")).Should().BeNull();
+        AssetTypeLocator.TryGetGetAssetType(GameCategory.Skyrim, Path.Combine("Meshes", "Armor", "Iron", "IronGauntlets.nif")).Should().BeOfType<SkyrimModelAssetType>();
+        AssetTypeLocator.TryGetGetAssetType(GameCategory.Skyrim, Path.Combine("XMeshes", "Armor", "Iron", "IronGauntlets.nif")).Should().BeNull();
+        AssetTypeLocator.TryGetGetAssetType(GameCategory.Skyrim, Path.Combine("Meshes", "Armor", "Iron", "IronGauntlets.abc")).Should().BeNull();
 
-        IAssetType.GetAssetType(GameCategory.Skyrim, Path.Combine("Textures", "Armor", "Iron", "IronGauntlets.dds")).Should().BeOfType<SkyrimTextureAssetType>();
-        IAssetType.GetAssetType(GameCategory.Skyrim, Path.Combine("XTextures", "Armor", "Iron", "IronGauntlets.dds")).Should().BeNull();
-        IAssetType.GetAssetType(GameCategory.Skyrim, Path.Combine("Textures", "Armor", "Iron", "IronGauntlets.abc")).Should().BeNull();
+        AssetTypeLocator.TryGetGetAssetType(GameCategory.Skyrim, Path.Combine("Textures", "Armor", "Iron", "IronGauntlets.dds")).Should().BeOfType<SkyrimTextureAssetType>();
+        AssetTypeLocator.TryGetGetAssetType(GameCategory.Skyrim, Path.Combine("XTextures", "Armor", "Iron", "IronGauntlets.dds")).Should().BeNull();
+        AssetTypeLocator.TryGetGetAssetType(GameCategory.Skyrim, Path.Combine("Textures", "Armor", "Iron", "IronGauntlets.abc")).Should().BeNull();
 
-        IAssetType.GetAssetType(GameCategory.Skyrim, Path.Combine("Sound", "FX", "IronGauntlets.wav")).Should().BeOfType<SkyrimSoundAssetType>();
-        IAssetType.GetAssetType(GameCategory.Skyrim, Path.Combine("XSound", "FX", "IronGauntlets.wav")).Should().BeNull();
-        IAssetType.GetAssetType(GameCategory.Skyrim, Path.Combine("Sound", "FX", "IronGauntlets.abc")).Should().BeNull();
+        AssetTypeLocator.TryGetGetAssetType(GameCategory.Skyrim, Path.Combine("Sound", "FX", "IronGauntlets.wav")).Should().BeOfType<SkyrimSoundAssetType>();
+        AssetTypeLocator.TryGetGetAssetType(GameCategory.Skyrim, Path.Combine("XSound", "FX", "IronGauntlets.wav")).Should().BeNull();
+        AssetTypeLocator.TryGetGetAssetType(GameCategory.Skyrim, Path.Combine("Sound", "FX", "IronGauntlets.abc")).Should().BeNull();
 
-        IAssetType.GetAssetType(GameCategory.Skyrim, Path.Combine("SEQ", "Skyrim.seq")).Should().BeOfType<SkyrimSeqAssetType>();
-        IAssetType.GetAssetType(GameCategory.Skyrim, Path.Combine("seq", "Skyrim.seq")).Should().BeOfType<SkyrimSeqAssetType>();
-        IAssetType.GetAssetType(GameCategory.Skyrim, Path.Combine("s3q", "Skyrim.abc")).Should().BeNull();
-        IAssetType.GetAssetType(GameCategory.Skyrim, Path.Combine("SEQ", "Skyrim.abc")).Should().BeNull();
+        AssetTypeLocator.TryGetGetAssetType(GameCategory.Skyrim, Path.Combine("SEQ", "Skyrim.seq")).Should().BeOfType<SkyrimSeqAssetType>();
+        AssetTypeLocator.TryGetGetAssetType(GameCategory.Skyrim, Path.Combine("seq", "Skyrim.seq")).Should().BeOfType<SkyrimSeqAssetType>();
+        AssetTypeLocator.TryGetGetAssetType(GameCategory.Skyrim, Path.Combine("s3q", "Skyrim.abc")).Should().BeNull();
+        AssetTypeLocator.TryGetGetAssetType(GameCategory.Skyrim, Path.Combine("SEQ", "Skyrim.abc")).Should().BeNull();
 
-        IAssetType.GetAssetType(GameCategory.Skyrim, Path.Combine("Scripts", "Source", "HelloWorld.psc")).Should().BeOfType<SkyrimScriptSourceAssetType>();
-        IAssetType.GetAssetType(GameCategory.Skyrim, Path.Combine("Script", "Source", "HelloWorld.psc")).Should().BeNull();
-        IAssetType.GetAssetType(GameCategory.Skyrim, Path.Combine("Scripts", "Source", "HelloWorld.abc")).Should().BeNull();
+        AssetTypeLocator.TryGetGetAssetType(GameCategory.Skyrim, Path.Combine("Scripts", "Source", "HelloWorld.psc")).Should().BeOfType<SkyrimScriptSourceAssetType>();
+        AssetTypeLocator.TryGetGetAssetType(GameCategory.Skyrim, Path.Combine("Script", "Source", "HelloWorld.psc")).Should().BeNull();
+        AssetTypeLocator.TryGetGetAssetType(GameCategory.Skyrim, Path.Combine("Scripts", "Source", "HelloWorld.abc")).Should().BeNull();
 
-        IAssetType.GetAssetType(GameCategory.Skyrim, Path.Combine("Scripts", "HelloWorld.pex")).Should().BeOfType<SkyrimScriptCompiledAssetType>();
-        IAssetType.GetAssetType(GameCategory.Skyrim, Path.Combine("Script", "HelloWorld.pex")).Should().BeNull();
-        IAssetType.GetAssetType(GameCategory.Skyrim, Path.Combine("Scripts", "HelloWorld.abc")).Should().BeNull();
+        AssetTypeLocator.TryGetGetAssetType(GameCategory.Skyrim, Path.Combine("Scripts", "HelloWorld.pex")).Should().BeOfType<SkyrimScriptCompiledAssetType>();
+        AssetTypeLocator.TryGetGetAssetType(GameCategory.Skyrim, Path.Combine("Script", "HelloWorld.pex")).Should().BeNull();
+        AssetTypeLocator.TryGetGetAssetType(GameCategory.Skyrim, Path.Combine("Scripts", "HelloWorld.abc")).Should().BeNull();
     }
 }

--- a/Mutagen.Bethesda.UnitTests/Skyrim/Assets/AssetTypeTests.cs
+++ b/Mutagen.Bethesda.UnitTests/Skyrim/Assets/AssetTypeTests.cs
@@ -46,34 +46,34 @@ public class AssetTypeTests
     [Fact]
     public void TestGetAssetType()
     {
-        IAssetType.GetAssetType(GameCategory.Skyrim, "Music\\Special\\Dungeon\\DungeonBoss01.xwm").Should().BeOfType<SkyrimMusicAssetType>();
-        IAssetType.GetAssetType(GameCategory.Skyrim, "Music\\Special\\Dungeon\\DungeonBoss01.wav").Should().BeOfType<SkyrimMusicAssetType>();
-        IAssetType.GetAssetType(GameCategory.Skyrim, "XMusic\\Special\\Dungeon\\DungeonBoss01.wav").Should().BeNull();
-        IAssetType.GetAssetType(GameCategory.Skyrim, "Music\\Special\\Dungeon\\DungeonBoss01.mp3").Should().BeNull();
+        IAssetType.GetAssetType(GameCategory.Skyrim, Path.Combine("Music", "Special", "Dungeon", "DungeonBoss01.xwm")).Should().BeOfType<SkyrimMusicAssetType>();
+        IAssetType.GetAssetType(GameCategory.Skyrim, Path.Combine("Music", "Special", "Dungeon", "DungeonBoss01.wav")).Should().BeOfType<SkyrimMusicAssetType>();
+        IAssetType.GetAssetType(GameCategory.Skyrim, Path.Combine("XMusic", "Special", "Dungeon", "DungeonBoss01.wav")).Should().BeNull();
+        IAssetType.GetAssetType(GameCategory.Skyrim, Path.Combine("Music", "Special", "Dungeon", "DungeonBoss01.mp3")).Should().BeNull();
 
-        IAssetType.GetAssetType(GameCategory.Skyrim, "Meshes\\Armor\\Iron\\IronGauntlets.nif").Should().BeOfType<SkyrimModelAssetType>();
-        IAssetType.GetAssetType(GameCategory.Skyrim, "XMeshes\\Armor\\Iron\\IronGauntlets.nif").Should().BeNull();
-        IAssetType.GetAssetType(GameCategory.Skyrim, "Meshes\\Armor\\Iron\\IronGauntlets.abc").Should().BeNull();
+        IAssetType.GetAssetType(GameCategory.Skyrim, Path.Combine("Meshes", "Armor", "Iron", "IronGauntlets.nif")).Should().BeOfType<SkyrimModelAssetType>();
+        IAssetType.GetAssetType(GameCategory.Skyrim, Path.Combine("XMeshes", "Armor", "Iron", "IronGauntlets.nif")).Should().BeNull();
+        IAssetType.GetAssetType(GameCategory.Skyrim, Path.Combine("Meshes", "Armor", "Iron", "IronGauntlets.abc")).Should().BeNull();
 
-        IAssetType.GetAssetType(GameCategory.Skyrim, "Textures\\Armor\\Iron\\IronGauntlets.dds").Should().BeOfType<SkyrimTextureAssetType>();
-        IAssetType.GetAssetType(GameCategory.Skyrim, "XTextures\\Armor\\Iron\\IronGauntlets.dds").Should().BeNull();
-        IAssetType.GetAssetType(GameCategory.Skyrim, "Textures\\Armor\\Iron\\IronGauntlets.abc").Should().BeNull();
+        IAssetType.GetAssetType(GameCategory.Skyrim, Path.Combine("Textures", "Armor", "Iron", "IronGauntlets.dds")).Should().BeOfType<SkyrimTextureAssetType>();
+        IAssetType.GetAssetType(GameCategory.Skyrim, Path.Combine("XTextures", "Armor", "Iron", "IronGauntlets.dds")).Should().BeNull();
+        IAssetType.GetAssetType(GameCategory.Skyrim, Path.Combine("Textures", "Armor", "Iron", "IronGauntlets.abc")).Should().BeNull();
 
-        IAssetType.GetAssetType(GameCategory.Skyrim, "Sound\\FX\\IronGauntlets.wav").Should().BeOfType<SkyrimSoundAssetType>();
-        IAssetType.GetAssetType(GameCategory.Skyrim, "XSound\\FX\\IronGauntlets.wav").Should().BeNull();
-        IAssetType.GetAssetType(GameCategory.Skyrim, "Sound\\FX\\IronGauntlets.abc").Should().BeNull();
+        IAssetType.GetAssetType(GameCategory.Skyrim, Path.Combine("Sound", "FX", "IronGauntlets.wav")).Should().BeOfType<SkyrimSoundAssetType>();
+        IAssetType.GetAssetType(GameCategory.Skyrim, Path.Combine("XSound", "FX", "IronGauntlets.wav")).Should().BeNull();
+        IAssetType.GetAssetType(GameCategory.Skyrim, Path.Combine("Sound", "FX", "IronGauntlets.abc")).Should().BeNull();
 
-        IAssetType.GetAssetType(GameCategory.Skyrim, "SEQ\\Skyrim.seq").Should().BeOfType<SkyrimSeqAssetType>();
-        IAssetType.GetAssetType(GameCategory.Skyrim, "seq\\Skyrim.seq").Should().BeOfType<SkyrimSeqAssetType>();
-        IAssetType.GetAssetType(GameCategory.Skyrim, "s3q\\Skyrim.abc").Should().BeNull();
-        IAssetType.GetAssetType(GameCategory.Skyrim, "SEQ\\Skyrim.abc").Should().BeNull();
+        IAssetType.GetAssetType(GameCategory.Skyrim, Path.Combine("SEQ", "Skyrim.seq")).Should().BeOfType<SkyrimSeqAssetType>();
+        IAssetType.GetAssetType(GameCategory.Skyrim, Path.Combine("seq", "Skyrim.seq")).Should().BeOfType<SkyrimSeqAssetType>();
+        IAssetType.GetAssetType(GameCategory.Skyrim, Path.Combine("s3q", "Skyrim.abc")).Should().BeNull();
+        IAssetType.GetAssetType(GameCategory.Skyrim, Path.Combine("SEQ", "Skyrim.abc")).Should().BeNull();
 
-        IAssetType.GetAssetType(GameCategory.Skyrim, "Scripts\\Source\\HelloWorld.psc").Should().BeOfType<SkyrimScriptSourceAssetType>();
-        IAssetType.GetAssetType(GameCategory.Skyrim, "Script\\Source\\HelloWorld.psc").Should().BeNull();
-        IAssetType.GetAssetType(GameCategory.Skyrim, "Scripts\\Source\\HelloWorld.abc").Should().BeNull();
+        IAssetType.GetAssetType(GameCategory.Skyrim, Path.Combine("Scripts", "Source", "HelloWorld.psc")).Should().BeOfType<SkyrimScriptSourceAssetType>();
+        IAssetType.GetAssetType(GameCategory.Skyrim, Path.Combine("Script", "Source", "HelloWorld.psc")).Should().BeNull();
+        IAssetType.GetAssetType(GameCategory.Skyrim, Path.Combine("Scripts", "Source", "HelloWorld.abc")).Should().BeNull();
 
-        IAssetType.GetAssetType(GameCategory.Skyrim, "Scripts\\HelloWorld.pex").Should().BeOfType<SkyrimScriptCompiledAssetType>();
-        IAssetType.GetAssetType(GameCategory.Skyrim, "Script\\HelloWorld.pex").Should().BeNull();
-        IAssetType.GetAssetType(GameCategory.Skyrim, "Scripts\\HelloWorld.abc").Should().BeNull();
+        IAssetType.GetAssetType(GameCategory.Skyrim, Path.Combine("Scripts", "HelloWorld.pex")).Should().BeOfType<SkyrimScriptCompiledAssetType>();
+        IAssetType.GetAssetType(GameCategory.Skyrim, Path.Combine("Script", "HelloWorld.pex")).Should().BeNull();
+        IAssetType.GetAssetType(GameCategory.Skyrim, Path.Combine("Scripts", "HelloWorld.abc")).Should().BeNull();
     }
 }

--- a/Mutagen.Bethesda.UnitTests/Skyrim/Assets/AssetTypeTests.cs
+++ b/Mutagen.Bethesda.UnitTests/Skyrim/Assets/AssetTypeTests.cs
@@ -1,5 +1,6 @@
 ﻿using FluentAssertions;
 using Mutagen.Bethesda.Assets;
+using Mutagen.Bethesda.Skyrim.Assets;
 using Noggog;
 using Xunit;
 
@@ -41,4 +42,38 @@ public class AssetTypeTests
         }
     }
 #endif
+
+    [Fact]
+    public void TestGetAssetType()
+    {
+        IAssetType.GetAssetType(GameCategory.Skyrim, "Music\\Special\\Dungeon\\DungeonBoss01.xwm").Should().BeOfType<SkyrimMusicAssetType>();
+        IAssetType.GetAssetType(GameCategory.Skyrim, "Music\\Special\\Dungeon\\DungeonBoss01.wav").Should().BeOfType<SkyrimMusicAssetType>();
+        IAssetType.GetAssetType(GameCategory.Skyrim, "XMusic\\Special\\Dungeon\\DungeonBoss01.wav").Should().BeNull();
+        IAssetType.GetAssetType(GameCategory.Skyrim, "Music\\Special\\Dungeon\\DungeonBoss01.mp3").Should().BeNull();
+
+        IAssetType.GetAssetType(GameCategory.Skyrim, "Meshes\\Armor\\Iron\\IronGauntlets.nif").Should().BeOfType<SkyrimModelAssetType>();
+        IAssetType.GetAssetType(GameCategory.Skyrim, "XMeshes\\Armor\\Iron\\IronGauntlets.nif").Should().BeNull();
+        IAssetType.GetAssetType(GameCategory.Skyrim, "Meshes\\Armor\\Iron\\IronGauntlets.abc").Should().BeNull();
+
+        IAssetType.GetAssetType(GameCategory.Skyrim, "Textures\\Armor\\Iron\\IronGauntlets.dds").Should().BeOfType<SkyrimTextureAssetType>();
+        IAssetType.GetAssetType(GameCategory.Skyrim, "XTextures\\Armor\\Iron\\IronGauntlets.dds").Should().BeNull();
+        IAssetType.GetAssetType(GameCategory.Skyrim, "Textures\\Armor\\Iron\\IronGauntlets.abc").Should().BeNull();
+
+        IAssetType.GetAssetType(GameCategory.Skyrim, "Sound\\FX\\IronGauntlets.wav").Should().BeOfType<SkyrimSoundAssetType>();
+        IAssetType.GetAssetType(GameCategory.Skyrim, "XSound\\FX\\IronGauntlets.wav").Should().BeNull();
+        IAssetType.GetAssetType(GameCategory.Skyrim, "Sound\\FX\\IronGauntlets.abc").Should().BeNull();
+
+        IAssetType.GetAssetType(GameCategory.Skyrim, "SEQ\\Skyrim.seq").Should().BeOfType<SkyrimSeqAssetType>();
+        IAssetType.GetAssetType(GameCategory.Skyrim, "seq\\Skyrim.seq").Should().BeOfType<SkyrimSeqAssetType>();
+        IAssetType.GetAssetType(GameCategory.Skyrim, "s3q\\Skyrim.abc").Should().BeNull();
+        IAssetType.GetAssetType(GameCategory.Skyrim, "SEQ\\Skyrim.abc").Should().BeNull();
+
+        IAssetType.GetAssetType(GameCategory.Skyrim, "Scripts\\Source\\HelloWorld.psc").Should().BeOfType<SkyrimScriptSourceAssetType>();
+        IAssetType.GetAssetType(GameCategory.Skyrim, "Script\\Source\\HelloWorld.psc").Should().BeNull();
+        IAssetType.GetAssetType(GameCategory.Skyrim, "Scripts\\Source\\HelloWorld.abc").Should().BeNull();
+
+        IAssetType.GetAssetType(GameCategory.Skyrim, "Scripts\\HelloWorld.pex").Should().BeOfType<SkyrimScriptCompiledAssetType>();
+        IAssetType.GetAssetType(GameCategory.Skyrim, "Script\\HelloWorld.pex").Should().BeNull();
+        IAssetType.GetAssetType(GameCategory.Skyrim, "Scripts\\HelloWorld.abc").Should().BeNull();
+    }
 }


### PR DESCRIPTION
Add GetAssetType() based on file extension and base folder. Tests are included.

@Noggog I had to include a limited version of ConvertToDataRelativePath(), without the base folder check as that already needs information about the asset type. I don't know how to properly do this without copy paste as I'm not very familiar with Spans. If you see a way to do that, feel free to change it :)