### PR TITLE
Print line number and offending entry on plugins parse failure

### DIFF
--- a/Mutagen.Bethesda.Core.UnitTests/Plugins/Order/PluginListingsParserTests.cs
+++ b/Mutagen.Bethesda.Core.UnitTests/Plugins/Order/PluginListingsParserTests.cs
@@ -89,6 +89,6 @@ ModB.esp
             .ToList())
             .Should()
             .Throw<InvalidDataException>()
-            .WithMessage("Load order file had malformed line at line 3: \"*Malformed\"");
+            .WithMessage("Load order file had malformed entry at line 3: \"*Malformed\"");
     }
 }

--- a/Mutagen.Bethesda.Core.UnitTests/Plugins/Order/PluginListingsParserTests.cs
+++ b/Mutagen.Bethesda.Core.UnitTests/Plugins/Order/PluginListingsParserTests.cs
@@ -73,4 +73,22 @@ ModB.esp#Hello
             new LoadOrderListing("ModB.esp", false),
             new LoadOrderListing("ModC.esp", true));
     }
+
+    [Fact]
+    public void PrintLinesOnFailure()
+    {
+        var parser = new PluginListingsParser(
+            new PluginListingCommentTrimmer(),
+            new LoadOrderListingParser(
+                new HasEnabledMarkersInjection(true)));
+
+        parser.Invoking(p => p.Parse(GetStream(
+@"*ModA.esm
+ModB.esp
+*Malformed"))
+            .ToList())
+            .Should()
+            .Throw<InvalidDataException>()
+            .WithMessage("Load order file had malformed line at line 3: \"*Malformed\"");
+    }
 }

--- a/Mutagen.Bethesda.Core/Plugins/Order/DI/PluginListingsParser.cs
+++ b/Mutagen.Bethesda.Core/Plugins/Order/DI/PluginListingsParser.cs
@@ -30,13 +30,23 @@ public sealed class PluginListingsParser : IPluginListingsParser
     /// <inheritdoc />
     public IEnumerable<ILoadOrderListingGetter> Parse(Stream stream)
     {
+        uint currentLine = 0;
         using var streamReader = new StreamReader(stream);
         while (!streamReader.EndOfStream)
         {
+            currentLine++;
             var str = streamReader.ReadLine().AsSpan();
             str = _commentTrimmer.Trim(str);
             if (MemoryExtensions.IsWhiteSpace(str) || str.Length == 0) continue;
-            yield return _listingParser.FromString(str);
+
+            if (_listingParser.TryFromString(str, out var listing))
+            {
+                yield return listing;
+            }
+            else
+            {
+                throw new InvalidDataException($"Load order file had malformed line at line {currentLine}: \"{str}\"");
+            }
         }
     }
 }

--- a/Mutagen.Bethesda.Core/Plugins/Order/DI/PluginListingsParser.cs
+++ b/Mutagen.Bethesda.Core/Plugins/Order/DI/PluginListingsParser.cs
@@ -45,7 +45,7 @@ public sealed class PluginListingsParser : IPluginListingsParser
             }
             else
             {
-                throw new InvalidDataException($"Load order file had malformed line at line {currentLine}: \"{str}\"");
+                throw new InvalidDataException($"Load order file had malformed entry at line {currentLine}: \"{str}\"");
             }
         }
     }


### PR DESCRIPTION
## Changes
- Adds new test case for failure plugin parsing to `Mutagen.Bethesda.Core.UnitTests/Plugins/Order/PluginListingsParserTests.cs`
- Updates `PluginListingsParser.Parse` to track the current line number for inclusion in error message

Closes #435 