### PR TITLE
Fixes list rendering in documentation

### DIFF
--- a/docs/best-practices/Accessing-Known-Records.md
+++ b/docs/best-practices/Accessing-Known-Records.md
@@ -33,6 +33,7 @@ First, a FormKey is created pointing to the known record for the Argonian race i
 This will retrieve the winning override.
 
 However, there's a few annoyances:
+
 - Neither the dev nor future readers know the FormID for records offhand, and so must always look them up.
 - The only indication that `123456` points to the argonian race is to look it up and check, or hope the variable is named something intelligent (like `argonianRaceFormKey`)
 - Potential for typos.  What if it was actually `123457` and got mis-copied?

--- a/docs/best-practices/FormLink-vs-FormLinkNullable.md
+++ b/docs/best-practices/FormLink-vs-FormLinkNullable.md
@@ -2,6 +2,7 @@
 FormLinks are used widely as a strongly typed identifier of a record, as an alternative to FormID, EditorID, or even FormKey.
 
 When using them, though, there are two variants:
+
 - `FormLink`
 - `FormLinkNullable`
 
@@ -19,10 +20,12 @@ A FormLinkNullable can be null in two ways:
 
 An example of this is in Skyrim Npc's Worn Armor.   It is a `FormID` in the subrecord `WNAM`, which points to an Armor an Npc wears.
 Consider how this Worn Armor can be null:
+
 - `WNAM`'s value can be 0
 - WNAM can be missing entirely
 
 And how a `FormLinkNullable`'s `FormKey` will be exposed in those differing scenarios:
+
 - When `WNAM`s value is 0, `FormKey` will not be null, and will contain a zero ID
 - When `WNAM` is missing entirely, `FormKey` member will be null
 

--- a/docs/best-practices/FormLinks-Always-Target-Getter-Interfaces.md
+++ b/docs/best-practices/FormLinks-Always-Target-Getter-Interfaces.md
@@ -1,6 +1,7 @@
 # FormLinks Always Target Getter Interfaces
 ## Complication
 `FormLinks` are `FormKeys` with typing information mixed in as to which record type they should associate with.  As such, they require you specify the typing you want to target.  Assuming you just wanted to target Npcs, there are still a few options:
+
 - `Npc` -> The direct class
 - `INpc` -> The setter interface
 - `INpcGetter` -> The readonly interface

--- a/docs/best-practices/Getters-Everywhere.md
+++ b/docs/best-practices/Getters-Everywhere.md
@@ -1,6 +1,7 @@
 # Getters Everywhere
 ## Overview
 Mutagen offers up records in several ways.  Consider dealing with an Npc, it would offer:
+
 - `Npc` class.   A class with all the fields an Npc has
 - `INpc` interface.   An interface with all the fields an Npc has.  The class implements this.
 - `INpcGetter` interface.  An interface with all the fields an Npc has, but only gettable.  Cannot be modified.
@@ -70,6 +71,7 @@ orthornSetter.Speed *= 2;
 ```
 
 This is better in a few ways:
+
 - As part of the modification process, we are required to indicate which mod is going to "house" those modifications
 - The object instance we are modifying only exists in our outgoing patch, rather than many mods
 - The original Skyrim.esm definition is left intact.  In fact, it cannot possibly be modified as the entire mod object is readonly fundamentally.

--- a/docs/best-practices/TryGet-Concepts.md
+++ b/docs/best-practices/TryGet-Concepts.md
@@ -2,6 +2,7 @@
 There are many concepts within Mutagen that are optional, nullable, or may not link up at runtime.
 
 It is good practice to code in a way that is able to handle both situations:
+
 - The field is not null.  The lookup found its target.  Etc
 - The field is null.  The lookup failed to find its target.  Etc
 

--- a/docs/environment/Environment-Construction.md
+++ b/docs/environment/Environment-Construction.md
@@ -27,6 +27,7 @@ Lets you fluently tweak the environment that will be built to be customized to y
 
 ### Problem
 There are a lot of times when the [Single Game Category Construction](#single-game-category-construction) game environment does not suit your needs.  Consider:
+
 - Wanting to omit a mod
 - Wanting to add an output mod, and integrate it with the link cache
 

--- a/docs/environment/Game-Locations.md
+++ b/docs/environment/Game-Locations.md
@@ -24,6 +24,7 @@ if (GameLocations.TryGetDataFolder(GameRelease.SkyrimSE, out var dataFolder))
 
 ## Sources
 Currently, Mutagen locates games via a few sources:
+
 - Looks in the registry
 - Looks in Steam systems (via [GameFinder](https://github.com/erri120/GameFinder))
 

--- a/docs/environment/index.md
+++ b/docs/environment/index.md
@@ -21,6 +21,7 @@ using (var env = GameEnvironment.Typical.Skyrim(SkyrimRelease.SkyrimSE))
 
 ## GameEnvironmentState
 The environment object that is given to you has lots of useful contextual items:
+
 - A LoadOrder object with the current load order 
 - ReadOnly Mod objects ready for use on the load order object, when they are found to exist
 - LinkCache relative to the load order

--- a/docs/examples/Print-Some-Content.md
+++ b/docs/examples/Print-Some-Content.md
@@ -14,6 +14,7 @@ foreach (var name in mod.NPCs.Records
 ```
 
 An outline of what is going on in the code above:
+
 - A mod object is created (in the [Overlay Pattern](Binary-Overlay))
 - The NPC group's records are iterated over
 - Using typical C# LINQ patterns, `Name` is selected and filtered out if empty or duplicates

--- a/docs/familiar/Nullability-to-Indicate-Record-Presence.md
+++ b/docs/familiar/Nullability-to-Indicate-Record-Presence.md
@@ -11,6 +11,7 @@ string? OptionalField { get; set; }
 The `RequiredField` cannot be `null`, and always must have some value.  The `OptionalField` is allowed to be `null`.  Mutagen utilizes this distinction to communicate that `OptionalField` is considered "unset" if/when it is `null`.
 
 Going off the earlier `Potion` interface:
+
 - FormKey cannot be null, and must always have a value.
 - EditorID, Name, Model, Icon are all optional, and will be null if they are not set.
 

--- a/docs/game-specific/oblivion/Oblivion-Aspect-Interfaces.md
+++ b/docs/game-specific/oblivion/Oblivion-Aspect-Interfaces.md
@@ -5,6 +5,7 @@ Aspect Interfaces expose common aspects of records.  For example, `INamed` are i
 Functions can then be written that take in `INamed`, allowing any record that has a name to be passed in.
 ## Interfaces to Concrete Classes
 ### IModeled
+
 - Activator
 - AlchemicalApparatus
 - Ammunition
@@ -35,6 +36,7 @@ Functions can then be written that take in `INamed`, allowing any record that ha
 - Weapon
 - Weather
 ### INamed
+
 - AClothing
 - Activator
 - AlchemicalApparatus
@@ -75,6 +77,7 @@ Functions can then be written that take in `INamed`, allowing any record that ha
 - Weapon
 - Worldspace
 ### IWeightValue
+
 - AlchemicalApparatusData
 - AmmunitionData
 - ArmorData
@@ -86,136 +89,193 @@ Functions can then be written that take in `INamed`, allowing any record that ha
 - WeaponData
 ## Concrete Classes to Interfaces
 ### AClothing
+
 - INamed
 ### Activator
+
 - IModeled
 - INamed
 ### AlchemicalApparatus
+
 - IModeled
 - INamed
 ### AlchemicalApparatusData
+
 - IWeightValue
 ### Ammunition
+
 - IModeled
 - INamed
 ### AmmunitionData
+
 - IWeightValue
 ### AnimatedObject
+
 - IModeled
 ### Armor
+
 - INamed
 ### ArmorData
+
 - IWeightValue
 ### Birthsign
+
 - INamed
 ### BodyData
+
 - IModeled
 ### Book
+
 - IModeled
 - INamed
 ### Cell
+
 - INamed
 ### Class
+
 - INamed
 ### Climate
+
 - IModeled
 ### Clothing
+
 - INamed
 ### ClothingData
+
 - IWeightValue
 ### Container
+
 - IModeled
 - INamed
 ### Creature
+
 - IModeled
 - INamed
 ### DialogTopic
+
 - INamed
 ### Door
+
 - IModeled
 - INamed
 ### Enchantment
+
 - INamed
 ### Eye
+
 - INamed
 ### FacePart
+
 - IModeled
 ### Faction
+
 - INamed
 ### Flora
+
 - IModeled
 - INamed
 ### Furniture
+
 - IModeled
 - INamed
 ### Grass
+
 - IModeled
 ### Hair
+
 - IModeled
 - INamed
 ### IdleAnimation
+
 - IModeled
 ### Ingredient
+
 - IModeled
 - INamed
 ### Key
+
 - IModeled
 - INamed
 ### KeyData
+
 - IWeightValue
 ### Light
+
 - IModeled
 - INamed
 ### LightData
+
 - IWeightValue
 ### LocalVariable
+
 - INamed
 ### MagicEffect
+
 - IModeled
 - INamed
 ### MapMarker
+
 - INamed
 ### Miscellaneous
+
 - IModeled
 - INamed
 ### Npc
+
 - IModeled
 - INamed
 ### Potion
+
 - IModeled
 - INamed
 ### Quest
+
 - INamed
 ### Race
+
 - INamed
 ### ScriptEffect
+
 - INamed
 ### SigilStone
+
 - IModeled
 - INamed
 ### SigilStoneData
+
 - IWeightValue
 ### SoulGem
+
 - IModeled
 - INamed
 ### SoulGemData
+
 - IWeightValue
 ### Spell
+
 - INamed
 ### SpellLeveled
+
 - INamed
 ### SpellUnleveled
+
 - INamed
 ### Static
+
 - IModeled
 ### Tree
+
 - IModeled
 ### Weapon
+
 - IModeled
 - INamed
 ### WeaponData
+
 - IWeightValue
 ### Weather
+
 - IModeled
 ### Worldspace
+
 - INamed

--- a/docs/game-specific/oblivion/Oblivion-Link-Interfaces.md
+++ b/docs/game-specific/oblivion/Oblivion-Link-Interfaces.md
@@ -7,23 +7,31 @@ An interface would be defined such as 'IItem', which all Armor, Weapon, Ingredie
 A `FormLink<IItem>` could then point to all those record types by pointing to the interface instead.
 ## Interfaces to Concrete Classes
 ### IOwner
+
 - Faction
 - Npc
 ### IPlaced
+
 - Landscape
 - PlacedCreature
 - PlacedNpc
 - PlacedObject
 ## Concrete Classes to Interfaces
 ### Faction
+
 - IOwner
 ### Landscape
+
 - IPlaced
 ### Npc
+
 - IOwner
 ### PlacedCreature
+
 - IPlaced
 ### PlacedNpc
+
 - IPlaced
 ### PlacedObject
+
 - IPlaced

--- a/docs/game-specific/skyrim/Skyrim-Aspect-Interfaces.md
+++ b/docs/game-specific/skyrim/Skyrim-Aspect-Interfaces.md
@@ -5,6 +5,7 @@ Aspect Interfaces expose common aspects of records.  For example, `INamed` are i
 Functions can then be written that take in `INamed`, allowing any record that has a name to be passed in.
 ## Interfaces to Concrete Classes
 ### IHasIcons
+
 - AlchemicalApparatus
 - Ammunition
 - ArmorModel
@@ -20,6 +21,7 @@ Functions can then be written that take in `INamed`, allowing any record that ha
 - SoulGem
 - Weapon
 ### IKeyworded
+
 - Activator
 - Ammunition
 - Armor
@@ -41,6 +43,7 @@ Functions can then be written that take in `INamed`, allowing any record that ha
 - TalkingActivator
 - Weapon
 ### IModeled
+
 - Activator
 - AddonNode
 - AlchemicalApparatus
@@ -81,6 +84,7 @@ Functions can then be written that take in `INamed`, allowing any record that ha
 - Tree
 - Weapon
 ### INamed
+
 - Activator
 - ActorValueInformation
 - AlchemicalApparatus
@@ -158,6 +162,7 @@ Functions can then be written that take in `INamed`, allowing any record that ha
 - WordOfPower
 - Worldspace
 ### IObjectBounded
+
 - AcousticSpace
 - Activator
 - AddonNode
@@ -197,6 +202,7 @@ Functions can then be written that take in `INamed`, allowing any record that ha
 - Tree
 - Weapon
 ### IWeightValue
+
 - AlchemicalApparatus
 - Ammunition
 - Armor
@@ -210,29 +216,37 @@ Functions can then be written that take in `INamed`, allowing any record that ha
 - SoulGem
 - WeaponBasicStats
 ### Keyword
+
 - Keyword
 ## Concrete Classes to Interfaces
 ### AcousticSpace
+
 - IObjectBounded
 ### Activator
+
 - IKeyworded
 - IModeled
 - INamed
 - IObjectBounded
 ### ActorValueInformation
+
 - INamed
 ### AddonNode
+
 - IModeled
 - IObjectBounded
 ### AlchemicalApparatus
+
 - IHasIcons
 - IModeled
 - INamed
 - IObjectBounded
 - IWeightValue
 ### AlternateTexture
+
 - INamed
 ### Ammunition
+
 - IHasIcons
 - IKeyworded
 - IModeled
@@ -240,27 +254,36 @@ Functions can then be written that take in `INamed`, allowing any record that ha
 - IObjectBounded
 - IWeightValue
 ### AnimatedObject
+
 - IModeled
 ### APackageData
+
 - INamed
 ### Armor
+
 - IKeyworded
 - INamed
 - IObjectBounded
 - IWeightValue
 ### ArmorModel
+
 - IHasIcons
 - IModeled
 ### ArtObject
+
 - IModeled
 - IObjectBounded
 ### BodyData
+
 - IModeled
 ### BodyPart
+
 - INamed
 ### BodyPartData
+
 - IModeled
 ### Book
+
 - IHasIcons
 - IKeyworded
 - IModeled
@@ -268,67 +291,90 @@ Functions can then be written that take in `INamed`, allowing any record that ha
 - IObjectBounded
 - IWeightValue
 ### CameraShot
+
 - IModeled
 ### Cell
+
 - INamed
 ### Class
+
 - INamed
 ### Climate
+
 - IModeled
 ### CollisionLayer
+
 - INamed
 ### ColorRecord
+
 - INamed
 ### Container
+
 - IModeled
 - INamed
 - IObjectBounded
 ### DestructionStage
+
 - IModeled
 ### DialogTopic
+
 - INamed
 ### Door
+
 - IModeled
 - INamed
 - IObjectBounded
 ### DualCastData
+
 - IObjectBounded
 ### Explosion
+
 - IModeled
 - INamed
 - IObjectBounded
 ### Eyes
+
 - INamed
 ### Faction
+
 - INamed
 ### Flora
+
 - IKeyworded
 - IModeled
 - INamed
 - IObjectBounded
 ### Furniture
+
 - IKeyworded
 - IModeled
 - INamed
 - IObjectBounded
 ### Grass
+
 - IModeled
 - IObjectBounded
 ### Hazard
+
 - IModeled
 - INamed
 - IObjectBounded
 ### HeadData
+
 - IModeled
 ### HeadPart
+
 - IModeled
 - INamed
 ### IdleMarker
+
 - IModeled
 - IObjectBounded
 ### Impact
+
 - IModeled
 ### Ingestible
+
 - IHasIcons
 - IKeyworded
 - IModeled
@@ -336,6 +382,7 @@ Functions can then be written that take in `INamed`, allowing any record that ha
 - IObjectBounded
 - IWeightValue
 ### Ingredient
+
 - IHasIcons
 - IKeyworded
 - IModeled
@@ -343,6 +390,7 @@ Functions can then be written that take in `INamed`, allowing any record that ha
 - IObjectBounded
 - IWeightValue
 ### Key
+
 - IHasIcons
 - IKeyworded
 - IModeled
@@ -350,37 +398,50 @@ Functions can then be written that take in `INamed`, allowing any record that ha
 - IObjectBounded
 - IWeightValue
 ### Keyword
+
 - Keyword
 ### LeveledItem
+
 - IObjectBounded
 ### LeveledNpc
+
 - IModeled
 - IObjectBounded
 ### LeveledSpell
+
 - IObjectBounded
 ### Light
+
 - IHasIcons
 - IModeled
 - INamed
 - IObjectBounded
 - IWeightValue
 ### LoadScreen
+
 - IHasIcons
 ### Location
+
 - IKeyworded
 - INamed
 ### MagicEffect
+
 - IKeyworded
 - INamed
 ### MapMarker
+
 - INamed
 ### MaterialObject
+
 - IModeled
 ### MaterialType
+
 - INamed
 ### Message
+
 - INamed
 ### MiscItem
+
 - IHasIcons
 - IKeyworded
 - IModeled
@@ -388,90 +449,126 @@ Functions can then be written that take in `INamed`, allowing any record that ha
 - IObjectBounded
 - IWeightValue
 ### MoveableStatic
+
 - IModeled
 - INamed
 - IObjectBounded
 ### MovementType
+
 - INamed
 ### Npc
+
 - IKeyworded
 - INamed
 - IObjectBounded
 ### ObjectEffect
+
 - INamed
 - IObjectBounded
 ### PackageDataBool
+
 - INamed
 ### PackageDataFloat
+
 - INamed
 ### PackageDataInt
+
 - INamed
 ### PackageDataLocation
+
 - INamed
 ### PackageDataObjectList
+
 - INamed
 ### PackageDataTarget
+
 - INamed
 ### PackageDataTopic
+
 - INamed
 ### Perk
+
 - IHasIcons
 - INamed
 ### Phoneme
+
 - INamed
 ### Projectile
+
 - IModeled
 - INamed
 - IObjectBounded
 ### Quest
+
 - INamed
 ### QuestAlias
+
 - IKeyworded
 - INamed
 ### Race
+
 - IKeyworded
 - INamed
 ### RegionData
+
 - IHasIcons
 ### RegionMap
+
 - INamed
 ### SceneAction
+
 - INamed
 ### ScenePhase
+
 - INamed
 ### ScriptBoolListProperty
+
 - INamed
 ### ScriptBoolProperty
+
 - INamed
 ### ScriptEntry
+
 - INamed
 ### ScriptFloatListProperty
+
 - INamed
 ### ScriptFloatProperty
+
 - INamed
 ### ScriptIntListProperty
+
 - INamed
 ### ScriptIntProperty
+
 - INamed
 ### ScriptObjectListProperty
+
 - INamed
 ### ScriptObjectProperty
+
 - INamed
 ### ScriptProperty
+
 - INamed
 ### ScriptStringListProperty
+
 - INamed
 ### ScriptStringProperty
+
 - INamed
 ### Scroll
+
 - IKeyworded
 - IModeled
 - INamed
 - IObjectBounded
 - IWeightValue
 ### Shout
+
 - INamed
 ### SoulGem
+
 - IHasIcons
 - IKeyworded
 - IModeled
@@ -479,38 +576,50 @@ Functions can then be written that take in `INamed`, allowing any record that ha
 - IObjectBounded
 - IWeightValue
 ### SoundCategory
+
 - INamed
 ### SoundMarker
+
 - IObjectBounded
 ### Spell
+
 - IKeyworded
 - INamed
 - IObjectBounded
 ### Static
+
 - IModeled
 - IObjectBounded
 ### TalkingActivator
+
 - IKeyworded
 - IModeled
 - INamed
 - IObjectBounded
 ### TextureSet
+
 - IObjectBounded
 ### Tree
+
 - IModeled
 - INamed
 - IObjectBounded
 ### Water
+
 - INamed
 ### Weapon
+
 - IHasIcons
 - IKeyworded
 - IModeled
 - INamed
 - IObjectBounded
 ### WeaponBasicStats
+
 - IWeightValue
 ### WordOfPower
+
 - INamed
 ### Worldspace
+
 - INamed

--- a/docs/game-specific/skyrim/Skyrim-Link-Interfaces.md
+++ b/docs/game-specific/skyrim/Skyrim-Link-Interfaces.md
@@ -7,12 +7,15 @@ An interface would be defined such as 'IItem', which all Armor, Weapon, Ingredie
 A `FormLink<IItem>` could then point to all those record types by pointing to the interface instead.
 ## Interfaces to Concrete Classes
 ### IAliasVoiceType
+
 - FormList
 - Npc
 ### IComplexLocation
+
 - Cell
 - Worldspace
 ### IConstructible
+
 - AlchemicalApparatus
 - Ammunition
 - Armor
@@ -26,23 +29,29 @@ A `FormLink<IItem>` could then point to all those record types by pointing to th
 - SoulGem
 - Weapon
 ### IDialog
+
 - DialogResponses
 - DialogTopic
 ### IEffectRecord
+
 - ObjectEffect
 - Spell
 ### IEmittance
+
 - Light
 - Region
 ### IHarvestTarget
+
 - Ingestible
 - Ingredient
 - LeveledItem
 - MiscItem
 ### IIdleRelation
+
 - ActionRecord
 - IdleAnimation
 ### IItem
+
 - AlchemicalApparatus
 - Ammunition
 - Armor
@@ -57,28 +66,35 @@ A `FormLink<IItem>` could then point to all those record types by pointing to th
 - SoulGem
 - Weapon
 ### IKeywordLinkedReference
+
 - APlacedTrap
 - Keyword
 - PlacedNpc
 - PlacedObject
 ### ILinkedReference
+
 - APlacedTrap
 - PlacedNpc
 - PlacedObject
 ### ILocationRecord
+
 - Location
 - LocationReferenceType
 ### ILocationTargetable
+
 - Door
 - PlacedNpc
 - PlacedObject
 ### ILockList
+
 - FormList
 - Npc
 ### INpcSpawn
+
 - LeveledNpc
 - Npc
 ### IObjectId
+
 - Activator
 - Ammunition
 - Armor
@@ -104,147 +120,193 @@ A `FormLink<IItem>` could then point to all those record types by pointing to th
 - TextureSet
 - Weapon
 ### IOutfitTarget
+
 - Armor
 - LeveledItem
 ### IOwner
+
 - Faction
 - PlacedNpc
 ### IPlaced
+
 - APlaced
 - APlacedTrap
 - PlacedNpc
 - PlacedObject
 ### IPlacedSimple
+
 - PlacedNpc
 - PlacedObject
 ### IPlacedThing
+
 - APlacedTrap
 - PlacedObject
 ### IPlacedTrapTarget
+
 - Hazard
 - Projectile
 ### IRegionTarget
+
 - Flora
 - LandscapeTexture
 - MoveableStatic
 - Static
 - Tree
 ### IRelatable
+
 - Faction
 - Race
 ### ISound
+
 - SoundDescriptor
 - SoundMarker
 ### ISpellSpawn
+
 - LeveledSpell
 - Spell
 ## Concrete Classes to Interfaces
 ### ActionRecord
+
 - IIdleRelation
 ### Activator
+
 - IObjectId
 ### AlchemicalApparatus
+
 - IConstructible
 - IItem
 ### Ammunition
+
 - IConstructible
 - IItem
 - IObjectId
 ### APlaced
+
 - IPlaced
 ### APlacedTrap
+
 - IKeywordLinkedReference
 - ILinkedReference
 - IPlaced
 - IPlacedThing
 ### Armor
+
 - IConstructible
 - IItem
 - IObjectId
 - IOutfitTarget
 ### Book
+
 - IConstructible
 - IItem
 - IObjectId
 ### Cell
+
 - IComplexLocation
 ### Container
+
 - IObjectId
 ### DialogResponses
+
 - IDialog
 ### DialogTopic
+
 - IDialog
 ### Door
+
 - ILocationTargetable
 - IObjectId
 ### Faction
+
 - IObjectId
 - IOwner
 - IRelatable
 ### Flora
+
 - IRegionTarget
 ### FormList
+
 - IAliasVoiceType
 - ILockList
 - IObjectId
 ### Furniture
+
 - IObjectId
 ### Hazard
+
 - IPlacedTrapTarget
 ### IdleAnimation
+
 - IIdleRelation
 ### IdleMarker
+
 - IObjectId
 ### Ingestible
+
 - IConstructible
 - IHarvestTarget
 - IItem
 - IObjectId
 ### Ingredient
+
 - IConstructible
 - IHarvestTarget
 - IItem
 ### Key
+
 - IConstructible
 - IItem
 - IObjectId
 ### Keyword
+
 - IKeywordLinkedReference
 ### LandscapeTexture
+
 - IRegionTarget
 ### LeveledItem
+
 - IHarvestTarget
 - IItem
 - IOutfitTarget
 ### LeveledNpc
+
 - INpcSpawn
 ### LeveledSpell
+
 - ISpellSpawn
 ### Light
+
 - IConstructible
 - IEmittance
 - IItem
 - IObjectId
 ### Location
+
 - ILocationRecord
 ### LocationReferenceType
+
 - ILocationRecord
 ### MiscItem
+
 - IConstructible
 - IHarvestTarget
 - IItem
 - IObjectId
 ### MoveableStatic
+
 - IObjectId
 - IRegionTarget
 ### Npc
+
 - IAliasVoiceType
 - ILockList
 - INpcSpawn
 - IObjectId
 ### ObjectEffect
+
 - IEffectRecord
 ### PlacedNpc
+
 - IKeywordLinkedReference
 - ILinkedReference
 - ILocationTargetable
@@ -252,6 +314,7 @@ A `FormLink<IItem>` could then point to all those record types by pointing to th
 - IPlaced
 - IPlacedSimple
 ### PlacedObject
+
 - IKeywordLinkedReference
 - ILinkedReference
 - ILocationTargetable
@@ -259,40 +322,54 @@ A `FormLink<IItem>` could then point to all those record types by pointing to th
 - IPlacedSimple
 - IPlacedThing
 ### Projectile
+
 - IObjectId
 - IPlacedTrapTarget
 ### Race
+
 - IRelatable
 ### Region
+
 - IEmittance
 ### Scroll
+
 - IConstructible
 - IItem
 - IObjectId
 ### Shout
+
 - IObjectId
 ### SoulGem
+
 - IConstructible
 - IItem
 ### SoundDescriptor
+
 - ISound
 ### SoundMarker
+
 - IObjectId
 - ISound
 ### Spell
+
 - IEffectRecord
 - IObjectId
 - ISpellSpawn
 ### Static
+
 - IObjectId
 - IRegionTarget
 ### TextureSet
+
 - IObjectId
 ### Tree
+
 - IRegionTarget
 ### Weapon
+
 - IConstructible
 - IItem
 - IObjectId
 ### Worldspace
+
 - IComplexLocation

--- a/docs/game-specific/skyrim/Skyrim-Perks.md
+++ b/docs/game-specific/skyrim/Skyrim-Perks.md
@@ -1,12 +1,14 @@
 # Skyrim Perks
 ## Perk Effect Types
 The abstract base class is `APerkEffect` which is inherited by:
+
 - `PerkQuestEffect`
 - `PerkAbilityEffect`
 - `APerkEntryPointEffect`
 
 ## Perk Entry Point Effect Types
 The abstract base class is `APerkEntryPointEffect` which is inherited by:
+
 - `PerkModifyValue`
 - `PerkAddRangeToValue`
 - `PerkModifyActorValue`

--- a/docs/linkcache/ModContexts.md
+++ b/docs/linkcache/ModContexts.md
@@ -2,6 +2,7 @@
 Mod Contexts are an opt-in advanced feature of most LinkCache functionality.  They act as storage for contextual information and the wiring and logic needed to perform certain actions in a context aware manner.
 
 `ModContext`s contain:
+
 - `Record` - The record itself
 - `ModKey` - The `ModKey` that the associated record came from.  Not where it was originally defined and declared, but rather what mod contained the version of the record as it is. (usually the winning override mod)
 - `Parent` - If dealing with a "nested" record like `PlacedObject`, this will contain a reference to the parent record (like a `Cell`).

--- a/docs/linkcache/Record-Lookup.md
+++ b/docs/linkcache/Record-Lookup.md
@@ -1,6 +1,7 @@
 # Record Lookup
 ## TryResolve
 `TryResolve` is the typical call for looking up records pointed to by a FormKey.  Similar to how Control-Clicking a FormID in xEdit will bring you to the record a FormID points to.  It takes a LinkCache as a parameter to the call, which will inspect the content it is attached to (whether it's a load order or a single mod) and try to locate the record that matches:
+
 - The FormKey (FormID)
 - The type specified
 
@@ -32,6 +33,7 @@ if (myLinkCache.TryResolve(myFormKey, out var record))
 ```
 
 But the code above has two problems:
+
 - It will only be able to return `IMajorRecordGetter` or some other very umbrella type
 - It will complain that an unoptimized call is used
 

--- a/docs/linkcache/index.md
+++ b/docs/linkcache/index.md
@@ -1,11 +1,13 @@
 # Link Cache
 The LinkCache is the record lookup engine.  It powers a lot of functionality, such as:
+
 - Looking up records by [FormKey/FormLink](../plugins/ModKey,-FormKey,-FormLink.md#resolves)
 - Finding the [Winning Override](Winning-Overrides) in a [Load Order](../loadorder/index.md)
 - [Iterating over all versions of a record](Previous-Override-Iteration) within a [Load Order](../loadorder/index.md)
 
 ## Context
 Every LinkCache is created from a context:
+
 - A single mod
 - A [Load Order](../loadorder/index.md)
 - Any arbitrary enumeration of mods
@@ -38,6 +40,7 @@ If you do not plan to add/remove records from the Mods, it is always recommended
 Sometimes it is desirable to have a mod on a Link Cache that you are allowed to modify.  [Synthesis](https://github.com/Mutagen-Modding/Synthesis), for example, needs to be able to modify the outgoing Patch Mod object.
 
 In these scenarios, we can create a Mutable Link Cache.  This is a combination of an Immutable Link Cache for most of the mods in a load order, PLUS a mutable component for the final mods at the end that we want to modify.  As such there are a few things to consider:
+
 - Most of the load order still gets the speed optimizations of being immutable
 - We only pay the speed price when dealing with the one (few) mutable mods at the end.
 - Because of this structure, the mutable mods MUST be at the end.

--- a/docs/loadorder/index.md
+++ b/docs/loadorder/index.md
@@ -8,11 +8,13 @@ If you want to construct a Load Order object more manually, this will be discuss
 
 ## ModListings
 A `ModListing` consists of:
+
 - A `ModKey`
 - Whether it's marked as enabled
 - Whether "ghosted" and has an extra suffix causes the game to ignore it
 
 A `ModListing` can also be generic, such as `ModListing<ISkyrimModGetter>`.  This will then also contain:
+
 - A nullable Mod object, which is present if the Mod in question exists on disk in the Data Folder
 
 
@@ -21,6 +23,7 @@ A `ModListing` can also be generic, such as `ModListing<ISkyrimModGetter>`.  Thi
 
 ### Priority vs Listed Ordering
 While `LoadOrder` is a "list" of `ModListing` object, two properties are exposed for when you want to enumerate to help clarify behavior:
+
 - **ListedOrder** - Enumerates items in the order they were listed
 - **PriorityOrder** - Enumerates the items so that highest priority comes first (reverse)
 
@@ -100,11 +103,13 @@ LoadOrder.Write(
 
 ## PluginListings and CreationClubListings
 The above API abstracts away the complications that a Load Order is driven from a few sources:
+
 - Implicit Listings (Mods that don't need to be listed, but are assumed)
 - Normal Plugins File (Plugins.txt)
 - Installed Creation Club Mods ([GameName].ccc)
 
 Logic related to each concept lives in its own class:
+
 - Implicits.Listings
 - PluginListings
 - CreationClubListings

--- a/docs/lowlevel/Binary-Streams.md
+++ b/docs/lowlevel/Binary-Streams.md
@@ -4,5 +4,6 @@
 
 ## MutagenBinaryReadStream
 This is just a further extension on BinaryReadStream, offering additionally:
+
 - A [Header Struct](Header-Structs.md) object for reference when alignment is important
 - An offset member, to help calculate position relative to a source file, if the MutagenBinaryReadStream happens to be a substream on only a slice of data.

--- a/docs/lowlevel/Binary-Utility.md
+++ b/docs/lowlevel/Binary-Utility.md
@@ -110,6 +110,7 @@ if (finds.TryGetValue(full, out loc))
 
 
 It takes a few optional arguments:
+
 - RecordInterest, to limit the search to specific `RecordType`s
 - Additional Criteria lambda, to add custom filter logic
 

--- a/docs/lowlevel/Game-Constants.md
+++ b/docs/lowlevel/Game-Constants.md
@@ -2,6 +2,7 @@
 As Bethesda games are released, headers are modified slightly.  They still have a lot in common, but certain things move or the total length changes, or something else that will misalign any common parsing code.
 
 `GameConstants` is a class containing all the various alignment information specific to a game.  Things like:
+
 - ModHeaderLength
 - HeaderIncludedInLength
 - LengthLength (amount of bytes the 'length' section is)

--- a/docs/lowlevel/Header-Structs.md
+++ b/docs/lowlevel/Header-Structs.md
@@ -5,6 +5,7 @@ Header Structs are lightweight overlays that "lay" on top of some bytes and offe
 Using Header Structs, very performant and low level parsing is possible while retaining a large degree of safety and usability.  
 
 Some notable features:
+
 - **Alignment is handled internally**.  User can access the fields they are interested in, without needing to worry about proper offsetting.
 - **No parsing is done except what the user asks for**.  If only one field is accessed, then most of the header data will remain unparsed, and that work skipped.
 - **Code written with this setup can work with any Bethesda game**, as swapping out [Game Constants](Game-Constants.md) will realign everything properly.
@@ -52,6 +53,7 @@ This code will only do the minimal parsing necessary to locate/print the EditorI
 Header Structs come in a few combinations and flavors.  The above code makes use of several of them.
 ### Categories
 There are Header Structs for:
+
 - Groups
 - MajorRecords
 - Subrecords
@@ -66,6 +68,7 @@ Each category also comes in a few flavors.
 This is the most basic version that has been discussed in the descriptions above.  It overlays on top of bytes and offers API to access the various aspects of the header.
 
 Typical accessors include:
+
 - `RecordType` that the header is (EDID, NPC_, etc)
 - `HeaderLength`
 - `ContentLength`

--- a/docs/plugins/Abstract-Subclassing.md
+++ b/docs/plugins/Abstract-Subclassing.md
@@ -28,6 +28,7 @@ The subclassing helps encapsulate some complexity while remaining consistent and
 Consider that `NPC_`'s `Level` field is an integer normally.  But if you turn on the `PC Level Mult` flag, it suddenly acts as a float.   So how can Mutagen expose this in a type safe manner if the field can just change its type depending on a switch somewhere else?
 
 Mutagen exposes this by using subclassing.  `ANpcLevel` has two subclasses:
+
 - `NpcLevel`, with `Level` as an integer
 - `PcLevelMult`, with `Level` as a float
 
@@ -98,6 +99,7 @@ An effect can reference many different types of records, where some effect types
 Each subclassing situation is different and is trying to solve a different complexity specific to that record.  As things mature, documentation outlining each specific structure will probably be written.
 
 In the meantime, you can:
+
 - Utilize Intellisense, and follow references in the IDE to see the classes and what they contain.
 - Of importance:  The interfaces of these abstract classes contain comments of what options are available:
 ```cs
@@ -110,4 +112,5 @@ public partial interface IANpcLevel
 }
 ```
 This helps narrow down which types it can be so you know what to switch on and handle.
+
 - Also, you can sometimes refer to the xmls that define the records, like the ones linked above.

--- a/docs/plugins/AssetLink.md
+++ b/docs/plugins/AssetLink.md
@@ -27,6 +27,7 @@ In all examples, the `DataRelativePath` remains the same, as that is what it's a
 
 ## AssetTypes - AssetLink's Generic Type
 An `AssetLink`'s generic type is the type of asset it relates to.  So, for example, a Skyrim Model path will be of type `AssetLink<SkyrimModelAssetType>`, where `SkyrimModelAssetType` is a meta class containing information about Skyrim Model assets:
+
 - `BaseFolder`, what subfolder underneath /Data/ these assests are expected to live
 - `FileExtensions`, what expected file extensions these types of meta files will have
 
@@ -54,11 +55,14 @@ foreach (var asset in assetContainer.EnumerateAllAssetLinks(assetLinkCache))
 
 ## AssetLinkQuery
 This is a flag enum with three options, letting you control what type of Assets you want to enumerate:
+
 - `Listed`.  Assets explicitly listed in the records:
   - Skyrim Model Path
+
 - `Inferred`.  Assets that can be inferred by fields that exist on the record
   - Armor Addon World Model `_0` `_1` suffix assets
   - Book text `src` links pointing to textures
+
 - `Resolved`.  Assets that can be inferred by looking at other records, and require FormLink lookups on a Link Cache.
   - Dialog Topic's Voice Type paths 
 

--- a/docs/plugins/Binary-Exporting.md
+++ b/docs/plugins/Binary-Exporting.md
@@ -19,6 +19,7 @@ This extra information helps keep the masters in proper order, as the load order
 
 ### Master Content
 Mutagen automatically handles the logic to determine which masters are required.  It will iterate all records for:
+
 - Overridden 
 
 ### Master Ordering

--- a/docs/plugins/Binary-Format-Complexity-Abstraction.md
+++ b/docs/plugins/Binary-Format-Complexity-Abstraction.md
@@ -18,10 +18,13 @@ Additionally, some common Record Types have alternate versions to denote differe
 ## List Mechanics
 ## Item Storage
 There are a lot of varying ways that lists are stored in the binary format:
+
 - Repeated subrecords, with their Record Header as the delimiter.  Unknown amount.
   _(SPLO records in Oblivion)_
+
 - Extra prepended subrecord /w the count of items in the list.  This can then be followed by repeated subrecords with Record Headers, or headerless raw data of known lengths.
   _(Keyword lists in Skyrim)_
+
 - A Record Header for the list itself, followed immediately by a uint count, followed by undelimited content of known length. _(Skyrim Model's Alternate Textures)_
 - Probably others
 

--- a/docs/plugins/Binary-Overlay.md
+++ b/docs/plugins/Binary-Overlay.md
@@ -48,6 +48,7 @@ using (IOblivionModGetter mod = OblivionMod.CreateFromBinaryOverlay(pathToMod))
 This code is intended to print each Potion's Editor ID to the console.
 
 ### What work is actually done by this code?
+
 - A file is opened
 - An overlay class that implements `IOblivionModGetter` and has a reference to the file stream is instantiated.
 - Quick skip-over parsing of the file is done to locate the locations of the Groups.
@@ -63,6 +64,7 @@ This code is intended to print each Potion's Editor ID to the console.
 - After loop is over, the stream is closed.
 
 ### What are some things that were not done?
+
 - No Groups besides Potion were parsed. Their top level locations were noted, but no contents were processed.
 - No subrecords were parsed, except EditorID (EDID).
 - No object had a reference to all the Potion records, so as to keep their contents in memory.  The Group object simply has a list of locations.  The user has the only reference to any Potion record at any given moment, and as soon as they were done with it was cleaned up.
@@ -72,11 +74,13 @@ This code is intended to print each Potion's Editor ID to the console.
 The Binary Overlay concept is a powerful tool that can be used for vast speed/memory improvements for certain jobs.  It is suggested for use in most importing scenarios.  Actual normal record objects should generally be reserved for use when constructing new/modified records for output.
 
 ### Pros
+
 - Much faster as there is no parsing of fields that are not used.
 - No need to specify ahead of time which records will be used.
 - Much lower memory footprint as records only exist as the user is interacting with them.
 
 ### Cons:
+
 - The source stream must remain open for the lifetime of the overlay.
 - Any access of the mod or group objects can only be done if the stream is open.
 - Overlays are readonly, so copies to new objects must be made if user wishes to modify contents.

--- a/docs/plugins/Copy-Functionality.md
+++ b/docs/plugins/Copy-Functionality.md
@@ -12,6 +12,7 @@ Potion potionCopy = (Potion)potionSource.DeepCopy();
 ```
 
 Some things to note:
+
 - FormKey will match the original source
 - Changes to either object will not affect the other
 - The new record will not be a part of any Mod or Group unless added explicity.
@@ -27,6 +28,7 @@ potionCopy.DeepCopyIn(potionSource);
 ```
 
 Some things to note:
+
 - `FormKey`s are immutable, and will never be changed even with a copy in.  If you want a second record with the original's `FormKey`, use DeepCopy instead.
 - Changes to either object will not affect the other
 

--- a/docs/plugins/FormKey-Allocation-and-Persistence.md
+++ b/docs/plugins/FormKey-Allocation-and-Persistence.md
@@ -2,6 +2,7 @@
 It is common that tooling that is generating new records when creating plugins wants to keep their FormKeys consistent across several runs.  The same records should get the same FormKeys.
 
 There are some challenges with fulfilling this:
+
 - How is a record detected to be the "same" as one from a previous run?
 - Where/How do you persist the mapping information between runs?
 

--- a/docs/plugins/Interfaces-(Aspect-Link-Getters).md
+++ b/docs/plugins/Interfaces-(Aspect-Link-Getters).md
@@ -1,5 +1,6 @@
 # Interfaces
 Mutagen exposes a few categories of interfaces:
+
 - **[Getters and Setters](#getters-and-setters)** _(Immutable vs Mutable)_
 - **[Aspect](#aspect-interfaces)** _(Expose aspects common to many records)_
 - **[Link](#link-interfaces)** _(Enables FormLinks to point to an umbrella of record types)_

--- a/docs/plugins/ModKey,-FormKey,-FormLink.md
+++ b/docs/plugins/ModKey,-FormKey,-FormLink.md
@@ -1,4 +1,5 @@
 This article covers three fundamental identifiers:
+
 - **[ModKey](#modkey)** _(a unique identifier for a mod)_
 - **[FormKey](#formkey)** _(FormID)_
 - **[FormLink](#formlink)** _(Typing added to a FormKey)_
@@ -7,6 +8,7 @@ This article covers three fundamental identifiers:
 `ModKey`s represent a unique identifier for a mod, as an alternative to a raw string.
 
 They contain:
+
 - `string` of a mod's name (without '.esp' or '.esm')
 - An `enum` of whether it is a master, plugin, or light master
 
@@ -36,6 +38,7 @@ modKey = ModKey.FromFileName("Skyrim.esm");
 A `FormKey` represents a unique identifier for a record. They are Mutagen's interpretation of a `FormID`.
 
 They contain:
+
 - A record's `uint` ID (without master indices)
 - A `ModKey`
 
@@ -73,6 +76,7 @@ formKey = FormKey.Factory("123456:Skyrim.esm");
 A `FormLink` adds type safety to the concept of a `FormKey`
 
 They contain:
+
 - A `FormKey`
 - A Major Record type `<T>`
 

--- a/docs/plugins/Translation-Masks.md
+++ b/docs/plugins/Translation-Masks.md
@@ -97,6 +97,7 @@ rec.DeepCopy(new Npc.TranslationMask(true)
 This is an easy way to specify that you want all fields copied except the name.  Destructible's submask object will be left null, but in this case, that means we want to copy it.  (we shouldn't have to define Destructible's subobject in order to bring it over)
 
 Okay, but what about the case when we want to omit Destructible, then?  There's some confusion when you try to do this with nullable subobjects.  Does a false mean:
+
 - Destructible should not be considered at all during equality
 - All fields on the destructible mask should be false.
 Those are two slightly different things.

--- a/docs/wpf/FormKey-Picker.md
+++ b/docs/wpf/FormKey-Picker.md
@@ -1,5 +1,6 @@
 # FormKey Picker
 The FormKey Picker helps users select record(s) by typing in:
+
 - EditorIDs
 - FormKeys
 - FormIDs (Mod indices relative to current load order)

--- a/docs/wpf/ModKey-Picker.md
+++ b/docs/wpf/ModKey-Picker.md
@@ -2,6 +2,7 @@
 The ModKey Picker helps users select mod(s) by typing in their names.
 
 The picker can reference certain objects to know what mods actually exist on a user's active load order:
+
 - A [Load Order](../loadorder/index.md) object
 - Any enumerable of type `ModKey` or `IModListingGetter`
 - An `IObservable<IChangeSet<T>>` of type `ModKey` or `IModListingGetter`. (Reactive Extension concepts)

--- a/docs/wpf/Reflection-Powered-Settings.md
+++ b/docs/wpf/Reflection-Powered-Settings.md
@@ -20,6 +20,7 @@ We can supply that definition to this control, and get a UI immediately:
 ![Reflection Powered Settings](https://i.imgur.com/PdXSnk5.gif)
 
 As such, it is an easy way to get a decent UI for any class, and is very helpful if:
+
 - You aren't used to WPF and just want to get something up and running
 - If you don't know ahead of time what fields will exist (Synthesis patchers being a prime example)
 
@@ -129,6 +130,7 @@ public IFormLinkGetter ArmorsAndWeapons { get; set; } = FormLinkInformation.Null
 ```
 
 # Allowed Field Types
+
 - `bool`
 - `string`
 - Integers (signed and unsigned)

--- a/docs/wpf/index.md
+++ b/docs/wpf/index.md
@@ -1,5 +1,6 @@
 # WPF Library
 If you are making a C# WPF UI application with Mutagen, you can import `Mutagen.Bethesda.WPF` to get some tooling related to Bethesda specific content.
+
 - Controls for Bethesda specific concepts, such as FormKeyPickers, LoadOrder displays, etc
 - Reflection powered settings editor
 - ValueConverters for binding things like Visibility to whether a FormKey can be looked up


### PR DESCRIPTION
I'm very excited to have found this library! After spending some time reading the documentation, I have found that lists in the Mutagen documentations aren't rendered properly in GitHub Pages, for example in [index.md](https://mutagen-modding.github.io/Mutagen/):

![image](https://github.com/Mutagen-Modding/Mutagen/assets/30065933/0d6c256a-9ec4-4a39-8412-2174954bfe0f)

This PR has a very simple fix to add a preceding empty line before all markdown lists in the docs/ folder to ensure they are rendered as lists.

Accomplished with a simple regex replace:

```plaintext
'^([^-].*)\r\n-', '$1

-'
```