### PR TITLE
Env asset provider

### DIFF
--- a/Mutagen.Bethesda.Autofac/MutagenModule.cs
+++ b/Mutagen.Bethesda.Autofac/MutagenModule.cs
@@ -54,5 +54,7 @@ public class MutagenModule : Module
             .AsSelf();
         builder.RegisterType<ArchiveAssetProvider>()
             .AsSelf();
+        builder.RegisterType<CachedArchiveListingDetailsProvider>()
+            .AsImplementedInterfaces();
     }
 }

--- a/Mutagen.Bethesda.Autofac/MutagenModule.cs
+++ b/Mutagen.Bethesda.Autofac/MutagenModule.cs
@@ -25,7 +25,6 @@ public class MutagenModule : Module
             .InNamespacesOf(
                 typeof(IArchiveReaderProvider),
                 // typeof(IGetFontConfig),
-                typeof(IAssetProvider),
                 typeof(IDataDirectoryLookup),
                 typeof(IImplicitBaseMasterProvider),
                 typeof(ILoadOrderWriter),
@@ -48,5 +47,12 @@ public class MutagenModule : Module
         builder.RegisterType<GameLocatorLookupCache>()
             .As<IGameDirectoryLookup>()
             .As<IDataDirectoryLookup>();
+        builder.RegisterType<GameAssetProvider>()
+            .As<IAssetProvider>()
+            .AsSelf();
+        builder.RegisterType<DataDirectoryAssetProvider>()
+            .AsSelf();
+        builder.RegisterType<ArchiveAssetProvider>()
+            .AsSelf();
     }
 }

--- a/Mutagen.Bethesda.Core.UnitTests/Archives/GetApplicableArchivePathsTests.cs
+++ b/Mutagen.Bethesda.Core.UnitTests/Archives/GetApplicableArchivePathsTests.cs
@@ -45,16 +45,17 @@ sResourceArchiveList={SomeExplicitListingBsa}, {UnusedExplicitListingBsa}") }
         var ext = new ArchiveExtensionProvider(gameReleaseInjection);
         return new GetApplicableArchivePaths(
             fs, 
-            new GetArchiveIniListings(
-                fs,
-                new IniPathProvider(
-                    gameReleaseInjection,
-                    new IniPathLookupInjection(MyDocumentsPath))),
             new CheckArchiveApplicability(
                 ext),
             new DataDirectoryInjection(BaseFolder),
             ext,
-            new LoadOrderListingsInjection(Array.Empty<ModKey>()));
+            new CachedArchiveListingDetailsProvider(
+                new LoadOrderListingsInjection(Array.Empty<ModKey>()),
+                new GetArchiveIniListings(
+                    fs,
+                    new IniPathProvider(
+                        gameReleaseInjection,
+                        new IniPathLookupInjection(MyDocumentsPath)))));
     }
 
     #region No ModKey

--- a/Mutagen.Bethesda.Core.UnitTests/Archives/GetApplicableArchivePathsTests.cs
+++ b/Mutagen.Bethesda.Core.UnitTests/Archives/GetApplicableArchivePathsTests.cs
@@ -7,6 +7,7 @@ using Mutagen.Bethesda.Inis;
 using Mutagen.Bethesda.Inis.DI;
 using Mutagen.Bethesda.Installs.DI;
 using Mutagen.Bethesda.Plugins;
+using Mutagen.Bethesda.Plugins.Order.DI;
 using Mutagen.Bethesda.Testing;
 using Noggog;
 using Noggog.Testing.IO;
@@ -52,30 +53,14 @@ sResourceArchiveList={SomeExplicitListingBsa}, {UnusedExplicitListingBsa}") }
             new CheckArchiveApplicability(
                 ext),
             new DataDirectoryInjection(BaseFolder),
-            ext);
+            ext,
+            new LoadOrderListingsInjection(Array.Empty<ModKey>()));
     }
 
     #region No ModKey
+    
     [Fact]
-    public void NoModKey_Unordered()
-    {
-        var fs = GetFileSystem();
-        fs.File.WriteAllText(Path.Combine(BaseFolder, MyModBsa), string.Empty);
-        fs.File.WriteAllText(Path.Combine(BaseFolder, SkyrimBsa), string.Empty);
-        fs.File.WriteAllText(Path.Combine(BaseFolder, SomeExplicitListingBsa), string.Empty);
-        var get = GetClass(fs);
-        var applicable = get.Get(Enumerable.Empty<FileName>())
-            .ToArray();
-        applicable.Should().Equal(new FilePath[]
-        {
-            Path.Combine(BaseFolder, MyModBsa),
-            Path.Combine(BaseFolder, SkyrimBsa),
-            Path.Combine(BaseFolder, SomeExplicitListingBsa),
-        });
-    }
-
-    [Fact]
-    public void NoModKey_Ordered()
+    public void NoModKey()
     {
         var fs = GetFileSystem();
         fs.File.WriteAllText(Path.Combine(BaseFolder, MyModBsa), string.Empty);
@@ -102,7 +87,7 @@ sResourceArchiveList={SomeExplicitListingBsa}, {UnusedExplicitListingBsa}") }
     {
         var fs = GetFileSystem();
         var get = GetClass(fs);
-        get.Get(TestConstants.Skyrim, Enumerable.Empty<FileName>())
+        get.Get(TestConstants.Skyrim)
             .Should().BeEmpty();
     }
 
@@ -119,41 +104,7 @@ sResourceArchiveList={SomeExplicitListingBsa}, {UnusedExplicitListingBsa}") }
     }
 
     [Fact]
-    public void BaseMod_Unordered()
-    {
-        var fs = GetFileSystem();
-        var get = GetClass(fs);
-        fs.File.WriteAllText(Path.Combine(BaseFolder, SkyrimBsa), string.Empty);
-        fs.File.WriteAllText(Path.Combine(BaseFolder, SomeExplicitListingBsa), string.Empty);
-        fs.File.WriteAllText(Path.Combine(BaseFolder, MyModBsa), string.Empty);
-        var applicable = get.Get(TestConstants.Skyrim, Enumerable.Empty<FileName>())
-            .ToArray();
-        applicable.Should().Equal(new FilePath[]
-        {
-            Path.Combine(BaseFolder, SkyrimBsa),
-            Path.Combine(BaseFolder, SomeExplicitListingBsa)
-        });
-    }
-
-    [Fact]
-    public void Typical_Unordered()
-    {
-        var fs = GetFileSystem();
-        var get = GetClass(fs);
-        fs.File.WriteAllText(Path.Combine(BaseFolder, $"{TestConstants.MasterModKey2.Name}.bsa"), string.Empty);
-        fs.File.WriteAllText(Path.Combine(BaseFolder, SomeExplicitListingBsa), string.Empty);
-        fs.File.WriteAllText(Path.Combine(BaseFolder, MyModBsa), string.Empty);
-        var applicable = get.Get(TestConstants.MasterModKey2, Enumerable.Empty<FileName>())
-            .ToArray();
-        applicable.Should().Equal(new FilePath[]
-        {
-            Path.Combine(BaseFolder, $"{TestConstants.MasterModKey2.Name}.bsa"),
-            Path.Combine(BaseFolder, SomeExplicitListingBsa)
-        });
-    }
-
-    [Fact]
-    public void BaseMod_Ordered()
+    public void BaseMod()
     {
         var fs = GetFileSystem();
         var get = GetClass(fs);
@@ -170,7 +121,7 @@ sResourceArchiveList={SomeExplicitListingBsa}, {UnusedExplicitListingBsa}") }
     }
 
     [Fact]
-    public void Typical_Ordered()
+    public void Typical()
     {
         var fs = GetFileSystem();
         var get = GetClass(fs);
@@ -182,7 +133,7 @@ sResourceArchiveList={SomeExplicitListingBsa}, {UnusedExplicitListingBsa}") }
         applicable.Should().Equal(new FilePath[]
         {
             Path.Combine(BaseFolder, SomeExplicitListingBsa),
-            Path.Combine(BaseFolder, $"{TestConstants.MasterModKey2.Name}.bsa"),
+            Path.Combine(BaseFolder, $"{TestConstants.MasterModKey2.Name}.bsa")
         });
     }
     #endregion

--- a/Mutagen.Bethesda.Core/Archives/Archive.cs
+++ b/Mutagen.Bethesda.Core/Archives/Archive.cs
@@ -26,17 +26,18 @@ public static class Archive
             modOrdering.EmptyIfNull().Select(x => new LoadOrderListing(x, enabled: true)));
         return new GetApplicableArchivePaths(
             fileSystem,
-            new GetArchiveIniListings(
-                fileSystem,
-                new IniPathProvider(
-                    new GameReleaseInjection(release),
-                    new IniPathLookup(
-                        GameLocatorLookupCache.Instance))),
             new CheckArchiveApplicability(
                 ext),
             new DataDirectoryInjection(dataFolderPath),
             ext,
-            lo);
+            new CachedArchiveListingDetailsProvider(
+                lo,
+                new GetArchiveIniListings(
+                    fileSystem,
+                    new IniPathProvider(
+                        new GameReleaseInjection(release),
+                        new IniPathLookup(
+                            GameLocatorLookupCache.Instance)))));
     }
         
     /// <summary>
@@ -85,7 +86,7 @@ public static class Archive
         bool returnEmptyIfMissing = true)
     {
         return GetApplicableArchivePathsDi(release, dataFolderPath, modOrdering: null, fileSystem: fileSystem)
-            .Get(returnEmptyIfMissing: returnEmptyIfMissing);
+            .Get();
     }
 
     /// <summary>
@@ -95,13 +96,12 @@ public static class Archive
     /// <param name="dataFolderPath">Folder to query within</param>
     /// <param name="archiveOrdering">Archive ordering overload.  Empty enumerable means no ordering.</param>
     /// <param name="fileSystem">FileSystem to use</param>
-    /// <param name="returnEmptyIfMissing">If ini file is missing, return empty instead of throwing an exception</param>
     /// <returns></returns>
     public static IEnumerable<FilePath> GetApplicableArchivePaths(GameRelease release, DirectoryPath dataFolderPath,
         IEnumerable<FileName>? archiveOrdering, IFileSystem? fileSystem = null, bool returnEmptyIfMissing = true)
     {
         return GetApplicableArchivePathsDi(release, dataFolderPath, archiveOrdering.EmptyIfNull().Select(ModKey.FromFileName), fileSystem)
-            .Get(returnEmptyIfMissing: returnEmptyIfMissing);
+            .Get();
     }
 
     /// <summary>
@@ -111,13 +111,12 @@ public static class Archive
     /// <param name="dataFolderPath">Folder to query within</param>
     /// <param name="modOrdering">Archive ordering overload based on a mod order.  Empty enumerable means no ordering.</param>
     /// <param name="fileSystem">FileSystem to use</param>
-    /// <param name="returnEmptyIfMissing">If ini file is missing, return empty instead of throwing an exception</param>
     /// <returns></returns>
     public static IEnumerable<FilePath> GetApplicableArchivePaths(GameRelease release, DirectoryPath dataFolderPath,
         IEnumerable<ModKey>? modOrdering, IFileSystem? fileSystem = null, bool returnEmptyIfMissing = true)
     {
         return GetApplicableArchivePathsDi(release, dataFolderPath, modOrdering, fileSystem)
-            .Get(returnEmptyIfMissing: returnEmptyIfMissing);
+            .Get();
     }
 
     /// <summary>
@@ -129,13 +128,12 @@ public static class Archive
     /// <param name="dataFolderPath">Folder to query within</param>
     /// <param name="modKey">ModKey to query about</param>
     /// <param name="fileSystem">FileSystem to use</param>
-    /// <param name="returnEmptyIfMissing">If ini file is missing, return empty instead of throwing an exception</param>
     /// <returns></returns>
     public static IEnumerable<FilePath> GetApplicableArchivePaths(GameRelease release, DirectoryPath dataFolderPath,
         ModKey modKey, IFileSystem? fileSystem = null, bool returnEmptyIfMissing = true)
     {
         return GetApplicableArchivePathsDi(release, dataFolderPath, modOrdering: null, fileSystem: fileSystem)
-            .Get(modKey, returnEmptyIfMissing: returnEmptyIfMissing);
+            .Get(modKey);
     }
 
     /// <summary>
@@ -148,14 +146,13 @@ public static class Archive
     /// <param name="modKey">ModKey to query about</param>
     /// <param name="archiveOrdering">Archive ordering overload.  Empty enumerable means no ordering.</param>
     /// <param name="fileSystem">FileSystem to use</param>
-    /// <param name="returnEmptyIfMissing">If ini file is missing, return empty instead of throwing an exception</param>
     /// <returns></returns>
     public static IEnumerable<FilePath> GetApplicableArchivePaths(GameRelease release, DirectoryPath dataFolderPath, 
         ModKey modKey, IEnumerable<FileName>? archiveOrdering, 
-        IFileSystem? fileSystem = null, bool returnEmptyIfMissing = true)
+        IFileSystem? fileSystem = null)
     {
         return GetApplicableArchivePathsDi(release, dataFolderPath, archiveOrdering.EmptyIfNull().Select(ModKey.FromFileName), fileSystem)
-            .Get(modKey, returnEmptyIfMissing: returnEmptyIfMissing);
+            .Get(modKey);
     }
 
     /// <summary>

--- a/Mutagen.Bethesda.Core/Archives/DI/CachedArchiveListingDetailsProvider.cs
+++ b/Mutagen.Bethesda.Core/Archives/DI/CachedArchiveListingDetailsProvider.cs
@@ -1,0 +1,53 @@
+﻿using Mutagen.Bethesda.Plugins.Order.DI;
+using Noggog;
+
+namespace Mutagen.Bethesda.Archives.DI;
+
+public class CachedArchiveListingDetailsProvider : IArchiveListingDetailsProvider
+{
+    private readonly ILoadOrderListingsProvider _listingsProvider;
+    private readonly IGetArchiveIniListings _getArchiveIniListings;
+    private readonly Lazy<Payload> _payload;
+
+    private class Payload
+    {
+        public required IReadOnlyList<FileName> Listed { get; init; }
+        public required IReadOnlyList<FileName> Priority { get; init; }
+        public required IReadOnlySet<FileName> Set { get; init; }
+    }
+    
+    public CachedArchiveListingDetailsProvider(
+        ILoadOrderListingsProvider listingsProvider,
+        IGetArchiveIniListings getArchiveIniListings)
+    {
+        _listingsProvider = listingsProvider;
+        _getArchiveIniListings = getArchiveIniListings;
+        _payload = new Lazy<Payload>(() =>
+        {
+            var listed = new List<FileName>();
+            listed.AddRange(_getArchiveIniListings.TryGet().EmptyIfNull());
+            listed.AddRange(_listingsProvider.Get()
+                .Where(x => x.Enabled)
+                .Select(x => x.ModKey)
+                .Select(x => x.FileName));
+            return new Payload()
+            {
+                Listed = listed,
+                Priority = ((IEnumerable<FileName>)listed).Reverse().ToList(),
+                Set = listed.ToHashSet(),
+            };
+        });
+    }
+
+    public bool Empty => _payload.Value.Listed.Count == 0;
+    
+    public int PriorityIndexFor(FileName fileName)
+    {
+        return _payload.Value.Priority.IndexOf(fileName);
+    }
+    
+    public bool Contains(FileName fileName)
+    {
+        return _payload.Value.Set.Contains(fileName);
+    }
+}

--- a/Mutagen.Bethesda.Core/Archives/DI/GetApplicableArchivePaths.cs
+++ b/Mutagen.Bethesda.Core/Archives/DI/GetApplicableArchivePaths.cs
@@ -1,6 +1,7 @@
 using System.IO.Abstractions;
 using Mutagen.Bethesda.Environments.DI;
 using Mutagen.Bethesda.Plugins;
+using Mutagen.Bethesda.Plugins.Order.DI;
 using Noggog;
 
 namespace Mutagen.Bethesda.Archives.DI;
@@ -14,22 +15,6 @@ public interface IGetApplicableArchivePaths
     IEnumerable<FilePath> Get(bool returnEmptyIfMissing = true);
 
     /// <summary>
-    /// Enumerates all Archives
-    /// </summary>
-    /// <param name="archiveOrdering">Archive ordering overload.  Empty enumerable means no ordering.</param>
-    /// <param name="returnEmptyIfMissing">If ini file is missing, return empty instead of throwing an exception</param>
-    /// <returns></returns>
-    IEnumerable<FilePath> Get(IEnumerable<FileName>? archiveOrdering, bool returnEmptyIfMissing = true);
-
-    /// <summary>
-    /// Enumerates all Archives
-    /// </summary>
-    /// <param name="modOrdering">Archive ordering overload based on a mod order.  Empty enumerable means no ordering.</param>
-    /// <param name="returnEmptyIfMissing">If ini file is missing, return empty instead of throwing an exception</param>
-    /// <returns></returns>
-    IEnumerable<FilePath> Get(IEnumerable<ModKey>? modOrdering, bool returnEmptyIfMissing = true);
-
-    /// <summary>
     /// Enumerates all applicable Archives for a given ModKey<br/>
     /// This call is intended to return Archives related to one specific mod.<br/>
     /// NOTE:  It is currently a bit experimental
@@ -38,28 +23,6 @@ public interface IGetApplicableArchivePaths
     /// <param name="returnEmptyIfMissing">If ini file is missing, return empty instead of throwing an exception</param>
     /// <returns></returns>
     IEnumerable<FilePath> Get(ModKey modKey, bool returnEmptyIfMissing = true);
-
-    /// <summary>
-    /// Enumerates all applicable Archives for a given ModKey<br/>
-    /// This call is intended to return Archives related to one specific mod.<br/>
-    /// NOTE:  It is currently a bit experimental
-    /// </summary>
-    /// <param name="modKey">ModKey to query about</param>
-    /// <param name="archiveOrdering">Archive ordering overload.  Empty enumerable means no ordering.</param>
-    /// <param name="returnEmptyIfMissing">If ini file is missing, return empty instead of throwing an exception</param>
-    /// <returns></returns>
-    IEnumerable<FilePath> Get(ModKey modKey, IEnumerable<FileName>? archiveOrdering, bool returnEmptyIfMissing = true);
-
-    /// <summary>
-    /// Enumerates all applicable Archives for a given ModKey<br/>
-    /// This call is intended to return Archives related to one specific mod.<br/>
-    /// NOTE:  It is currently a bit experimental
-    /// </summary>
-    /// <param name="modKey">ModKey to query about</param>
-    /// <param name="archiveOrdering">How to order the archive paths.  Null for no ordering</param>
-    /// <param name="returnEmptyIfMissing">If ini file is missing, return empty instead of throwing an exception</param>
-    /// <returns>Full paths of Archives that apply to the given mod and exist</returns>
-    IEnumerable<FilePath> Get(ModKey modKey, IComparer<FileName>? archiveOrdering, bool returnEmptyIfMissing = true);
 }
 
 public sealed class GetApplicableArchivePaths : IGetApplicableArchivePaths
@@ -69,52 +32,37 @@ public sealed class GetApplicableArchivePaths : IGetApplicableArchivePaths
     private readonly ICheckArchiveApplicability _applicability;
     private readonly IDataDirectoryProvider _dataDirectoryProvider;
     private readonly IArchiveExtensionProvider _archiveExtension;
+    private readonly ILoadOrderListingsProvider _loadOrderListingsProvider;
 
     public GetApplicableArchivePaths(
         IFileSystem fileSystem,
         IGetArchiveIniListings iniListings,
         ICheckArchiveApplicability applicability,
         IDataDirectoryProvider dataDirectoryProvider,
-        IArchiveExtensionProvider archiveExtension)
+        IArchiveExtensionProvider archiveExtension,
+        ILoadOrderListingsProvider loadOrderListingsProvider)
     {
         _fileSystem = fileSystem;
         _iniListings = iniListings;
         _applicability = applicability;
         _dataDirectoryProvider = dataDirectoryProvider;
         _archiveExtension = archiveExtension;
+        _loadOrderListingsProvider = loadOrderListingsProvider;
     }
         
     /// <inheritdoc />
     public IEnumerable<FilePath> Get(bool returnEmptyIfMissing = true)
     {
-        return GetInternal(default(ModKey?), GetPriorityOrderComparer(null, emptyIfMissing: returnEmptyIfMissing), returnEmptyIfMissing);
-    }
-
-    /// <inheritdoc />
-    public IEnumerable<FilePath> Get(IEnumerable<FileName>? archiveOrdering, bool returnEmptyIfMissing = true)
-    {
-        return GetInternal(default(ModKey?), GetPriorityOrderComparer(archiveOrdering, emptyIfMissing: returnEmptyIfMissing), returnEmptyIfMissing);
-    }
-
-    public IEnumerable<FilePath> Get(IEnumerable<ModKey>? modOrdering, bool returnEmptyIfMissing = true)
-    {
-        return GetInternal(default, GetPriorityModOrderComparer(modOrdering), returnEmptyIfMissing);
+        return GetInternal(default(ModKey?), GetPriorityOrderComparer(emptyIfMissing: returnEmptyIfMissing), returnEmptyIfMissing);
     }
 
     /// <inheritdoc />
     public IEnumerable<FilePath> Get(ModKey modKey, bool returnEmptyIfMissing = true)
     {
-        return Get(modKey, GetPriorityOrderComparer(null, emptyIfMissing: returnEmptyIfMissing), returnEmptyIfMissing);
+        return Get(modKey, GetPriorityOrderComparer(emptyIfMissing: returnEmptyIfMissing), returnEmptyIfMissing);
     }
 
-    /// <inheritdoc />
-    public IEnumerable<FilePath> Get(ModKey modKey, IEnumerable<FileName>? archiveOrdering, bool returnEmptyIfMissing = true)
-    {
-        return Get(modKey, GetPriorityOrderComparer(archiveOrdering, emptyIfMissing: returnEmptyIfMissing), returnEmptyIfMissing);
-    }
-
-    /// <inheritdoc />
-    public IEnumerable<FilePath> Get(ModKey modKey, IComparer<FileName>? archiveOrdering, bool returnEmptyIfMissing = true)
+    private IEnumerable<FilePath> Get(ModKey modKey, IComparer<FileName>? archiveOrdering, bool returnEmptyIfMissing = true)
     {
         return GetInternal(modKey, archiveOrdering, returnEmptyIfMissing);
     }
@@ -158,17 +106,17 @@ public sealed class GetApplicableArchivePaths : IGetApplicableArchivePaths
     }
 
 
-    private IComparer<FileName>? GetPriorityOrderComparer(IEnumerable<FileName>? listedArchiveOrdering, bool emptyIfMissing)
+    private IComparer<FileName>? GetPriorityOrderComparer(bool emptyIfMissing)
     {
+        IReadOnlyList<FileName> archiveOrderingList;
         if (emptyIfMissing)
         {
-            listedArchiveOrdering ??= _iniListings.TryGet() ?? Enumerable.Empty<FileName>();
+            archiveOrderingList = _iniListings.TryGet()?.ToList() ?? [];
         }
         else
         {
-            listedArchiveOrdering ??= _iniListings.Get();
+            archiveOrderingList = _iniListings.Get().ToList();
         }
-        var archiveOrderingList = listedArchiveOrdering.ToList();
         if (archiveOrderingList.Count == 0) return null;
         archiveOrderingList.Reverse();
         return Comparer<FileName>.Create((a, b) =>
@@ -179,34 +127,6 @@ public sealed class GetApplicableArchivePaths : IGetApplicableArchivePaths
             if (indexA == -1) return 1;
             if (indexB == -1) return -1;
             return indexA - indexB;
-        });
-    }
-    
-    private IComparer<FileName>? GetPriorityModOrderComparer(IEnumerable<ModKey>? listedModOrdering)
-    {
-        if (listedModOrdering is null) return null;
-
-        var iniListedArchives = _iniListings.Get().ToList();
-        var modOrderingList = listedModOrdering.ToList();
-        return Comparer<FileName>.Create((a, b) =>
-        {
-            var iniIndexOfA = iniListedArchives.IndexOf(a);
-            var iniIndexOfB = iniListedArchives.IndexOf(b);
-
-            // Handle if any of the archives are listed in the ini file
-            if (iniIndexOfA != -1 || iniIndexOfB != -1) {
-                if (iniIndexOfA == -1) return 1;
-                if (iniIndexOfB == -1) return -1;
-                return iniIndexOfA - iniIndexOfB;
-            }
-
-            // If neither are listed in the ini file, use the mod ordering
-            var modIndexA = modOrderingList.FindIndex(modKey => _applicability.IsApplicable(modKey, a));
-            var modIndexB = modOrderingList.FindIndex(modKey => _applicability.IsApplicable(modKey, b));
-            if (modIndexA == -1 && modIndexB == -1) return 0;
-            if (modIndexA == -1) return 1;
-            if (modIndexB == -1) return -1;
-            return modIndexA - modIndexB;
         });
     }
 }

--- a/Mutagen.Bethesda.Core/Archives/DI/IArchiveListingDetailsProvider.cs
+++ b/Mutagen.Bethesda.Core/Archives/DI/IArchiveListingDetailsProvider.cs
@@ -1,0 +1,10 @@
+﻿using Noggog;
+
+namespace Mutagen.Bethesda.Archives.DI;
+
+public interface IArchiveListingDetailsProvider
+{
+    bool Empty { get; }
+    int PriorityIndexFor(FileName fileName);
+    bool Contains(FileName fileName);
+}

--- a/Mutagen.Bethesda.Core/Assets/DI/ArchiveAssetProvider.cs
+++ b/Mutagen.Bethesda.Core/Assets/DI/ArchiveAssetProvider.cs
@@ -3,7 +3,7 @@ using System.IO.Abstractions;
 using Mutagen.Bethesda.Archives;
 using Mutagen.Bethesda.Archives.DI;
 using Mutagen.Bethesda.Environments.DI;
-using Mutagen.Bethesda.Plugins;
+
 namespace Mutagen.Bethesda.Assets.DI;
 
 public class ArchiveAssetProvider : IAssetProvider
@@ -29,12 +29,7 @@ public class ArchiveAssetProvider : IAssetProvider
 
     public bool TryGetStream(DataRelativePath assetPath, [MaybeNullWhen(false)] out Stream stream)
     {
-        return TryGetStream(assetPath, null, out stream);
-    }
-
-    public bool TryGetStream(DataRelativePath assetPath, IEnumerable<ModKey>? modOrdering, [MaybeNullWhen(false)] out Stream stream)
-    {
-        var archiveFile = GetArchiveFile(assetPath, modOrdering);
+        var archiveFile = GetArchiveFile(assetPath);
         if (archiveFile is null)
         {
             stream = null;
@@ -47,12 +42,7 @@ public class ArchiveAssetProvider : IAssetProvider
 
     public bool TryGetSize(DataRelativePath assetPath, out uint size)
     {
-        return TryGetSize(assetPath, null, out size);
-    }
-
-    public bool TryGetSize(DataRelativePath assetPath, IEnumerable<ModKey>? modOrdering, out uint size)
-    {
-        var archiveFile = GetArchiveFile(assetPath, modOrdering);
+        var archiveFile = GetArchiveFile(assetPath);
         if (archiveFile is null)
         {
             size = 0;
@@ -63,13 +53,13 @@ public class ArchiveAssetProvider : IAssetProvider
         return true;
     }
 
-    private IArchiveFile? GetArchiveFile(DataRelativePath assetPath, IEnumerable<ModKey>? modOrdering = null)
+    private IArchiveFile? GetArchiveFile(DataRelativePath assetPath)
     {
         var dataRelativeDirectoryPath = _fileSystem.Path.GetDirectoryName(assetPath.Path);
         if (dataRelativeDirectoryPath is null) return null;
 
         var fileName = _fileSystem.Path.GetFileName(assetPath.Path);
-        var applicableArchivePaths = _getApplicableArchivePaths.Get(modOrdering);
+        var applicableArchivePaths = _getApplicableArchivePaths.Get();
         foreach (var archivePath in applicableArchivePaths)
         {
             var archiveReader = Archive.CreateReader(_gameReleaseContext.Release, archivePath, _fileSystem);

--- a/Mutagen.Bethesda.Core/Assets/DI/AssetProviderMixIn.cs
+++ b/Mutagen.Bethesda.Core/Assets/DI/AssetProviderMixIn.cs
@@ -1,5 +1,6 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 using Mutagen.Bethesda.Plugins.Assets;
+
 namespace Mutagen.Bethesda.Assets.DI;
 
 public static class AssetProviderMixIn

--- a/Mutagen.Bethesda.Core/Assets/DI/DataDirectoryAssetProvider.cs
+++ b/Mutagen.Bethesda.Core/Assets/DI/DataDirectoryAssetProvider.cs
@@ -1,6 +1,7 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 using System.IO.Abstractions;
 using Mutagen.Bethesda.Environments.DI;
+
 namespace Mutagen.Bethesda.Assets.DI;
 
 public class DataDirectoryAssetProvider : IAssetProvider

--- a/Mutagen.Bethesda.Core/Assets/DI/GameAssetProvider.cs
+++ b/Mutagen.Bethesda.Core/Assets/DI/GameAssetProvider.cs
@@ -1,4 +1,5 @@
 ﻿using System.Diagnostics.CodeAnalysis;
+
 namespace Mutagen.Bethesda.Assets.DI;
 
 public class GameAssetProvider : IAssetProvider

--- a/Mutagen.Bethesda.Core/Assets/DI/IAssetProvider.cs
+++ b/Mutagen.Bethesda.Core/Assets/DI/IAssetProvider.cs
@@ -1,4 +1,5 @@
 ﻿using System.Diagnostics.CodeAnalysis;
+
 namespace Mutagen.Bethesda.Assets.DI;
 
 public interface IAssetProvider

--- a/Mutagen.Bethesda.Core/Environments/DI/GameEnvironmentProvider.cs
+++ b/Mutagen.Bethesda.Core/Environments/DI/GameEnvironmentProvider.cs
@@ -1,4 +1,5 @@
-﻿using Mutagen.Bethesda.Plugins.Cache;
+﻿using Mutagen.Bethesda.Assets.DI;
+using Mutagen.Bethesda.Plugins.Cache;
 using Mutagen.Bethesda.Plugins.Order.DI;
 using Mutagen.Bethesda.Plugins.Records;
 
@@ -29,19 +30,22 @@ public sealed class GameEnvironmentProvider : IGameEnvironmentProvider
     private readonly IDataDirectoryProvider _dataDirectoryProvider;
     private readonly IPluginListingsPathContext _pluginListingsPathContext;
     private readonly ICreationClubListingsPathProvider _cccPath;
+    private readonly IAssetProvider _assetProvider;
 
     public GameEnvironmentProvider(
         IGameReleaseContext gameReleaseContext,
         ILoadOrderImporter loadOrderImporter,
         IDataDirectoryProvider dataDirectoryProvider,
         IPluginListingsPathContext pluginListingsPathContext,
-        ICreationClubListingsPathProvider cccPath)
+        ICreationClubListingsPathProvider cccPath,
+        IAssetProvider assetProvider)
     {
         _gameReleaseContext = gameReleaseContext;
         _loadOrderImporter = loadOrderImporter;
         _dataDirectoryProvider = dataDirectoryProvider;
         _pluginListingsPathContext = pluginListingsPathContext;
         _cccPath = cccPath;
+        _assetProvider = assetProvider;
     }
 
     public IGameEnvironment Construct(LinkCachePreferences? linkCachePrefs = null)        
@@ -55,6 +59,7 @@ public sealed class GameEnvironmentProvider : IGameEnvironmentProvider
             creationClubListingsFilePath: _cccPath.Path,
             loadOrder: loadOrder,
             linkCache: loadOrder.ToUntypedImmutableLinkCache(linkCachePrefs),
+            assetProvider: _assetProvider,
             dispose: true);
     }
 }
@@ -67,19 +72,22 @@ public sealed class GameEnvironmentProvider<TMod> : IGameEnvironmentProvider<TMo
     private readonly IDataDirectoryProvider _dataDirectoryProvider;
     private readonly IPluginListingsPathContext _pluginListingsPathContext;
     private readonly ICreationClubListingsPathProvider _cccPath;
+    private readonly IAssetProvider _assetProvider;
 
     public GameEnvironmentProvider(
         IGameReleaseContext gameReleaseContext,
         ILoadOrderImporter<TMod> loadOrderImporter,
         IDataDirectoryProvider dataDirectoryProvider,
         IPluginListingsPathContext pluginListingsPathContext,
-        ICreationClubListingsPathProvider cccPath)
+        ICreationClubListingsPathProvider cccPath,
+        IAssetProvider assetProvider)
     {
         _gameReleaseContext = gameReleaseContext;
         _loadOrderImporter = loadOrderImporter;
         _dataDirectoryProvider = dataDirectoryProvider;
         _pluginListingsPathContext = pluginListingsPathContext;
         _cccPath = cccPath;
+        _assetProvider = assetProvider;
     }
 
     public IGameEnvironment<TMod> Construct(LinkCachePreferences? linkCachePrefs = null)        
@@ -93,6 +101,7 @@ public sealed class GameEnvironmentProvider<TMod> : IGameEnvironmentProvider<TMo
             creationClubListingsFilePath: _cccPath.Path,
             loadOrder: loadOrder,
             linkCache: loadOrder.ToUntypedImmutableLinkCache(linkCachePrefs),
+            assetProvider: _assetProvider,
             dispose: true);
     }
 }
@@ -106,19 +115,22 @@ public sealed class GameEnvironmentProvider<TModSetter, TModGetter> : IGameEnvir
     private readonly IDataDirectoryProvider _dataDirectoryProvider;
     private readonly IPluginListingsPathContext _pluginListingsPathContext;
     private readonly ICreationClubListingsPathProvider _cccPath;
+    private readonly IAssetProvider _assetProvider;
 
     public GameEnvironmentProvider(
         IGameReleaseContext gameReleaseContext,
         ILoadOrderImporter<TModGetter> loadOrderImporter,
         IDataDirectoryProvider dataDirectoryProvider,
         IPluginListingsPathContext pluginListingsPathContext,
-        ICreationClubListingsPathProvider cccPath)
+        ICreationClubListingsPathProvider cccPath,
+        IAssetProvider assetProvider)
     {
         _gameReleaseContext = gameReleaseContext;
         _loadOrderImporter = loadOrderImporter;
         _dataDirectoryProvider = dataDirectoryProvider;
         _pluginListingsPathContext = pluginListingsPathContext;
         _cccPath = cccPath;
+        _assetProvider = assetProvider;
     }
 
     public IGameEnvironment<TModSetter, TModGetter> Construct(LinkCachePreferences? linkCachePrefs = null)        
@@ -132,6 +144,7 @@ public sealed class GameEnvironmentProvider<TModSetter, TModGetter> : IGameEnvir
             creationClubListingsFilePath: _cccPath.Path,
             loadOrder: loadOrder,
             linkCache: loadOrder.ToImmutableLinkCache<TModSetter, TModGetter>(linkCachePrefs),
+            assetProvider: _assetProvider,
             dispose: true);
     }
 }

--- a/Mutagen.Bethesda.Core/Environments/DI/IGameDirectoryLookup.cs
+++ b/Mutagen.Bethesda.Core/Environments/DI/IGameDirectoryLookup.cs
@@ -35,3 +35,67 @@ public interface IGameDirectoryLookup
     /// <returns>The game directory, if located</returns>
     DirectoryPath? TryGet(GameRelease release);
 }
+
+public class GameDirectoryLookupInjection : IGameDirectoryLookup
+{
+    private readonly GameRelease _release;
+    private readonly DirectoryPath[] _path;
+    
+    public GameDirectoryLookupInjection(GameRelease release, DirectoryPath? path)
+    {
+        _release = release;
+        if (path == null)
+        {
+            _path = [];
+        }
+        else
+        {
+            _path = [path.Value];
+        }
+    }
+
+    private void CheckRelease(GameRelease release)
+    {
+        if (release != _release)
+        {
+            throw new ArgumentException($"Accessed a game release the inejction was not intended for: {release} != {_release}", nameof(release));
+        }
+    }
+
+    public IEnumerable<DirectoryPath> GetAll(GameRelease release)
+    {
+        CheckRelease(release);
+        return _path;
+    }
+    
+    public bool TryGet(GameRelease release, out DirectoryPath path)
+    {
+        if (release != _release || _path.Length == 0)
+        {
+            path = default;
+            return false;
+        }
+        
+        path = _path[0];
+        return true;
+    }
+    
+    public DirectoryPath Get(GameRelease release)
+    {
+        CheckRelease(release);
+        return _path[0];
+    }
+    
+    public DirectoryPath? TryGet(GameRelease release)
+    {
+        CheckRelease(release);
+        if (release != _release)
+        {
+            return default;
+        }
+
+        if (_path.Length == 0) return default;
+
+        return _path[0];
+    }
+}

--- a/Mutagen.Bethesda.Core/Environments/GameEnvironment.cs
+++ b/Mutagen.Bethesda.Core/Environments/GameEnvironment.cs
@@ -223,17 +223,18 @@ public sealed class GameEnvironmentState :
                 fs,
                 new GetApplicableArchivePaths(
                     fs,
-                    new GetArchiveIniListings(
-                        fs,
-                        new IniPathProvider(
-                            gameReleaseInjection,
-                            new IniPathLookup(
-                                gameDirLookup))),
                     new CheckArchiveApplicability(
                         archiveExt),
                     dataDirectory,
                     archiveExt,
-                    loListingsProvider),
+                    new CachedArchiveListingDetailsProvider(
+                        loListingsProvider,
+                        new GetArchiveIniListings(
+                            fs,
+                            new IniPathProvider(
+                                gameReleaseInjection,
+                                new IniPathLookup(
+                                    gameDirLookup))))),
                 gameReleaseInjection));
         return new GameEnvironmentProvider<IModGetter>(
                 gameReleaseInjection,
@@ -375,17 +376,18 @@ public sealed class GameEnvironmentState<TMod> :
                 fs,
                 new GetApplicableArchivePaths(
                     fs,
-                    new GetArchiveIniListings(
-                        fs,
-                        new IniPathProvider(
-                            gameReleaseInjection,
-                            new IniPathLookup(
-                                gameDirLookup))),
                     new CheckArchiveApplicability(
                         archiveExt),
                     dataDirectory,
                     archiveExt,
-                    loListingsProvider),
+                    new CachedArchiveListingDetailsProvider(
+                        loListingsProvider,
+                        new GetArchiveIniListings(
+                            fs,
+                            new IniPathProvider(
+                                gameReleaseInjection,
+                                new IniPathLookup(
+                                    gameDirLookup))))),
                 gameReleaseInjection));
         return new GameEnvironmentProvider<TMod>(
                 gameReleaseInjection,
@@ -539,17 +541,18 @@ public sealed class GameEnvironmentState<TModSetter, TModGetter> :
                 fs,
                 new GetApplicableArchivePaths(
                     fs,
-                    new GetArchiveIniListings(
-                        fs,
-                        new IniPathProvider(
-                            gameReleaseInjection,
-                            new IniPathLookup(
-                                gameDirLookup))),
                     new CheckArchiveApplicability(
                         archiveExt),
                     dataDirectory,
                     archiveExt,
-                    loListingsProvider),
+                    new CachedArchiveListingDetailsProvider(
+                        loListingsProvider,
+                        new GetArchiveIniListings(
+                            fs,
+                            new IniPathProvider(
+                                gameReleaseInjection,
+                                new IniPathLookup(
+                                    gameDirLookup))))),
                 gameReleaseInjection));
         return new GameEnvironmentProvider<TModSetter, TModGetter>(
                 gameReleaseInjection,

--- a/Mutagen.Bethesda.Core/Environments/GameEnvironmentBuilder.cs
+++ b/Mutagen.Bethesda.Core/Environments/GameEnvironmentBuilder.cs
@@ -276,17 +276,18 @@ public sealed record GameEnvironmentBuilder<TMod, TModGetter>
                 fs,
                 new GetApplicableArchivePaths(
                     fs,
-                    new GetArchiveIniListings(
-                        fs,
-                        new IniPathProvider(
-                            Release,
-                            new IniPathLookup(
-                                gameDirectoryLookup))),
                     new CheckArchiveApplicability(
                         archiveExt),
                     dataDirectory,
                     archiveExt,
-                    loListings),
+                    new CachedArchiveListingDetailsProvider(
+                        loListings,
+                        new GetArchiveIniListings(
+                            fs,
+                            new IniPathProvider(
+                                Release,
+                                new IniPathLookup(
+                                    gameDirectoryLookup))))),
                 Release));
 
         return new GameEnvironmentState<TMod, TModGetter>(
@@ -560,17 +561,18 @@ public sealed record GameEnvironmentBuilder
                 fs,
                 new GetApplicableArchivePaths(
                     fs,
-                    new GetArchiveIniListings(
-                        fs,
-                        new IniPathProvider(
-                            Release,
-                            new IniPathLookup(
-                                gameDirectoryLookup))),
                     new CheckArchiveApplicability(
                         archiveExt),
                     dataDirectory,
                     archiveExt,
-                    loListings),
+                    new CachedArchiveListingDetailsProvider(
+                        loListings,
+                        new GetArchiveIniListings(
+                            fs,
+                            new IniPathProvider(
+                                Release,
+                                new IniPathLookup(
+                                    gameDirectoryLookup))))),
                 Release));
         
         return new GameEnvironmentState(

--- a/Mutagen.Bethesda.Core/Environments/GameEnvironmentBuilder.cs
+++ b/Mutagen.Bethesda.Core/Environments/GameEnvironmentBuilder.cs
@@ -3,6 +3,9 @@ using Mutagen.Bethesda.Plugins.Order;
 using Mutagen.Bethesda.Plugins.Records;
 using System.Collections.Immutable;
 using System.IO.Abstractions;
+using Mutagen.Bethesda.Archives.DI;
+using Mutagen.Bethesda.Assets.DI;
+using Mutagen.Bethesda.Inis.DI;
 using Mutagen.Bethesda.Installs.DI;
 using Mutagen.Bethesda.Plugins;
 using Mutagen.Bethesda.Plugins.Binary.Parameters;
@@ -175,6 +178,9 @@ public sealed record GameEnvironmentBuilder<TMod, TModGetter>
                 Release,
                 GameLocatorLookupCache.Instance), 
             DataDirectoryProvider);
+        
+        var gameDirectoryLookup = Resolve<IGameDirectoryLookup>(
+            () => new GameDirectoryLookupInjection(Release.Release, dataDirectory.Path.Directory));
 
         var pluginPathProvider = Resolve<IPluginListingsPathContext>(
             () => new PluginListingsPathContext(
@@ -240,10 +246,11 @@ public sealed record GameEnvironmentBuilder<TMod, TModGetter>
             filteredListings = filter(filteredListings);
         }
 
+        var loListings = new LoadOrderListingsInjection(filteredListings);
         var loGetter = new LoadOrderImporter<TModGetter>(
             fs,
             dataDirectory,
-            new LoadOrderListingsInjection(filteredListings),
+            loListings,
             new ModImporter<TModGetter>(
                 fs,
                 Release),
@@ -260,13 +267,36 @@ public sealed record GameEnvironmentBuilder<TMod, TModGetter>
 
         var linkCache = lo.ToMutableLinkCache(MutableMods.ToArray());
 
+        var archiveExt = new ArchiveExtensionProvider(Release);
+        var assetProvider = new GameAssetProvider(
+            new DataDirectoryAssetProvider(
+                fs,
+                dataDirectory),
+            new ArchiveAssetProvider(
+                fs,
+                new GetApplicableArchivePaths(
+                    fs,
+                    new GetArchiveIniListings(
+                        fs,
+                        new IniPathProvider(
+                            Release,
+                            new IniPathLookup(
+                                gameDirectoryLookup))),
+                    new CheckArchiveApplicability(
+                        archiveExt),
+                    dataDirectory,
+                    archiveExt,
+                    loListings),
+                Release));
+
         return new GameEnvironmentState<TMod, TModGetter>(
             Release.Release,
             dataFolderPath: dataDirectory.Path,
             loadOrderFilePath: pluginPathProvider.Path,
             creationClubListingsFilePath: cccPath.Path,
             loadOrder: lo,
-            linkCache: linkCache);
+            linkCache: linkCache,
+            assetProvider: assetProvider);
     }
 }
 
@@ -430,6 +460,9 @@ public sealed record GameEnvironmentBuilder
                 GameLocatorLookupCache.Instance), 
             DataDirectoryProvider);
         
+        var gameDirectoryLookup = Resolve<IGameDirectoryLookup>(
+            () => new GameDirectoryLookupInjection(Release.Release, dataDirectory.Path.Directory));
+        
         var pluginPathProvider = Resolve<IPluginListingsPathContext>(
             () => new PluginListingsPathContext(
                 new PluginListingsPathProvider(),
@@ -494,11 +527,12 @@ public sealed record GameEnvironmentBuilder
             filteredListings = filter(filteredListings);
         }
 
+        var loListings = new LoadOrderListingsInjection(filteredListings);
         var loGetter = new LoadOrderImporter(
             fs,
             Release,
             dataDirectory,
-            new LoadOrderListingsInjection(filteredListings),
+            loListings,
             new KeyedMasterStyleReader(
                 Release,
                 fs),
@@ -517,13 +551,36 @@ public sealed record GameEnvironmentBuilder
 
         var linkCache = lo.ToUntypedMutableLinkCache(Release.Release.ToCategory(), MutableMods.ToArray());
 
+        var archiveExt = new ArchiveExtensionProvider(Release);
+        var assetProvider = new GameAssetProvider(
+            new DataDirectoryAssetProvider(
+                fs,
+                dataDirectory),
+            new ArchiveAssetProvider(
+                fs,
+                new GetApplicableArchivePaths(
+                    fs,
+                    new GetArchiveIniListings(
+                        fs,
+                        new IniPathProvider(
+                            Release,
+                            new IniPathLookup(
+                                gameDirectoryLookup))),
+                    new CheckArchiveApplicability(
+                        archiveExt),
+                    dataDirectory,
+                    archiveExt,
+                    loListings),
+                Release));
+        
         return new GameEnvironmentState(
             Release.Release,
             dataFolderPath: dataDirectory.Path,
             loadOrderFilePath: pluginPathProvider.Path,
             creationClubListingsFilePath: cccPath.Path,
             loadOrder: lo,
-            linkCache: linkCache);
+            linkCache: linkCache,
+            assetProvider: assetProvider);
     }
 }
 

--- a/Mutagen.Bethesda.Core/Mutagen.Bethesda.Core.csproj
+++ b/Mutagen.Bethesda.Core/Mutagen.Bethesda.Core.csproj
@@ -45,6 +45,7 @@
         <Compile Include="Archives\Bsa\BsaVersionType.cs" />
         <Compile Include="Archives\Bsa\BsaFileNameBlock.cs" />
         <Compile Include="Archives\DI\ArchiveExtensionProvider.cs" />
+        <Compile Include="Archives\DI\CachedArchiveListingDetailsProvider.cs" />
         <Compile Include="Archives\DI\ArchiveReaderProvider.cs">
             <CodeLanguage>cs</CodeLanguage>
             <DefaultPackFolder>content</DefaultPackFolder>
@@ -65,6 +66,7 @@
             <DefaultPackFolder>content</DefaultPackFolder>
             <BuildAction>Compile</BuildAction>
         </Compile>
+        <Compile Include="Archives\DI\IArchiveListingDetailsProvider.cs" />
         <Compile Include="Archives\Exceptions\ArchiveException.cs" />
         <Compile Include="Archives\IArchiveFile.cs" />
         <Compile Include="Archives\IArchiveFolder.cs" />

--- a/Mutagen.Bethesda.Core/Strings/StringsFolderLookupOverlay.cs
+++ b/Mutagen.Bethesda.Core/Strings/StringsFolderLookupOverlay.cs
@@ -102,8 +102,7 @@ public sealed class StringsFolderLookupOverlay : IStringsFolderLookup
                         }
                     }
                     foreach (var bsaFile in Archive.GetApplicableArchivePaths(
-                        release, dataPath, modKey, instructions?.BsaOrdering, fileSystem: fileSystem,
-                        returnEmptyIfMissing: true))
+                        release, dataPath, modKey, instructions?.BsaOrdering, fileSystem: fileSystem))
                     {
                         try
                         {


### PR DESCRIPTION
@Elscrux mainly wanted to make sure this API change didn't affect you negatively.   The asset provider suite has had the custom ordering parameter removed, in favor of just leaning on a dependency of the load order provider.   Felt a lot cleaner, and helped make it easier to expose an IAssetProvider through the game environment