### PR TITLE
Fix mismatching strings entry length

### DIFF
--- a/Mutagen.Bethesda.Core/Strings/StringsWriter.cs
+++ b/Mutagen.Bethesda.Core/Strings/StringsWriter.cs
@@ -165,7 +165,7 @@ public sealed class StringsWriter : IDisposable
                         break;
                     case StringsSource.IL:
                     case StringsSource.DL:
-                        writer.Write(item.String.Length + 1);
+                        writer.Write(encoding.GetByteCount(item.String) + 1);
                         writer.Write(item.String, StringBinaryType.NullTerminate, encoding);
                         break;
                     default:


### PR DESCRIPTION
Fix mismatching length for encodings where the byte count and string length are different.

I tested this for the Dragonborn book DLC2Book2CommonRavenRock01. Using non-latin languages like Japanese or Russian had their book text cut off roughly in the middle because it was using the string length, not the byte length of the encoding that is used.