### PR TITLE
Add IKeyworded.HasKeywords extension methods for IEnumerables

### DIFF
--- a/Mutagen.Bethesda.Core/Plugins/Aspects/IKeyworded.cs
+++ b/Mutagen.Bethesda.Core/Plugins/Aspects/IKeyworded.cs
@@ -287,8 +287,7 @@ namespace Mutagen.Bethesda
             }
             foreach (var keywordForm in keyworded.Keywords.Select(link => link.FormKey))
             {
-                TKeyword keyword;
-                if (cache.TryResolve(keywordForm, out keyword!))
+                if (cache.TryResolve<TKeyword>(keywordForm, out var keyword))
                 {
                     var kwEditorID = keyword.EditorID;
                     if (editorIDs.Any(editorID => kwEditorID?.Equals(editorID, stringComparison) ?? false))

--- a/Mutagen.Bethesda.Core/Plugins/Aspects/IKeyworded.cs
+++ b/Mutagen.Bethesda.Core/Plugins/Aspects/IKeyworded.cs
@@ -219,48 +219,12 @@ namespace Mutagen.Bethesda
         /// <param name="keyworded">Keyworded record to check</param>
         /// <param name="keywordKeys">FormKeys of the Keyword records to look for</param>
         /// <returns>True if the Keyworded record contains a Keyword link /w any of the given FormKeys</returns>
-        public static bool HasKeyword<TKeyword>(
+        public static bool HasAnyKeyword<TKeyword>(
             this IKeywordedGetter<TKeyword> keyworded,
             IEnumerable<FormKey> keywordKeys)
             where TKeyword : class, IKeywordCommonGetter
         {
             return keyworded.Keywords?.IntersectBy(keywordKeys, x => x.FormKey).Any() ?? false;
-        }
-        
-        /// <summary>
-        /// Checks if a Keyworded record contains any specific Keyword, by FormKey.
-        /// Also looks up that keyword in the given cache. <br />
-        /// <br />
-        /// Note that this function only succeeds if the record contains the keyword,
-        /// and the cache found it as well. <br />
-        /// <br />
-        /// It is possible that the record contains the keyword, but it could not be found
-        /// by the cache.
-        /// <br />
-        /// Aspects: IKeywordedGetter&lt;IKeywordCommonGetter&gt;
-        /// </summary>
-        /// <param name="keyworded">Keyworded record to check</param>
-        /// <param name="keywordKeys">FormKeys of the Keyword records to look for</param>
-        /// <param name="cache">LinkCache to resolve against</param>
-        /// <param name="keyword">Keyword record retrieved, if keyworded record does contain</param>
-        /// <returns>True if the Keyworded record contains a Keyword link /w any of the given FormKeys</returns>
-        public static bool TryResolveKeyword<TKeyword>(
-            this IKeywordedGetter<TKeyword> keyworded,
-            IEnumerable<FormKey> keywordKeys,
-            ILinkCache cache,
-            [MaybeNullWhen(false)] out TKeyword keyword)
-            where TKeyword : class, IKeywordCommonGetter
-        {
-            foreach (var keywordKey in keywordKeys)
-            {
-                if (cache.TryResolve(keywordKey, out keyword) && HasKeyword(keyworded, keywordKey))
-                {
-                    return true;
-                }
-            }
-
-            keyword = default;
-            return false;
         }
         
          /// <summary>
@@ -271,39 +235,12 @@ namespace Mutagen.Bethesda
         /// <param name="keyworded">Keyworded record to check</param>
         /// <param name="keywordLink">FormLinks of the Keyword records to look for</param>
         /// <returns>True if the Keyworded record contains a Keyword link /w any of the given FormKeys</returns>
-        public static bool HasKeyword<TKeyword>(
+        public static bool HasAnyKeyword<TKeyword>(
             this IKeywordedGetter<TKeyword> keyworded,
             IEnumerable<IFormLinkGetter<TKeyword>> keywordLink)
             where TKeyword : class, IKeywordCommonGetter
         {
-            return HasKeyword(keyworded, keywordLink.Select(x => x.FormKey));
-        }
-
-        /// <summary>
-        /// Checks if a Keyworded record contains any specific Keyword, by FormKey.
-        /// Also looks up that keyword in the given cache. <br />
-        /// <br />
-        /// Note that this function only succeeds if the record contains the keyword,
-        /// and the cache found it as well. <br />
-        /// <br />
-        /// It is possible that the record contains the keyword, but it could not be found
-        /// by the cache.
-        /// <br />
-        /// Aspects: IKeywordedGetter&lt;IKeywordCommonGetter&gt;
-        /// </summary>
-        /// <param name="keyworded">Keyworded record to check</param>
-        /// <param name="keywordLinks">FormLinks of the Keyword records to look for</param>
-        /// <param name="cache">LinkCache to resolve against</param>
-        /// <param name="keyword">Keyword record retrieved, if keyworded record does contain</param>
-        /// <returns>True if the Keyworded record contains a Keyword link /w any of the given FormKeys</returns>
-        public static bool TryResolveKeyword<TKeyword>(
-            this IKeywordedGetter<TKeyword> keyworded,
-            IEnumerable<IFormLinkGetter<TKeyword>> keywordLinks,
-            ILinkCache cache,
-            [MaybeNullWhen(false)] out TKeyword keyword)
-            where TKeyword : class, IKeywordCommonGetter
-        {
-            return TryResolveKeyword(keyworded, keywordLinks.Select(x => x.FormKey), cache, out keyword);
+            return HasAnyKeyword(keyworded, keywordLink.Select(x => x.FormKey));
         }
         
          /// <summary>
@@ -314,58 +251,12 @@ namespace Mutagen.Bethesda
         /// <param name="keyworded">Keyworded record to check</param>
         /// <param name="keywords">Keyword records to look for</param>
         /// <returns>True if the Keyworded record contains a Keyword link /w any of the given Keyword records' FormKey</returns>
-        public static bool HasKeyword<TKeyword>(
+        public static bool HasAnyKeyword<TKeyword>(
             this IKeywordedGetter<TKeyword> keyworded,
             IEnumerable<TKeyword> keywords)
             where TKeyword : class, IKeywordCommonGetter
         {
-            return keyworded.HasKeyword(keywords.Select(x => x.FormKey));
-        }
-
-        /// <summary>
-        /// Checks if a Keyworded record contains any specific Keyword, by EditorID.
-        /// Also looks up that keyword in the given cache.
-        /// <br />
-        /// Aspects: IKeywordedGetter&lt;IKeywordCommonGetter&gt;
-        /// </summary>
-        /// <param name="keyworded">Keyworded record to check</param>
-        /// <param name="editorIDs">EditorIDs of the Keywordsto look for</param>
-        /// <param name="cache">LinkCache to resolve against</param>
-        /// <param name="keyword">Keyword record retrieved, if keyworded record does contain</param>
-        /// <param name="stringComparison">
-        /// What string comparison type to use.<br />
-        /// By default EditorIDs are case insensitive.
-        /// </param>
-        /// <returns>True if the Keyworded record contains a Keyword link that points to a winning Keyword record /w the any of the given EditorIDs</returns>
-        public static bool TryResolveKeyword<TKeyword>(
-            this IKeywordedGetter<TKeyword> keyworded,
-            IEnumerable<string> editorIDs,
-            ILinkCache cache,
-            [MaybeNullWhen(false)] out TKeyword keyword,
-            StringComparison stringComparison = StringComparison.OrdinalIgnoreCase)
-            where TKeyword : class, IKeywordCommonGetter
-        {
-            // ToDo
-            // Consider EDID link cache systems if/when available
-            if (keyworded.Keywords == null)
-            {
-                keyword = default;
-                return false;
-            }
-            foreach (var keywordForm in keyworded.Keywords.Select(link => link.FormKey))
-            {
-                if (cache.TryResolve(keywordForm, out keyword))
-                {
-                    var kwEditorID = keyword.EditorID;
-                    if (editorIDs.Any(editorID => kwEditorID?.Equals(editorID, stringComparison) ?? false))
-                    {
-                        return true;
-                    }
-                }
-            }
-
-            keyword = default;
-            return false;
+            return keyworded.HasAnyKeyword(keywords.Select(x => x.FormKey));
         }
 
         /// <summary>
@@ -381,14 +272,33 @@ namespace Mutagen.Bethesda
         /// By default EditorIDs are case insensitive.
         /// </param>
         /// <returns>True if the Keyworded record contains a Keyword link that points to a winning Keyword record /w any of the the given EditorIDs</returns>
-        public static bool HasKeyword<TKeyword>(
+        public static bool HasAnyKeyword<TKeyword>(
             this IKeywordedGetter<TKeyword> keyworded,
             IEnumerable<string> editorIDs,
             ILinkCache cache,
             StringComparison stringComparison = StringComparison.OrdinalIgnoreCase)
             where TKeyword : class, IKeywordCommonGetter
         {
-            return TryResolveKeyword(keyworded, editorIDs, cache, out _, stringComparison);
+            // ToDo
+            // Consider EDID link cache systems if/when available
+            if (keyworded.Keywords == null)
+            {
+                return false;
+            }
+            foreach (var keywordForm in keyworded.Keywords.Select(link => link.FormKey))
+            {
+                TKeyword keyword;
+                if (cache.TryResolve(keywordForm, out keyword!))
+                {
+                    var kwEditorID = keyword.EditorID;
+                    if (editorIDs.Any(editorID => kwEditorID?.Equals(editorID, stringComparison) ?? false))
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
         }
     }
 }

--- a/Mutagen.Bethesda.UnitTests/Plugins/Aspects/IKeywordedTests.cs
+++ b/Mutagen.Bethesda.UnitTests/Plugins/Aspects/IKeywordedTests.cs
@@ -131,72 +131,72 @@ public class IKeywordedTests
     
     #region List Tests
     [Fact]
-    public void HasKeyword_ByFormKeyList_Empty()
+    public void HasAnyKeyword_ByFormKeyList_Empty()
     {
         Npc npc = new Npc(TestConstants.Form1, SkyrimRelease.SkyrimSE);
-        npc.HasKeyword(ImmutableList.Create(TestConstants.Form2, TestConstants.Form3)).Should().BeFalse();
+        npc.HasAnyKeyword(ImmutableList.Create(TestConstants.Form2, TestConstants.Form3)).Should().BeFalse();
     }
 
     [Fact]
-    public void HasKeyword_ByFormKeyList_NotFound()
+    public void HasAnyKeyword_ByFormKeyList_NotFound()
     {
         Npc npc = new Npc(TestConstants.Form1, SkyrimRelease.SkyrimSE);
         npc.Keywords = new ExtendedList<IFormLinkGetter<IKeywordGetter>>();
         npc.Keywords.Add(TestConstants.Form3);
-        npc.HasKeyword(ImmutableList.Create(TestConstants.Form2, TestConstants.Form4)).Should().BeFalse();
+        npc.HasAnyKeyword(ImmutableList.Create(TestConstants.Form2, TestConstants.Form4)).Should().BeFalse();
     }
 
     [Fact]
-    public void HasKeyword_ByFormKeyList_Found()
+    public void HasAnyKeyword_ByFormKeyList_Found()
     {
         Npc npc = new Npc(TestConstants.Form1, SkyrimRelease.SkyrimSE);
         npc.Keywords = new ExtendedList<IFormLinkGetter<IKeywordGetter>>();
         npc.Keywords.Add(TestConstants.Form2);
-        npc.HasKeyword(ImmutableList.Create(TestConstants.Form3, TestConstants.Form2)).Should().BeTrue();
+        npc.HasAnyKeyword(ImmutableList.Create(TestConstants.Form3, TestConstants.Form2)).Should().BeTrue();
     }
 
     [Fact]
-    public void HasKeyword_ByRecordList_Empty()
+    public void HasAnyKeyword_ByRecordList_Empty()
     {
         Npc npc = new Npc(TestConstants.Form1, SkyrimRelease.SkyrimSE);
         Keyword keyword1 = new Keyword(TestConstants.Form3, SkyrimRelease.SkyrimSE);
         Keyword keyword2 = new Keyword(TestConstants.Form4, SkyrimRelease.SkyrimSE);
-        npc.HasKeyword(ImmutableList.Create(keyword1, keyword2)).Should().BeFalse();
+        npc.HasAnyKeyword(ImmutableList.Create(keyword1, keyword2)).Should().BeFalse();
     }
 
     [Fact]
-    public void HasKeyword_ByRecordList_NotFound()
+    public void HasAnyKeyword_ByRecordList_NotFound()
     {
         Npc npc = new Npc(TestConstants.Form1, SkyrimRelease.SkyrimSE);
         Keyword keyword2 = new Keyword(TestConstants.Form2, SkyrimRelease.SkyrimSE);
         Keyword keyword4 = new Keyword(TestConstants.Form4, SkyrimRelease.SkyrimSE);
         npc.Keywords = new ExtendedList<IFormLinkGetter<IKeywordGetter>>();
         npc.Keywords.Add(TestConstants.Form3);
-        npc.HasKeyword(ImmutableList.Create(keyword2, keyword4)).Should().BeFalse();
+        npc.HasAnyKeyword(ImmutableList.Create(keyword2, keyword4)).Should().BeFalse();
     }
 
     [Fact]
-    public void HasKeyword_ByRecordList_Found()
+    public void HasAnyKeyword_ByRecordList_Found()
     {
         Npc npc = new Npc(TestConstants.Form1, SkyrimRelease.SkyrimSE);
         Keyword keyword3 = new Keyword(TestConstants.Form3, SkyrimRelease.SkyrimSE);
         Keyword keyword4 = new Keyword(TestConstants.Form4, SkyrimRelease.SkyrimSE);
         npc.Keywords = new ExtendedList<IFormLinkGetter<IKeywordGetter>>();
         npc.Keywords.Add(keyword4);
-        npc.HasKeyword(ImmutableList.Create(keyword3, keyword4)).Should().BeTrue();
+        npc.HasAnyKeyword(ImmutableList.Create(keyword3, keyword4)).Should().BeTrue();
     }
 
     [Fact]
-    public void HasKeyword_ByEditorIDList_Empty()
+    public void HasAnyKeyword_ByEditorIDList_Empty()
     {
         SkyrimMod mod = new SkyrimMod(TestConstants.PluginModKey, SkyrimRelease.SkyrimSE);
         var npc = mod.Npcs.AddNew();
         var cache = mod.ToImmutableLinkCache();
-        npc.HasKeyword(ImmutableList.Create(TestConstants.Edid1), cache).Should().BeFalse();
+        npc.HasAnyKeyword(ImmutableList.Create(TestConstants.Edid1), cache).Should().BeFalse();
     }
 
     [Fact]
-    public void HasKeyword_ByEditorIDList_NotFound()
+    public void HasAnyKeyword_ByEditorIDList_NotFound()
     {
         SkyrimMod mod = new SkyrimMod(TestConstants.PluginModKey, SkyrimRelease.SkyrimSE);
         var npc = mod.Npcs.AddNew();
@@ -205,11 +205,11 @@ public class IKeywordedTests
         keyword.EditorID = TestConstants.Edid2;
         npc.Keywords = new ExtendedList<IFormLinkGetter<IKeywordGetter>>();
         npc.Keywords.Add(keyword);
-        npc.HasKeyword(ImmutableList.Create(TestConstants.Edid1), cache).Should().BeFalse();
+        npc.HasAnyKeyword(ImmutableList.Create(TestConstants.Edid1), cache).Should().BeFalse();
     }
 
     [Fact]
-    public void HasKeyword_ByEditorIDList_Found()
+    public void HasAnyKeyword_ByEditorIDList_Found()
     {
         SkyrimMod mod = new SkyrimMod(TestConstants.PluginModKey, SkyrimRelease.SkyrimSE);
         var npc = mod.Npcs.AddNew();
@@ -218,37 +218,7 @@ public class IKeywordedTests
         keyword.EditorID = TestConstants.Edid1;
         npc.Keywords = new ExtendedList<IFormLinkGetter<IKeywordGetter>>();
         npc.Keywords.Add(keyword);
-        npc.HasKeyword(ImmutableList.Create(TestConstants.Edid2, TestConstants.Edid1), cache).Should().BeTrue();
-    }
-
-    [Fact]
-    public void TryResolveKeyword_ByFormKeyList_Found()
-    {
-        SkyrimMod mod = new SkyrimMod(TestConstants.PluginModKey, SkyrimRelease.SkyrimSE);
-        var npc = mod.Npcs.AddNew();
-        var cache = mod.ToImmutableLinkCache();
-        Keyword keyword1 = mod.Keywords.AddNew();
-        keyword1.EditorID = TestConstants.Edid1;
-        Keyword keyword2 = mod.Keywords.AddNew();
-        keyword2.EditorID = TestConstants.Edid2;
-        npc.Keywords = new ExtendedList<IFormLinkGetter<IKeywordGetter>>();
-        npc.Keywords.Add(keyword1);
-        npc.TryResolveKeyword(ImmutableList.Create(keyword2.FormKey, keyword1.FormKey), cache, out var kw).Should().BeTrue();
-        kw.Should().Be(keyword1);
-    }
-
-    [Fact]
-    public void TryResolveKeyword_ByEditorIDList_Found()
-    {
-        SkyrimMod mod = new SkyrimMod(TestConstants.PluginModKey, SkyrimRelease.SkyrimSE);
-        var npc = mod.Npcs.AddNew();
-        var cache = mod.ToImmutableLinkCache();
-        Keyword keyword = mod.Keywords.AddNew();
-        keyword.EditorID = TestConstants.Edid1;
-        npc.Keywords = new ExtendedList<IFormLinkGetter<IKeywordGetter>>();
-        npc.Keywords.Add(keyword);
-        npc.TryResolveKeyword(ImmutableList.Create(TestConstants.Edid2, TestConstants.Edid1), cache, out var kw).Should().BeTrue();
-        kw.Should().Be(keyword);
+        npc.HasAnyKeyword(ImmutableList.Create(TestConstants.Edid2, TestConstants.Edid1), cache).Should().BeTrue();
     }
     #endregion
 }

--- a/Mutagen.Bethesda.UnitTests/Plugins/Aspects/IKeywordedTests.cs
+++ b/Mutagen.Bethesda.UnitTests/Plugins/Aspects/IKeywordedTests.cs
@@ -59,19 +59,16 @@ public class IKeywordedTests
     }
     
     [Theory, MutagenModAutoData]
-    public void HasKeyword_ByEditorID_Empty(SkyrimMod mod)
+    public void HasKeyword_ByEditorID_Empty(SkyrimMod mod, Npc npc)
     {
-        var npc = mod.Npcs.AddNew();
         var cache = mod.ToImmutableLinkCache();
         npc.HasKeyword(TestConstants.Edid1, cache).Should().BeFalse();
     }
 
     [Theory, MutagenModAutoData]
-    public void HasKeyword_ByEditorID_NotFound(SkyrimMod mod)
+    public void HasKeyword_ByEditorID_NotFound(SkyrimMod mod, Npc npc, Keyword keyword)
     {
-        var npc = mod.Npcs.AddNew();
         var cache = mod.ToImmutableLinkCache();
-        Keyword keyword = mod.Keywords.AddNew();
         keyword.EditorID = TestConstants.Edid2;
         npc.Keywords = new ExtendedList<IFormLinkGetter<IKeywordGetter>>();
         npc.Keywords.Add(keyword);
@@ -79,24 +76,19 @@ public class IKeywordedTests
     }
 
     [Theory, MutagenModAutoData]
-    public void HasKeyword_ByEditorID_Found(SkyrimMod mod)
+    public void HasKeyword_ByEditorID_Found(SkyrimMod mod, Npc npc, Keyword keyword)
     {
-        var npc = mod.Npcs.AddNew();
         var cache = mod.ToImmutableLinkCache();
-        Keyword keyword = mod.Keywords.AddNew();
         keyword.EditorID = TestConstants.Edid1;
         npc.Keywords = new ExtendedList<IFormLinkGetter<IKeywordGetter>>();
         npc.Keywords.Add(keyword);
-        npc.HasKeyword(TestConstants.Edid1, cache).Should().BeTrue();
+        npc.HasKeyword(keyword.EditorID, cache).Should().BeTrue();
     }
 
     [Theory, MutagenModAutoData]
-    public void TryResolveKeyword_ByFormKey_Found(SkyrimMod mod)
+    public void TryResolveKeyword_ByFormKey_Found(SkyrimMod mod, Npc npc, Keyword keyword)
     {
-        var npc = mod.Npcs.AddNew();
         var cache = mod.ToImmutableLinkCache();
-        Keyword keyword = mod.Keywords.AddNew();
-        keyword.EditorID = TestConstants.Edid1;
         npc.Keywords = new ExtendedList<IFormLinkGetter<IKeywordGetter>>();
         npc.Keywords.Add(keyword);
         npc.TryResolveKeyword(keyword.FormKey, cache, out var kw).Should().BeTrue();
@@ -104,15 +96,13 @@ public class IKeywordedTests
     }
 
     [Theory, MutagenModAutoData]
-    public void TryResolveKeyword_ByEditorID_Found(SkyrimMod mod)
+    public void TryResolveKeyword_ByEditorID_Found(SkyrimMod mod, Npc npc, Keyword keyword)
     {
-        var npc = mod.Npcs.AddNew();
         var cache = mod.ToImmutableLinkCache();
-        Keyword keyword = mod.Keywords.AddNew();
         keyword.EditorID = TestConstants.Edid1;
         npc.Keywords = new ExtendedList<IFormLinkGetter<IKeywordGetter>>();
         npc.Keywords.Add(keyword);
-        npc.TryResolveKeyword(TestConstants.Edid1, cache, out var kw).Should().BeTrue();
+        npc.TryResolveKeyword(keyword.EditorID, cache, out var kw).Should().BeTrue();
         kw.Should().Be(keyword);
     }
     #endregion
@@ -163,19 +153,16 @@ public class IKeywordedTests
     }
 
     [Theory, MutagenModAutoData]
-    public void HasAnyKeyword_ByEditorIDList_Empty(SkyrimMod mod)
+    public void HasAnyKeyword_ByEditorIDList_Empty(SkyrimMod mod, Npc npc)
     {
-        var npc = mod.Npcs.AddNew();
         var cache = mod.ToImmutableLinkCache();
         npc.HasAnyKeyword(ImmutableList.Create(TestConstants.Edid1), cache).Should().BeFalse();
     }
 
     [Theory, MutagenModAutoData]
-    public void HasAnyKeyword_ByEditorIDList_NotFound(SkyrimMod mod)
+    public void HasAnyKeyword_ByEditorIDList_NotFound(SkyrimMod mod, Npc npc, Keyword keyword)
     {
-        var npc = mod.Npcs.AddNew();
         var cache = mod.ToImmutableLinkCache();
-        Keyword keyword = mod.Keywords.AddNew();
         keyword.EditorID = TestConstants.Edid2;
         npc.Keywords = new ExtendedList<IFormLinkGetter<IKeywordGetter>>();
         npc.Keywords.Add(keyword);
@@ -183,15 +170,13 @@ public class IKeywordedTests
     }
 
     [Theory, MutagenModAutoData]
-    public void HasAnyKeyword_ByEditorIDList_Found(SkyrimMod mod)
+    public void HasAnyKeyword_ByEditorIDList_Found(SkyrimMod mod, Npc npc, Keyword keyword)
     {
-        var npc = mod.Npcs.AddNew();
         var cache = mod.ToImmutableLinkCache();
-        Keyword keyword = mod.Keywords.AddNew();
         keyword.EditorID = TestConstants.Edid1;
         npc.Keywords = new ExtendedList<IFormLinkGetter<IKeywordGetter>>();
         npc.Keywords.Add(keyword);
-        npc.HasAnyKeyword(ImmutableList.Create(TestConstants.Edid2, TestConstants.Edid1), cache).Should().BeTrue();
+        npc.HasAnyKeyword(ImmutableList.Create(TestConstants.Edid2, keyword.EditorID), cache).Should().BeTrue();
     }
     #endregion
 }

--- a/Mutagen.Bethesda.UnitTests/Plugins/Aspects/IKeywordedTests.cs
+++ b/Mutagen.Bethesda.UnitTests/Plugins/Aspects/IKeywordedTests.cs
@@ -5,6 +5,8 @@ using Mutagen.Bethesda.Plugins;
 using Mutagen.Bethesda.Skyrim;
 using Noggog;
 using Mutagen.Bethesda.Testing;
+using Mutagen.Bethesda.Testing.AutoData;
+
 using Xunit;
 
 namespace Mutagen.Bethesda.UnitTests.Plugins.Aspects;
@@ -12,72 +14,61 @@ namespace Mutagen.Bethesda.UnitTests.Plugins.Aspects;
 public class IKeywordedTests
 {
     #region Single Tests
-    [Fact]
-    public void HasKeyword_ByFormKey_Empty()
+    [Theory, MutagenModAutoData]
+    public void HasKeyword_ByFormKey_Empty(Npc npc, FormKey form)
     {
-        Npc npc = new Npc(TestConstants.Form1, SkyrimRelease.SkyrimSE);
-        npc.HasKeyword(TestConstants.Form2).Should().BeFalse();
+        npc.HasKeyword(form).Should().BeFalse();
     }
 
-    [Fact]
-    public void HasKeyword_ByFormKey_NotFound()
+    [Theory, MutagenModAutoData]
+    public void HasKeyword_ByFormKey_NotFound(Npc npc, FormKey form1, FormKey form2)
     {
-        Npc npc = new Npc(TestConstants.Form1, SkyrimRelease.SkyrimSE);
         npc.Keywords = new ExtendedList<IFormLinkGetter<IKeywordGetter>>();
-        npc.Keywords.Add(TestConstants.Form3);
-        npc.HasKeyword(TestConstants.Form2).Should().BeFalse();
+        npc.Keywords.Add(form1);
+        npc.HasKeyword(form2).Should().BeFalse();
     }
 
-    [Fact]
-    public void HasKeyword_ByFormKey_Found()
+    [Theory, MutagenModAutoData]
+    public void HasKeyword_ByFormKey_Found(Npc npc, FormKey form)
     {
-        Npc npc = new Npc(TestConstants.Form1, SkyrimRelease.SkyrimSE);
         npc.Keywords = new ExtendedList<IFormLinkGetter<IKeywordGetter>>();
-        npc.Keywords.Add(TestConstants.Form2);
-        npc.HasKeyword(TestConstants.Form2).Should().BeTrue();
+        npc.Keywords.Add(form);
+        npc.HasKeyword(form).Should().BeTrue();
     }
 
-    [Fact]
-    public void HasKeyword_ByRecord_Empty()
+    [Theory, MutagenModAutoData]
+    public void HasKeyword_ByRecord_Empty(Npc npc, Keyword keyword)
     {
-        Npc npc = new Npc(TestConstants.Form1, SkyrimRelease.SkyrimSE);
-        Keyword keyword = new Keyword(TestConstants.Form4, SkyrimRelease.SkyrimSE);
         npc.HasKeyword(keyword).Should().BeFalse();
     }
 
-    [Fact]
-    public void HasKeyword_ByRecord_NotFound()
+    [Theory, MutagenModAutoData]
+    public void HasKeyword_ByRecord_NotFound(Npc npc, Keyword keyword1, Keyword keyword2)
     {
-        Npc npc = new Npc(TestConstants.Form1, SkyrimRelease.SkyrimSE);
-        Keyword keyword = new Keyword(TestConstants.Form4, SkyrimRelease.SkyrimSE);
         npc.Keywords = new ExtendedList<IFormLinkGetter<IKeywordGetter>>();
-        npc.Keywords.Add(TestConstants.Form3);
-        npc.HasKeyword(keyword).Should().BeFalse();
+        npc.Keywords.Add(keyword1);
+        npc.HasKeyword(keyword2).Should().BeFalse();
     }
 
-    [Fact]
-    public void HasKeyword_ByRecord_Found()
+    [Theory, MutagenModAutoData]
+    public void HasKeyword_ByRecord_Found(Npc npc, Keyword keyword)
     {
-        Npc npc = new Npc(TestConstants.Form1, SkyrimRelease.SkyrimSE);
-        Keyword keyword = new Keyword(TestConstants.Form4, SkyrimRelease.SkyrimSE);
         npc.Keywords = new ExtendedList<IFormLinkGetter<IKeywordGetter>>();
         npc.Keywords.Add(keyword);
         npc.HasKeyword(keyword).Should().BeTrue();
     }
-
-    [Fact]
-    public void HasKeyword_ByEditorID_Empty()
+    
+    [Theory, MutagenModAutoData]
+    public void HasKeyword_ByEditorID_Empty(SkyrimMod mod)
     {
-        SkyrimMod mod = new SkyrimMod(TestConstants.PluginModKey, SkyrimRelease.SkyrimSE);
         var npc = mod.Npcs.AddNew();
         var cache = mod.ToImmutableLinkCache();
         npc.HasKeyword(TestConstants.Edid1, cache).Should().BeFalse();
     }
 
-    [Fact]
-    public void HasKeyword_ByEditorID_NotFound()
+    [Theory, MutagenModAutoData]
+    public void HasKeyword_ByEditorID_NotFound(SkyrimMod mod)
     {
-        SkyrimMod mod = new SkyrimMod(TestConstants.PluginModKey, SkyrimRelease.SkyrimSE);
         var npc = mod.Npcs.AddNew();
         var cache = mod.ToImmutableLinkCache();
         Keyword keyword = mod.Keywords.AddNew();
@@ -87,10 +78,9 @@ public class IKeywordedTests
         npc.HasKeyword(TestConstants.Edid1, cache).Should().BeFalse();
     }
 
-    [Fact]
-    public void HasKeyword_ByEditorID_Found()
+    [Theory, MutagenModAutoData]
+    public void HasKeyword_ByEditorID_Found(SkyrimMod mod)
     {
-        SkyrimMod mod = new SkyrimMod(TestConstants.PluginModKey, SkyrimRelease.SkyrimSE);
         var npc = mod.Npcs.AddNew();
         var cache = mod.ToImmutableLinkCache();
         Keyword keyword = mod.Keywords.AddNew();
@@ -100,10 +90,9 @@ public class IKeywordedTests
         npc.HasKeyword(TestConstants.Edid1, cache).Should().BeTrue();
     }
 
-    [Fact]
-    public void TryResolveKeyword_ByFormKey_Found()
+    [Theory, MutagenModAutoData]
+    public void TryResolveKeyword_ByFormKey_Found(SkyrimMod mod)
     {
-        SkyrimMod mod = new SkyrimMod(TestConstants.PluginModKey, SkyrimRelease.SkyrimSE);
         var npc = mod.Npcs.AddNew();
         var cache = mod.ToImmutableLinkCache();
         Keyword keyword = mod.Keywords.AddNew();
@@ -114,10 +103,9 @@ public class IKeywordedTests
         kw.Should().Be(keyword);
     }
 
-    [Fact]
-    public void TryResolveKeyword_ByEditorID_Found()
+    [Theory, MutagenModAutoData]
+    public void TryResolveKeyword_ByEditorID_Found(SkyrimMod mod)
     {
-        SkyrimMod mod = new SkyrimMod(TestConstants.PluginModKey, SkyrimRelease.SkyrimSE);
         var npc = mod.Npcs.AddNew();
         var cache = mod.ToImmutableLinkCache();
         Keyword keyword = mod.Keywords.AddNew();
@@ -130,75 +118,61 @@ public class IKeywordedTests
     #endregion
     
     #region List Tests
-    [Fact]
-    public void HasAnyKeyword_ByFormKeyList_Empty()
+    [Theory, MutagenModAutoData]
+    public void HasAnyKeyword_ByFormKeyList_Empty(Npc npc, FormKey form1, FormKey form2)
     {
-        Npc npc = new Npc(TestConstants.Form1, SkyrimRelease.SkyrimSE);
-        npc.HasAnyKeyword(ImmutableList.Create(TestConstants.Form2, TestConstants.Form3)).Should().BeFalse();
+        npc.HasAnyKeyword(ImmutableList.Create(form1, form2)).Should().BeFalse();
     }
 
-    [Fact]
-    public void HasAnyKeyword_ByFormKeyList_NotFound()
+    [Theory, MutagenModAutoData]
+    public void HasAnyKeyword_ByFormKeyList_NotFound(Npc npc, Keyword keyword, FormKey form1, FormKey form2)
     {
-        Npc npc = new Npc(TestConstants.Form1, SkyrimRelease.SkyrimSE);
         npc.Keywords = new ExtendedList<IFormLinkGetter<IKeywordGetter>>();
-        npc.Keywords.Add(TestConstants.Form3);
-        npc.HasAnyKeyword(ImmutableList.Create(TestConstants.Form2, TestConstants.Form4)).Should().BeFalse();
+        npc.Keywords.Add(keyword.ToLink());
+        npc.HasAnyKeyword(ImmutableList.Create(form1, form2)).Should().BeFalse();
     }
 
-    [Fact]
-    public void HasAnyKeyword_ByFormKeyList_Found()
+    [Theory, MutagenModAutoData]
+    public void HasAnyKeyword_ByFormKeyList_Found(Npc npc, Keyword keyword, FormKey form)
     {
-        Npc npc = new Npc(TestConstants.Form1, SkyrimRelease.SkyrimSE);
         npc.Keywords = new ExtendedList<IFormLinkGetter<IKeywordGetter>>();
-        npc.Keywords.Add(TestConstants.Form2);
-        npc.HasAnyKeyword(ImmutableList.Create(TestConstants.Form3, TestConstants.Form2)).Should().BeTrue();
+        npc.Keywords.Add(keyword.ToLink());
+        npc.HasAnyKeyword(ImmutableList.Create(form, keyword.ToLink().FormKey)).Should().BeTrue();
     }
 
-    [Fact]
-    public void HasAnyKeyword_ByRecordList_Empty()
+    [Theory, MutagenModAutoData]
+    public void HasAnyKeyword_ByRecordList_Empty(Npc npc, Keyword keyword1, Keyword keyword2)
     {
-        Npc npc = new Npc(TestConstants.Form1, SkyrimRelease.SkyrimSE);
-        Keyword keyword1 = new Keyword(TestConstants.Form3, SkyrimRelease.SkyrimSE);
-        Keyword keyword2 = new Keyword(TestConstants.Form4, SkyrimRelease.SkyrimSE);
         npc.HasAnyKeyword(ImmutableList.Create(keyword1, keyword2)).Should().BeFalse();
     }
 
-    [Fact]
-    public void HasAnyKeyword_ByRecordList_NotFound()
+    [Theory, MutagenModAutoData]
+    public void HasAnyKeyword_ByRecordList_NotFound(Npc npc, Keyword keyword1, Keyword keyword2, Keyword keyword3)
     {
-        Npc npc = new Npc(TestConstants.Form1, SkyrimRelease.SkyrimSE);
-        Keyword keyword2 = new Keyword(TestConstants.Form2, SkyrimRelease.SkyrimSE);
-        Keyword keyword4 = new Keyword(TestConstants.Form4, SkyrimRelease.SkyrimSE);
         npc.Keywords = new ExtendedList<IFormLinkGetter<IKeywordGetter>>();
-        npc.Keywords.Add(TestConstants.Form3);
-        npc.HasAnyKeyword(ImmutableList.Create(keyword2, keyword4)).Should().BeFalse();
+        npc.Keywords.Add(keyword1);
+        npc.HasAnyKeyword(ImmutableList.Create(keyword2, keyword3)).Should().BeFalse();
     }
 
-    [Fact]
-    public void HasAnyKeyword_ByRecordList_Found()
+    [Theory, MutagenModAutoData]
+    public void HasAnyKeyword_ByRecordList_Found(Npc npc, Keyword keyword1, Keyword keyword2)
     {
-        Npc npc = new Npc(TestConstants.Form1, SkyrimRelease.SkyrimSE);
-        Keyword keyword3 = new Keyword(TestConstants.Form3, SkyrimRelease.SkyrimSE);
-        Keyword keyword4 = new Keyword(TestConstants.Form4, SkyrimRelease.SkyrimSE);
         npc.Keywords = new ExtendedList<IFormLinkGetter<IKeywordGetter>>();
-        npc.Keywords.Add(keyword4);
-        npc.HasAnyKeyword(ImmutableList.Create(keyword3, keyword4)).Should().BeTrue();
+        npc.Keywords.Add(keyword2);
+        npc.HasAnyKeyword(ImmutableList.Create(keyword1, keyword2)).Should().BeTrue();
     }
 
-    [Fact]
-    public void HasAnyKeyword_ByEditorIDList_Empty()
+    [Theory, MutagenModAutoData]
+    public void HasAnyKeyword_ByEditorIDList_Empty(SkyrimMod mod)
     {
-        SkyrimMod mod = new SkyrimMod(TestConstants.PluginModKey, SkyrimRelease.SkyrimSE);
         var npc = mod.Npcs.AddNew();
         var cache = mod.ToImmutableLinkCache();
         npc.HasAnyKeyword(ImmutableList.Create(TestConstants.Edid1), cache).Should().BeFalse();
     }
 
-    [Fact]
-    public void HasAnyKeyword_ByEditorIDList_NotFound()
+    [Theory, MutagenModAutoData]
+    public void HasAnyKeyword_ByEditorIDList_NotFound(SkyrimMod mod)
     {
-        SkyrimMod mod = new SkyrimMod(TestConstants.PluginModKey, SkyrimRelease.SkyrimSE);
         var npc = mod.Npcs.AddNew();
         var cache = mod.ToImmutableLinkCache();
         Keyword keyword = mod.Keywords.AddNew();
@@ -208,10 +182,9 @@ public class IKeywordedTests
         npc.HasAnyKeyword(ImmutableList.Create(TestConstants.Edid1), cache).Should().BeFalse();
     }
 
-    [Fact]
-    public void HasAnyKeyword_ByEditorIDList_Found()
+    [Theory, MutagenModAutoData]
+    public void HasAnyKeyword_ByEditorIDList_Found(SkyrimMod mod)
     {
-        SkyrimMod mod = new SkyrimMod(TestConstants.PluginModKey, SkyrimRelease.SkyrimSE);
         var npc = mod.Npcs.AddNew();
         var cache = mod.ToImmutableLinkCache();
         Keyword keyword = mod.Keywords.AddNew();

--- a/Mutagen.Bethesda.UnitTests/Plugins/Aspects/IKeywordedTests.cs
+++ b/Mutagen.Bethesda.UnitTests/Plugins/Aspects/IKeywordedTests.cs
@@ -1,3 +1,5 @@
+using System.Collections.Immutable;
+
 using FluentAssertions;
 using Mutagen.Bethesda.Plugins;
 using Mutagen.Bethesda.Skyrim;
@@ -9,6 +11,7 @@ namespace Mutagen.Bethesda.UnitTests.Plugins.Aspects;
 
 public class IKeywordedTests
 {
+    #region Single Tests
     [Fact]
     public void HasKeyword_ByFormKey_Empty()
     {
@@ -124,4 +127,128 @@ public class IKeywordedTests
         npc.TryResolveKeyword(TestConstants.Edid1, cache, out var kw).Should().BeTrue();
         kw.Should().Be(keyword);
     }
+    #endregion
+    
+    #region List Tests
+    [Fact]
+    public void HasKeyword_ByFormKeyList_Empty()
+    {
+        Npc npc = new Npc(TestConstants.Form1, SkyrimRelease.SkyrimSE);
+        npc.HasKeyword(ImmutableList.Create(TestConstants.Form2, TestConstants.Form3)).Should().BeFalse();
+    }
+
+    [Fact]
+    public void HasKeyword_ByFormKeyList_NotFound()
+    {
+        Npc npc = new Npc(TestConstants.Form1, SkyrimRelease.SkyrimSE);
+        npc.Keywords = new ExtendedList<IFormLinkGetter<IKeywordGetter>>();
+        npc.Keywords.Add(TestConstants.Form3);
+        npc.HasKeyword(ImmutableList.Create(TestConstants.Form2, TestConstants.Form4)).Should().BeFalse();
+    }
+
+    [Fact]
+    public void HasKeyword_ByFormKeyList_Found()
+    {
+        Npc npc = new Npc(TestConstants.Form1, SkyrimRelease.SkyrimSE);
+        npc.Keywords = new ExtendedList<IFormLinkGetter<IKeywordGetter>>();
+        npc.Keywords.Add(TestConstants.Form2);
+        npc.HasKeyword(ImmutableList.Create(TestConstants.Form3, TestConstants.Form2)).Should().BeTrue();
+    }
+
+    [Fact]
+    public void HasKeyword_ByRecordList_Empty()
+    {
+        Npc npc = new Npc(TestConstants.Form1, SkyrimRelease.SkyrimSE);
+        Keyword keyword1 = new Keyword(TestConstants.Form3, SkyrimRelease.SkyrimSE);
+        Keyword keyword2 = new Keyword(TestConstants.Form4, SkyrimRelease.SkyrimSE);
+        npc.HasKeyword(ImmutableList.Create(keyword1, keyword2)).Should().BeFalse();
+    }
+
+    [Fact]
+    public void HasKeyword_ByRecordList_NotFound()
+    {
+        Npc npc = new Npc(TestConstants.Form1, SkyrimRelease.SkyrimSE);
+        Keyword keyword2 = new Keyword(TestConstants.Form2, SkyrimRelease.SkyrimSE);
+        Keyword keyword4 = new Keyword(TestConstants.Form4, SkyrimRelease.SkyrimSE);
+        npc.Keywords = new ExtendedList<IFormLinkGetter<IKeywordGetter>>();
+        npc.Keywords.Add(TestConstants.Form3);
+        npc.HasKeyword(ImmutableList.Create(keyword2, keyword4)).Should().BeFalse();
+    }
+
+    [Fact]
+    public void HasKeyword_ByRecordList_Found()
+    {
+        Npc npc = new Npc(TestConstants.Form1, SkyrimRelease.SkyrimSE);
+        Keyword keyword3 = new Keyword(TestConstants.Form3, SkyrimRelease.SkyrimSE);
+        Keyword keyword4 = new Keyword(TestConstants.Form4, SkyrimRelease.SkyrimSE);
+        npc.Keywords = new ExtendedList<IFormLinkGetter<IKeywordGetter>>();
+        npc.Keywords.Add(keyword4);
+        npc.HasKeyword(ImmutableList.Create(keyword3, keyword4)).Should().BeTrue();
+    }
+
+    [Fact]
+    public void HasKeyword_ByEditorIDList_Empty()
+    {
+        SkyrimMod mod = new SkyrimMod(TestConstants.PluginModKey, SkyrimRelease.SkyrimSE);
+        var npc = mod.Npcs.AddNew();
+        var cache = mod.ToImmutableLinkCache();
+        npc.HasKeyword(ImmutableList.Create(TestConstants.Edid1), cache).Should().BeFalse();
+    }
+
+    [Fact]
+    public void HasKeyword_ByEditorIDList_NotFound()
+    {
+        SkyrimMod mod = new SkyrimMod(TestConstants.PluginModKey, SkyrimRelease.SkyrimSE);
+        var npc = mod.Npcs.AddNew();
+        var cache = mod.ToImmutableLinkCache();
+        Keyword keyword = mod.Keywords.AddNew();
+        keyword.EditorID = TestConstants.Edid2;
+        npc.Keywords = new ExtendedList<IFormLinkGetter<IKeywordGetter>>();
+        npc.Keywords.Add(keyword);
+        npc.HasKeyword(ImmutableList.Create(TestConstants.Edid1), cache).Should().BeFalse();
+    }
+
+    [Fact]
+    public void HasKeyword_ByEditorIDList_Found()
+    {
+        SkyrimMod mod = new SkyrimMod(TestConstants.PluginModKey, SkyrimRelease.SkyrimSE);
+        var npc = mod.Npcs.AddNew();
+        var cache = mod.ToImmutableLinkCache();
+        Keyword keyword = mod.Keywords.AddNew();
+        keyword.EditorID = TestConstants.Edid1;
+        npc.Keywords = new ExtendedList<IFormLinkGetter<IKeywordGetter>>();
+        npc.Keywords.Add(keyword);
+        npc.HasKeyword(ImmutableList.Create(TestConstants.Edid2, TestConstants.Edid1), cache).Should().BeTrue();
+    }
+
+    [Fact]
+    public void TryResolveKeyword_ByFormKeyList_Found()
+    {
+        SkyrimMod mod = new SkyrimMod(TestConstants.PluginModKey, SkyrimRelease.SkyrimSE);
+        var npc = mod.Npcs.AddNew();
+        var cache = mod.ToImmutableLinkCache();
+        Keyword keyword1 = mod.Keywords.AddNew();
+        keyword1.EditorID = TestConstants.Edid1;
+        Keyword keyword2 = mod.Keywords.AddNew();
+        keyword2.EditorID = TestConstants.Edid2;
+        npc.Keywords = new ExtendedList<IFormLinkGetter<IKeywordGetter>>();
+        npc.Keywords.Add(keyword1);
+        npc.TryResolveKeyword(ImmutableList.Create(keyword2.FormKey, keyword1.FormKey), cache, out var kw).Should().BeTrue();
+        kw.Should().Be(keyword1);
+    }
+
+    [Fact]
+    public void TryResolveKeyword_ByEditorIDList_Found()
+    {
+        SkyrimMod mod = new SkyrimMod(TestConstants.PluginModKey, SkyrimRelease.SkyrimSE);
+        var npc = mod.Npcs.AddNew();
+        var cache = mod.ToImmutableLinkCache();
+        Keyword keyword = mod.Keywords.AddNew();
+        keyword.EditorID = TestConstants.Edid1;
+        npc.Keywords = new ExtendedList<IFormLinkGetter<IKeywordGetter>>();
+        npc.Keywords.Add(keyword);
+        npc.TryResolveKeyword(ImmutableList.Create(TestConstants.Edid2, TestConstants.Edid1), cache, out var kw).Should().BeTrue();
+        kw.Should().Be(keyword);
+    }
+    #endregion
 }


### PR DESCRIPTION
Close #415

We could make the non-list methods proxy to the list methods to reduce code duplication (by wrapping the single argument in a list), but wasn't sure it was worthwhile.