### PR TITLE
generated_code for generated files in editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -32,3 +32,6 @@ indent_style = space
 indent_size = 2
 trim_trailing_whitespace = true
 insert_final_newline = true
+
+[*_Generated.cs]
+generated_code = true


### PR DESCRIPTION
Set generated_code = true for *_Generated.cs in .editorconfig

When doing my other PR i noticed that there were a lot of extra spaces in files that I manually omitted.

When running `dotnet format Mutagen.Records.sln` in the root folder it also formatted the generated files, this flag fixes that.

This flag should also stop accidental formatting of generated files both in VS and Rider.

So if you want this behaviour it would be nice if you ran the format command in dev. There are currently a couple of hundred files with extra spaces in the source. (I didn't want to push them in this PR due to maybe not being in sync with the code if and when this is merged.)