### PR TITLE
Add missing unused map marker from Skyrim to MapMarkerType enum

### DIFF
--- a/Mutagen.Bethesda.Skyrim/Records/Major Records/MapMarker.cs
+++ b/Mutagen.Bethesda.Skyrim/Records/Major Records/MapMarker.cs
@@ -71,5 +71,6 @@ public partial class MapMarker
         TelMithryn = 56,
         ToSkyrim = 57,
         ToSolstheim = 58,
+        CastleKarstaag = 59
     }
 }


### PR DESCRIPTION
The MarkerType enum is missing the Castle Karstaag map marker from Skyrim. It's unused in the base game but many mods make use of it and the other unused markers (e.g. Altar, City and Smelter) are already included. I suspect the reason that it wasn't included thus far is that its id comes after the last used marker.