### PR TITLE
Change LinkTo type IDialog link interface with IDialogTopicGetter

### DIFF
--- a/Mutagen.Bethesda.Skyrim/Documentation/LinkInterfaceDocumentation_Generated.md
+++ b/Mutagen.Bethesda.Skyrim/Documentation/LinkInterfaceDocumentation_Generated.md
@@ -27,9 +27,6 @@ A `FormLink<IItem>` could then point to all those record types by pointing to th
 - Scroll
 - SoulGem
 - Weapon
-### IDialog
-- DialogResponses
-- DialogTopic
 ### IEffectRecord
 - ObjectEffect
 - Spell
@@ -338,10 +335,6 @@ A `FormLink<IItem>` could then point to all those record types by pointing to th
 - IObjectId
 - IPlaceableObject
 - IReferenceableObject
-### DialogResponses
-- IDialog
-### DialogTopic
-- IDialog
 ### Door
 - IExplodeSpawn
 - IObjectId

--- a/Mutagen.Bethesda.Skyrim/Interfaces/Link/LinkInterfaceMapping_Generated.cs
+++ b/Mutagen.Bethesda.Skyrim/Interfaces/Link/LinkInterfaceMapping_Generated.cs
@@ -283,17 +283,6 @@ internal class SkyrimLinkInterfaceMapping : IInterfaceMapping
                 Setter: typeof(IComplexLocation),
                 Getter: typeof(IComplexLocationGetter)));
         dict[typeof(IComplexLocationGetter)] = dict[typeof(IComplexLocation)] with { Setter = false };
-        dict[typeof(IDialog)] = new InterfaceMappingResult(
-            true,
-            new ILoquiRegistration[]
-            {
-                DialogResponses_Registration.Instance,
-                DialogTopic_Registration.Instance,
-            },
-            new InterfaceMappingTypes(
-                Setter: typeof(IDialog),
-                Getter: typeof(IDialogGetter)));
-        dict[typeof(IDialogGetter)] = dict[typeof(IDialog)] with { Setter = false };
         dict[typeof(IOwner)] = new InterfaceMappingResult(
             true,
             new ILoquiRegistration[]

--- a/Mutagen.Bethesda.Skyrim/Records/Major Records/DialogResponses.xml
+++ b/Mutagen.Bethesda.Skyrim/Records/Major Records/DialogResponses.xml
@@ -9,9 +9,7 @@
       <FormLink name="PreviousDialog" recordType="PNAM" refName="DialogResponses" />
       <Enum name="FavorLevel" enumName="FavorLevel" byteLength="1" recordType="CNAM" />
       <List name="LinkTo">
-        <FormLink recordType="TCLT">
-          <Interface>IDialog</Interface>
-        </FormLink>
+        <FormLink recordType="TCLT" refName="DialogTopic" />
       </List>
       <FormLink name="ResponseData" recordType="DNAM" refName="DialogResponses" />
       <RefList name="Responses" refName="DialogResponse" />
@@ -22,7 +20,6 @@
       <FormLink name="WalkAwayTopic" recordType="TWAT" refName="DialogTopic" />
       <FormLink name="AudioOutputOverride" recordType="ONAM" refName="SoundOutputModel" />
     </Fields>
-    <LinkInterface>IDialog</LinkInterface>
   </Object>
   <Object name="DialogResponseFlags" objType="Subrecord" recordType="ENAM">
     <Fields>

--- a/Mutagen.Bethesda.Skyrim/Records/Major Records/DialogResponses_Generated.cs
+++ b/Mutagen.Bethesda.Skyrim/Records/Major Records/DialogResponses_Generated.cs
@@ -125,15 +125,15 @@ namespace Mutagen.Bethesda.Skyrim
         #endregion
         #region LinkTo
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
-        private ExtendedList<IFormLinkGetter<IDialogGetter>> _LinkTo = new ExtendedList<IFormLinkGetter<IDialogGetter>>();
-        public ExtendedList<IFormLinkGetter<IDialogGetter>> LinkTo
+        private ExtendedList<IFormLinkGetter<IDialogTopicGetter>> _LinkTo = new ExtendedList<IFormLinkGetter<IDialogTopicGetter>>();
+        public ExtendedList<IFormLinkGetter<IDialogTopicGetter>> LinkTo
         {
             get => this._LinkTo;
             init => this._LinkTo = value;
         }
         #region Interface Members
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
-        IReadOnlyList<IFormLinkGetter<IDialogGetter>> IDialogResponsesGetter.LinkTo => _LinkTo;
+        IReadOnlyList<IFormLinkGetter<IDialogTopicGetter>> IDialogResponsesGetter.LinkTo => _LinkTo;
         #endregion
 
         #endregion
@@ -1342,7 +1342,6 @@ namespace Mutagen.Bethesda.Skyrim
     #region Interface
     public partial interface IDialogResponses :
         IAssetLinkContainer,
-        IDialog,
         IDialogResponsesGetter,
         IFormLinkContainer,
         IHaveVirtualMachineAdapter,
@@ -1358,7 +1357,7 @@ namespace Mutagen.Bethesda.Skyrim
         new IFormLinkNullable<IDialogTopicGetter> Topic { get; set; }
         new IFormLinkNullable<IDialogResponsesGetter> PreviousDialog { get; set; }
         new FavorLevel? FavorLevel { get; set; }
-        new ExtendedList<IFormLinkGetter<IDialogGetter>> LinkTo { get; }
+        new ExtendedList<IFormLinkGetter<IDialogTopicGetter>> LinkTo { get; }
         new IFormLinkNullable<IDialogResponsesGetter> ResponseData { get; set; }
         new ExtendedList<DialogResponse> Responses { get; }
         new ExtendedList<Condition> Conditions { get; }
@@ -1385,7 +1384,6 @@ namespace Mutagen.Bethesda.Skyrim
         ISkyrimMajorRecordGetter,
         IAssetLinkContainerGetter,
         IBinaryItem,
-        IDialogGetter,
         IFormLinkContainerGetter,
         IHaveVirtualMachineAdapterGetter,
         ILoquiObject<IDialogResponsesGetter>,
@@ -1403,7 +1401,7 @@ namespace Mutagen.Bethesda.Skyrim
         IFormLinkNullableGetter<IDialogTopicGetter> Topic { get; }
         IFormLinkNullableGetter<IDialogResponsesGetter> PreviousDialog { get; }
         FavorLevel? FavorLevel { get; }
-        IReadOnlyList<IFormLinkGetter<IDialogGetter>> LinkTo { get; }
+        IReadOnlyList<IFormLinkGetter<IDialogTopicGetter>> LinkTo { get; }
         IFormLinkNullableGetter<IDialogResponsesGetter> ResponseData { get; }
         IReadOnlyList<IDialogResponseGetter> Responses { get; }
         IReadOnlyList<IConditionGetter> Conditions { get; }
@@ -2486,7 +2484,7 @@ namespace Mutagen.Bethesda.Skyrim
                 {
                     item.LinkTo.SetTo(
                         rhs.LinkTo
-                            .Select(b => (IFormLinkGetter<IDialogGetter>)new FormLink<IDialogGetter>(b.FormKey)));
+                            .Select(b => (IFormLinkGetter<IDialogTopicGetter>)new FormLink<IDialogTopicGetter>(b.FormKey)));
                 }
                 catch (Exception ex)
                 when (errorMask != null)
@@ -2790,10 +2788,10 @@ namespace Mutagen.Bethesda.Skyrim
                 item.FavorLevel,
                 length: 1,
                 header: translationParams.ConvertToCustom(RecordTypes.CNAM));
-            Mutagen.Bethesda.Plugins.Binary.Translations.ListBinaryTranslation<IFormLinkGetter<IDialogGetter>>.Instance.Write(
+            Mutagen.Bethesda.Plugins.Binary.Translations.ListBinaryTranslation<IFormLinkGetter<IDialogTopicGetter>>.Instance.Write(
                 writer: writer,
                 items: item.LinkTo,
-                transl: (MutagenWriter subWriter, IFormLinkGetter<IDialogGetter> subItem, TypedWriteParams conv) =>
+                transl: (MutagenWriter subWriter, IFormLinkGetter<IDialogTopicGetter> subItem, TypedWriteParams conv) =>
                 {
                     FormLinkBinaryTranslation.Instance.Write(
                         writer: subWriter,
@@ -2964,7 +2962,7 @@ namespace Mutagen.Bethesda.Skyrim
                 case RecordTypeInts.TCLT:
                 {
                     item.LinkTo.SetTo(
-                        Mutagen.Bethesda.Plugins.Binary.Translations.ListBinaryTranslation<IFormLinkGetter<IDialogGetter>>.Instance.Parse(
+                        Mutagen.Bethesda.Plugins.Binary.Translations.ListBinaryTranslation<IFormLinkGetter<IDialogTopicGetter>>.Instance.Parse(
                             reader: frame,
                             triggeringRecord: translationParams.ConvertToCustom(RecordTypes.TCLT),
                             transl: FormLinkBinaryTranslation.Instance.Parse));
@@ -3129,7 +3127,7 @@ namespace Mutagen.Bethesda.Skyrim
         private int? _FavorLevelLocation;
         public FavorLevel? FavorLevel => _FavorLevelLocation.HasValue ? (FavorLevel)HeaderTranslation.ExtractSubrecordMemory(_recordData, _FavorLevelLocation!.Value, _package.MetaData.Constants)[0] : default(FavorLevel?);
         #endregion
-        public IReadOnlyList<IFormLinkGetter<IDialogGetter>> LinkTo { get; private set; } = Array.Empty<IFormLinkGetter<IDialogGetter>>();
+        public IReadOnlyList<IFormLinkGetter<IDialogTopicGetter>> LinkTo { get; private set; } = Array.Empty<IFormLinkGetter<IDialogTopicGetter>>();
         #region ResponseData
         private int? _ResponseDataLocation;
         public IFormLinkNullableGetter<IDialogResponsesGetter> ResponseData => FormLinkBinaryTranslation.Instance.NullableRecordOverlayFactory<IDialogResponsesGetter>(_package, _recordData, _ResponseDataLocation);
@@ -3259,10 +3257,10 @@ namespace Mutagen.Bethesda.Skyrim
                 }
                 case RecordTypeInts.TCLT:
                 {
-                    this.LinkTo = BinaryOverlayList.FactoryByArray<IFormLinkGetter<IDialogGetter>>(
+                    this.LinkTo = BinaryOverlayList.FactoryByArray<IFormLinkGetter<IDialogTopicGetter>>(
                         mem: stream.RemainingMemory,
                         package: _package,
-                        getter: (s, p) => FormLinkBinaryTranslation.Instance.OverlayFactory<IDialogGetter>(p, s),
+                        getter: (s, p) => FormLinkBinaryTranslation.Instance.OverlayFactory<IDialogTopicGetter>(p, s),
                         locs: ParseRecordLocations(
                             stream: stream,
                             constants: _package.MetaData.Constants.SubConstants,

--- a/Mutagen.Bethesda.Skyrim/Records/Major Records/DialogTopic.xml
+++ b/Mutagen.Bethesda.Skyrim/Records/Major Records/DialogTopic.xml
@@ -19,6 +19,5 @@
       <Int32 name="Unknown" binary="NoGeneration" />
       <RefList name="Responses" binary="NoGeneration" refName="DialogResponses" />
     </Fields>
-    <LinkInterface>IDialog</LinkInterface>
   </Object>
 </Loqui>

--- a/Mutagen.Bethesda.Skyrim/Records/Major Records/DialogTopic_Generated.cs
+++ b/Mutagen.Bethesda.Skyrim/Records/Major Records/DialogTopic_Generated.cs
@@ -972,7 +972,6 @@ namespace Mutagen.Bethesda.Skyrim
     #region Interface
     public partial interface IDialogTopic :
         IAssetLinkContainer,
-        IDialog,
         IDialogTopicGetter,
         IFormLinkContainer,
         ILoquiObjectSetter<IDialogTopicInternal>,
@@ -1011,7 +1010,6 @@ namespace Mutagen.Bethesda.Skyrim
         ISkyrimMajorRecordGetter,
         IAssetLinkContainerGetter,
         IBinaryItem,
-        IDialogGetter,
         IFormLinkContainerGetter,
         ILoquiObject<IDialogTopicGetter>,
         IMajorRecordGetterEnumerable,

--- a/Mutagen.Bethesda.Skyrim/Records/SkyrimMod_Generated.cs
+++ b/Mutagen.Bethesda.Skyrim/Records/SkyrimMod_Generated.cs
@@ -8799,10 +8799,6 @@ namespace Mutagen.Bethesda.Skyrim
                         type: type,
                         keys: keys);
                     break;
-                case "IDialog":
-                case "IDialogGetter":
-                    Remove(obj, keys, typeof(IDialogTopicGetter), throwIfUnknown: throwIfUnknown);
-                    break;
                 case "IOwner":
                 case "IOwnerGetter":
                     Remove(obj, keys, typeof(IFactionGetter), throwIfUnknown: throwIfUnknown);

--- a/Mutagen.Bethesda.Skyrim/Records/TypeSolidifier_Generated.cs
+++ b/Mutagen.Bethesda.Skyrim/Records/TypeSolidifier_Generated.cs
@@ -3131,30 +3131,6 @@ namespace Mutagen.Bethesda.Skyrim
         }
 
         /// <summary>
-        /// Scope a load order query to IDialog
-        /// </summary>
-        /// <param name="listings">ModListings to query</param>
-        /// <returns>A typed object to do further queries on IDialog</returns>
-        public static TypedLoadOrderAccess<ISkyrimMod, ISkyrimModGetter, IDialog, IDialogGetter> IDialog(this IEnumerable<IModListingGetter<ISkyrimModGetter>> listings)
-        {
-            return new TypedLoadOrderAccess<ISkyrimMod, ISkyrimModGetter, IDialog, IDialogGetter>(
-                (bool includeDeletedRecords) => listings.WinningOverrides<IDialogGetter>(includeDeletedRecords: includeDeletedRecords),
-                (ILinkCache linkCache, bool includeDeletedRecords) => listings.WinningContextOverrides<ISkyrimMod, ISkyrimModGetter, IDialog, IDialogGetter>(linkCache, includeDeletedRecords: includeDeletedRecords));
-        }
-
-        /// <summary>
-        /// Scope a load order query to IDialog
-        /// </summary>
-        /// <param name="mods">Mods to query</param>
-        /// <returns>A typed object to do further queries on IDialog</returns>
-        public static TypedLoadOrderAccess<ISkyrimMod, ISkyrimModGetter, IDialog, IDialogGetter> IDialog(this IEnumerable<ISkyrimModGetter> mods)
-        {
-            return new TypedLoadOrderAccess<ISkyrimMod, ISkyrimModGetter, IDialog, IDialogGetter>(
-                (bool includeDeletedRecords) => mods.WinningOverrides<IDialogGetter>(includeDeletedRecords: includeDeletedRecords),
-                (ILinkCache linkCache, bool includeDeletedRecords) => mods.WinningContextOverrides<ISkyrimMod, ISkyrimModGetter, IDialog, IDialogGetter>(linkCache, includeDeletedRecords: includeDeletedRecords));
-        }
-
-        /// <summary>
         /// Scope a load order query to IOwner
         /// </summary>
         /// <param name="listings">ModListings to query</param>


### PR DESCRIPTION
Only a IDialogTopicGetter can be linked to, not IDialogResponsesGetter. The original implementation was based on xEdit definitions, but the CK only allows IDialogTopicGetter and there are no instances of IDialogResponsesGetter being used.