### PR TITLE
Migrate from DotNetZip to `System.IO.Compression`.

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,7 +8,6 @@
     <PackageVersion Include="BenchmarkDotNet">
       <Version>0.13.12</Version>
     </PackageVersion>
-    <PackageVersion Include="DotNetZip" Version="1.16.0" />
     <PackageVersion Include="Extended.Wpf.Toolkit" Version="4.6.1" />
     <PackageVersion Include="CommandLineParser" Version="2.9.1" />
     <PackageVersion Include="FluentAssertions">
@@ -55,6 +54,7 @@
       <Version>2.3.57</Version>
     </PackageVersion>
     <PackageVersion Include="System.Collections.Immutable" Version="8.0.0" />
+    <PackageVersion Include="System.IO.Compression" Version="4.3.0" />
     <PackageVersion Include="System.Linq.Async" Version="6.0.1" />
     <PackageVersion Include="System.Text.Encoding.CodePages" Version="8.0.0" />
     <PackageVersion Include="xunit" Version="2.9.0" />

--- a/Mutagen.Bethesda.Core/Mutagen.Bethesda.Core.csproj
+++ b/Mutagen.Bethesda.Core/Mutagen.Bethesda.Core.csproj
@@ -19,13 +19,13 @@
     <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="DotNetZip" />
         <PackageReference Include="ini-parser-netstandard" />
         <PackageReference Include="K4os.Compression.LZ4.Streams" />
         <PackageReference Include="Loqui" />
         <PackageReference Include="Noggog.CSharpExt" />
         <PackageReference Include="SharpZipLib" />
         <PackageReference Include="System.Collections.Immutable" />
+        <PackageReference Include="System.IO.Compression" />
         <PackageReference Include="System.Text.Encoding.CodePages" />
         <PackageReference Include="GameFinder.StoreHandlers.GOG" />
         <PackageReference Include="GameFinder.StoreHandlers.Steam" />

--- a/Mutagen.Bethesda.Core/Plugins/Binary/Overlay/AListGroupOverlay.cs
+++ b/Mutagen.Bethesda.Core/Plugins/Binary/Overlay/AListGroupOverlay.cs
@@ -1,10 +1,10 @@
-using Ionic.Zlib;
 using Mutagen.Bethesda.Plugins.Binary.Headers;
 using Mutagen.Bethesda.Plugins.Binary.Translations;
 using Mutagen.Bethesda.Plugins.Internals;
 using Noggog;
 using System.Buffers.Binary;
 using System.Collections;
+using System.IO.Compression;
 using Loqui;
 using Mutagen.Bethesda.Plugins.Meta;
 using Mutagen.Bethesda.Plugins.Records;
@@ -47,9 +47,9 @@ internal sealed class GroupListOverlay<T> : IReadOnlyList<T>
             // Remove compression flag
             BinaryPrimitives.WriteInt32LittleEndian(buf.AsSpan().Slice(_package.MetaData.Constants.MajorConstants.FlagLocationOffset), majorMeta.MajorRecordFlags & ~Constants.CompressedFlag);
             // Copy uncompressed data over
-            using (var stream = new ZlibStream(new ByteMemorySliceStream(slice.Slice(majorMeta.HeaderLength + 4)), CompressionMode.Decompress))
+            using (var stream = new ZLibStream(new ByteMemorySliceStream(slice.Slice(majorMeta.HeaderLength + 4)), CompressionMode.Decompress))
             {
-                stream.Read(buf, majorMeta.HeaderLength, checked((int)uncompressedLength));
+                stream.ReadExactly(buf, majorMeta.HeaderLength, checked((int)uncompressedLength));
             }
             slice = new MemorySlice<byte>(buf);
         }

--- a/Mutagen.Bethesda/Mutagen.Bethesda.csproj
+++ b/Mutagen.Bethesda/Mutagen.Bethesda.csproj
@@ -14,7 +14,6 @@
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="DotNetZip" />
     <PackageReference Include="Loqui" />
     <PackageReference Include="Noggog.CSharpExt" />
   </ItemGroup>


### PR DESCRIPTION
DotNetZip is deprecated and its chain of transitive dependencies leads to a version of `System.Drawing.Common` with a known security vulnerability.

`System.IO.Compression` has mostly the same APIs except that `Read` methods are not exact; instead, the newer `Stream.ReadExact` method needs to be used to guarantee full decompression.