### PR TITLE
Important! Fix asset link

### DIFF
--- a/Mutagen.Bethesda.Core.UnitTests/Plugins/Assets/AssetLinkPathingTests.cs
+++ b/Mutagen.Bethesda.Core.UnitTests/Plugins/Assets/AssetLinkPathingTests.cs
@@ -21,6 +21,16 @@ public class AssetLinkPathingTests
     }
 
     [Fact]
+    public void AbsolutePathWithoutDataDirectory()
+    {
+        var path = @$"{absPrefix}{Path.Combine("MyMod", "Meshes", "Clutter", "MyMesh.nif")}";
+        Assert.Throws<AssetPathMisalignedException>(() =>
+        {
+            new AssetLink<TestAssetType>(path);
+        });
+    }
+
+    [Fact]
     public void DataRelativePath()
     {
         var path = Path.Combine("Data", "Meshes", "Clutter", "MyMesh.nif");

--- a/Mutagen.Bethesda.Core/Plugins/Assets/AssetLink.cs
+++ b/Mutagen.Bethesda.Core/Plugins/Assets/AssetLink.cs
@@ -15,7 +15,7 @@ public class AssetLinkGetter<TAssetType> :
     IAssetLinkGetter<TAssetType>
     where TAssetType : class, IAssetType
 {
-    protected DataRelativePath _DataRelativePath;
+    protected DataRelativePath _dataRelativePath;
     protected string _givenPath;
     protected static readonly TAssetType AssetInstance;
     public static readonly AssetLinkGetter<TAssetType> Null = new();
@@ -29,7 +29,7 @@ public class AssetLinkGetter<TAssetType> :
 
     public AssetLinkGetter()
     {
-        _DataRelativePath = Bethesda.Assets.DataRelativePath.NullPath;
+        _dataRelativePath = Bethesda.Assets.DataRelativePath.NullPath;
         _givenPath = Bethesda.Assets.DataRelativePath.NullPath;
     }
 
@@ -37,14 +37,14 @@ public class AssetLinkGetter<TAssetType> :
     {
         if (dataRelativePath.Path == Bethesda.Assets.DataRelativePath.NullPath)
         {
-            _DataRelativePath = Bethesda.Assets.DataRelativePath.NullPath;
+            _dataRelativePath = Bethesda.Assets.DataRelativePath.NullPath;
             _givenPath = Bethesda.Assets.DataRelativePath.NullPath;
         }
         else
         {
             AssertHasBaseFolder(dataRelativePath.Path);
             _givenPath = dataRelativePath.Path;
-            _DataRelativePath = dataRelativePath;
+            _dataRelativePath = dataRelativePath;
         }
     }
 
@@ -52,13 +52,13 @@ public class AssetLinkGetter<TAssetType> :
     {
         if (path == Bethesda.Assets.DataRelativePath.NullPath)
         {
-            _DataRelativePath = Bethesda.Assets.DataRelativePath.NullPath;
+            _dataRelativePath = Bethesda.Assets.DataRelativePath.NullPath;
             _givenPath = Bethesda.Assets.DataRelativePath.NullPath;
         }
         else
         {
             _givenPath = path;
-            _DataRelativePath = GetDataRelativePath(path);
+            _dataRelativePath = GetDataRelativePath(path);
         }
     }
 
@@ -66,14 +66,14 @@ public class AssetLinkGetter<TAssetType> :
     {
         if (path.Path == Bethesda.Assets.DataRelativePath.NullPath)
         {
-            _DataRelativePath = Bethesda.Assets.DataRelativePath.NullPath;
+            _dataRelativePath = Bethesda.Assets.DataRelativePath.NullPath;
             _givenPath = Bethesda.Assets.DataRelativePath.NullPath;
         }
         else
         {
             _givenPath = path;
-            _DataRelativePath = GetDataRelativePath(path.Path);
-            AssertHasBaseFolder(_DataRelativePath.Path);
+            _dataRelativePath = GetDataRelativePath(path.Path);
+            AssertHasBaseFolder(_dataRelativePath.Path);
         }
     }
 
@@ -115,7 +115,7 @@ public class AssetLinkGetter<TAssetType> :
 
     public string GivenPath => _givenPath;
 
-    public DataRelativePath DataRelativePath => _DataRelativePath.Path;
+    public DataRelativePath DataRelativePath => _dataRelativePath.Path;
 
     public string Extension => Path.GetExtension(GivenPath);
 
@@ -145,7 +145,7 @@ public class AssetLinkGetter<TAssetType> :
 
     public override int GetHashCode()
     {
-        return _DataRelativePath.GetHashCode();
+        return _dataRelativePath.GetHashCode();
     }
 
     public int CompareTo(AssetLinkGetter<TAssetType>? other)
@@ -214,7 +214,7 @@ public class AssetLink<TAssetType> :
         
         if (path.Value.Path.StartsWith(AssetInstance.BaseFolder, DataRelativePath.PathComparison))
         {
-            _DataRelativePath = path.Value;
+            _dataRelativePath = path.Value;
             _givenPath = path.Value.Path;
             return true;
         }
@@ -234,7 +234,7 @@ public class AssetLink<TAssetType> :
         
         if (dataRelativePath.Path.StartsWith(AssetInstance.BaseFolder, DataRelativePath.PathComparison))
         {
-            _DataRelativePath = dataRelativePath;
+            _dataRelativePath = dataRelativePath;
             _givenPath = path;
             return true;
         }
@@ -250,13 +250,13 @@ public class AssetLink<TAssetType> :
         {
             if (value == Bethesda.Assets.DataRelativePath.NullPath)
             {
-                _DataRelativePath = Bethesda.Assets.DataRelativePath.NullPath;
+                _dataRelativePath = Bethesda.Assets.DataRelativePath.NullPath;
                 _givenPath = Bethesda.Assets.DataRelativePath.NullPath;
             }
             else
             {
                 _givenPath = value;
-                _DataRelativePath = GetDataRelativePath(value);
+                _dataRelativePath = GetDataRelativePath(value);
             }
         }
     }
@@ -268,7 +268,7 @@ public class AssetLink<TAssetType> :
 
     public void SetToNull()
     {
-        _DataRelativePath = DataRelativePath.NullPath;
+        _dataRelativePath = DataRelativePath.NullPath;
         _givenPath = DataRelativePath.NullPath;
     }
 
@@ -279,7 +279,7 @@ public class AssetLink<TAssetType> :
 
     public override int GetHashCode()
     {
-        return _DataRelativePath.GetHashCode();
+        return _dataRelativePath.GetHashCode();
     }
 
     public override bool Equals(object? obj)
@@ -296,7 +296,7 @@ public class AssetLink<TAssetType> :
         if (ReferenceEquals(null, other)) return false;
         if (ReferenceEquals(this, other)) return true;
 
-        return _DataRelativePath.Equals(other._DataRelativePath);
+        return _dataRelativePath.Equals(other._dataRelativePath);
     }
 
     public int CompareTo(AssetLink<TAssetType>? other)
@@ -304,7 +304,7 @@ public class AssetLink<TAssetType> :
         if (ReferenceEquals(this, other)) return 0;
         if (ReferenceEquals(null, other)) return 1;
 
-        return _DataRelativePath.CompareTo(other._DataRelativePath);
+        return _dataRelativePath.CompareTo(other._dataRelativePath);
     }
 
     [return: NotNullIfNotNull("asset")]

--- a/Mutagen.Bethesda.Core/Plugins/Assets/AssetLink.cs
+++ b/Mutagen.Bethesda.Core/Plugins/Assets/AssetLink.cs
@@ -1,5 +1,4 @@
 using System.Diagnostics.CodeAnalysis;
-using System.Reflection;
 using Mutagen.Bethesda.Assets;
 using Mutagen.Bethesda.Plugins.Exceptions;
 using Noggog;
@@ -9,9 +8,9 @@ namespace Mutagen.Bethesda.Plugins.Assets;
 /// <summary>
 /// Asset referenced by a record
 /// </summary>
-public class AssetLinkGetter<TAssetType> : 
+public class AssetLinkGetter<TAssetType> :
     IEquatable<AssetLinkGetter<TAssetType>>,
-    IComparable<AssetLinkGetter<TAssetType>>, 
+    IComparable<AssetLinkGetter<TAssetType>>,
     IAssetLinkGetter<TAssetType>
     where TAssetType : class, IAssetType
 {
@@ -19,7 +18,7 @@ public class AssetLinkGetter<TAssetType> :
     protected string _givenPath;
     protected static readonly TAssetType AssetInstance;
     public static readonly AssetLinkGetter<TAssetType> Null = new();
-    
+
     public IAssetType AssetTypeInstance => AssetInstance;
 
     static AssetLinkGetter()
@@ -29,16 +28,16 @@ public class AssetLinkGetter<TAssetType> :
 
     public AssetLinkGetter()
     {
-        _dataRelativePath = Bethesda.Assets.DataRelativePath.NullPath;
-        _givenPath = Bethesda.Assets.DataRelativePath.NullPath;
+        _dataRelativePath = DataRelativePath.NullPath;
+        _givenPath = DataRelativePath.NullPath;
     }
 
     public AssetLinkGetter(DataRelativePath dataRelativePath)
     {
-        if (dataRelativePath.Path == Bethesda.Assets.DataRelativePath.NullPath)
+        if (dataRelativePath.Path == DataRelativePath.NullPath)
         {
-            _dataRelativePath = Bethesda.Assets.DataRelativePath.NullPath;
-            _givenPath = Bethesda.Assets.DataRelativePath.NullPath;
+            _dataRelativePath = DataRelativePath.NullPath;
+            _givenPath = DataRelativePath.NullPath;
         }
         else
         {
@@ -50,10 +49,10 @@ public class AssetLinkGetter<TAssetType> :
 
     public AssetLinkGetter(string path)
     {
-        if (path == Bethesda.Assets.DataRelativePath.NullPath)
+        if (path == DataRelativePath.NullPath)
         {
-            _dataRelativePath = Bethesda.Assets.DataRelativePath.NullPath;
-            _givenPath = Bethesda.Assets.DataRelativePath.NullPath;
+            _dataRelativePath = DataRelativePath.NullPath;
+            _givenPath = DataRelativePath.NullPath;
         }
         else
         {
@@ -64,10 +63,10 @@ public class AssetLinkGetter<TAssetType> :
 
     public AssetLinkGetter(FilePath path)
     {
-        if (path.Path == Bethesda.Assets.DataRelativePath.NullPath)
+        if (path.Path == DataRelativePath.NullPath)
         {
-            _dataRelativePath = Bethesda.Assets.DataRelativePath.NullPath;
-            _givenPath = Bethesda.Assets.DataRelativePath.NullPath;
+            _dataRelativePath = DataRelativePath.NullPath;
+            _givenPath = DataRelativePath.NullPath;
         }
         else
         {
@@ -79,7 +78,7 @@ public class AssetLinkGetter<TAssetType> :
 
     protected static string GetDataRelativePath(string path)
     {
-        if (!Bethesda.Assets.DataRelativePath.HasDataDirectory(path) 
+        if (!DataRelativePath.HasDataDirectory(path)
             && !HasBaseFolder(path))
         {
             path = Path.Combine(AssetInstance.BaseFolder, path);
@@ -91,7 +90,7 @@ public class AssetLinkGetter<TAssetType> :
     protected static bool HasBaseFolder(string path)
     {
         return path.StartsWith(AssetInstance.BaseFolder,
-            Bethesda.Assets.DataRelativePath.PathComparison);
+            DataRelativePath.PathComparison);
     }
 
     protected static void AssertHasBaseFolder(string path)
@@ -105,7 +104,7 @@ public class AssetLinkGetter<TAssetType> :
     protected static string ExtractAssertBaseFolderSubpath(DataRelativePath path)
     {
         if (!path.Path.StartsWith(AssetInstance.BaseFolder,
-                Bethesda.Assets.DataRelativePath.PathComparison))
+                DataRelativePath.PathComparison))
         {
             throw new AssetPathMisalignedException(path.Path, AssetInstance);
         }
@@ -155,11 +154,11 @@ public class AssetLinkGetter<TAssetType> :
 
         return DataRelativePath.CompareTo(other.DataRelativePath);
     }
-    
+
     public bool IsNull => DataRelativePath.IsNull;
 
     [return: NotNullIfNotNull("asset")]
-    public static implicit operator string? (AssetLinkGetter<TAssetType>? asset) => asset?.GivenPath;
+    public static implicit operator string?(AssetLinkGetter<TAssetType>? asset) => asset?.GivenPath;
 
     [return: NotNullIfNotNull("path")]
     public static implicit operator AssetLinkGetter<TAssetType>?(string? path) => path == null ? null : new(path);
@@ -174,8 +173,8 @@ public class AssetLinkGetter<TAssetType> :
 /// <summary>
 /// Asset referenced by a record
 /// </summary>
-public class AssetLink<TAssetType> : 
-    AssetLinkGetter<TAssetType>, 
+public class AssetLink<TAssetType> :
+    AssetLinkGetter<TAssetType>,
     IEquatable<AssetLink<TAssetType>>,
     IComparable<AssetLink<TAssetType>>,
     IAssetLink<AssetLink<TAssetType>, TAssetType>,
@@ -183,12 +182,12 @@ public class AssetLink<TAssetType> :
     where TAssetType : class, IAssetType
 {
     TAssetType IAssetLink<TAssetType>.AssetTypeInstance => AssetInstance;
-    
+
     public AssetLink()
         : base(DataRelativePath.NullPath)
     {
     }
-    
+
     public AssetLink(string path)
         : base(path)
     {
@@ -211,14 +210,14 @@ public class AssetLink<TAssetType> :
             SetToNull();
             return true;
         }
-        
+
         if (path.Value.Path.StartsWith(AssetInstance.BaseFolder, DataRelativePath.PathComparison))
         {
             _dataRelativePath = path.Value;
             _givenPath = path.Value.Path;
             return true;
         }
-        
+
         return false;
     }
 
@@ -231,14 +230,14 @@ public class AssetLink<TAssetType> :
         }
 
         DataRelativePath dataRelativePath = path;
-        
+
         if (dataRelativePath.Path.StartsWith(AssetInstance.BaseFolder, DataRelativePath.PathComparison))
         {
             _dataRelativePath = dataRelativePath;
             _givenPath = path;
             return true;
         }
-        
+
         return false;
     }
 
@@ -248,10 +247,10 @@ public class AssetLink<TAssetType> :
         get => _givenPath;
         set
         {
-            if (value == Bethesda.Assets.DataRelativePath.NullPath)
+            if (value == DataRelativePath.NullPath)
             {
-                _dataRelativePath = Bethesda.Assets.DataRelativePath.NullPath;
-                _givenPath = Bethesda.Assets.DataRelativePath.NullPath;
+                _dataRelativePath = DataRelativePath.NullPath;
+                _givenPath = DataRelativePath.NullPath;
             }
             else
             {

--- a/Mutagen.Bethesda.Core/Plugins/Assets/AssetLink.cs
+++ b/Mutagen.Bethesda.Core/Plugins/Assets/AssetLink.cs
@@ -78,12 +78,19 @@ public class AssetLinkGetter<TAssetType> :
 
     protected static DataRelativePath GetDataRelativePath(string path)
     {
-        if (!DataRelativePath.HasDataDirectory(path)
-            && !HasBaseFolder(path))
+        if (DataRelativePath.HasDataDirectory(path))
+        {
+            var dataRelativePath = new DataRelativePath(path);
+            AssertHasBaseFolder(dataRelativePath.Path);
+            return dataRelativePath;
+        }
+
+        if (!HasBaseFolder(path))
         {
             path = Path.Combine(AssetInstance.BaseFolder, path);
         }
 
+        // No check if the data relative path has a base folder is needed here
         return new DataRelativePath(path);
     }
 

--- a/Mutagen.Bethesda.Core/Plugins/Assets/AssetLink.cs
+++ b/Mutagen.Bethesda.Core/Plugins/Assets/AssetLink.cs
@@ -76,7 +76,7 @@ public class AssetLinkGetter<TAssetType> :
         }
     }
 
-    protected static string GetDataRelativePath(string path)
+    protected static DataRelativePath GetDataRelativePath(string path)
     {
         if (!DataRelativePath.HasDataDirectory(path)
             && !HasBaseFolder(path))
@@ -84,7 +84,7 @@ public class AssetLinkGetter<TAssetType> :
             path = Path.Combine(AssetInstance.BaseFolder, path);
         }
 
-        return path;
+        return new DataRelativePath(path);
     }
 
     protected static bool HasBaseFolder(string path)

--- a/Mutagen.Bethesda.Core/Plugins/Assets/AssetLink.cs
+++ b/Mutagen.Bethesda.Core/Plugins/Assets/AssetLink.cs
@@ -72,7 +72,6 @@ public class AssetLinkGetter<TAssetType> :
         {
             _givenPath = path;
             _dataRelativePath = GetDataRelativePath(path.Path);
-            AssertHasBaseFolder(_dataRelativePath.Path);
         }
     }
 

--- a/Mutagen.Bethesda.Core/Plugins/Assets/AssetLink.cs
+++ b/Mutagen.Bethesda.Core/Plugins/Assets/AssetLink.cs
@@ -58,15 +58,7 @@ public class AssetLinkGetter<TAssetType> :
         else
         {
             _givenPath = path;
-            
-            if (!Bethesda.Assets.DataRelativePath.HasDataDirectory(path) 
-                && !HasBaseFolder(path))
-            {
-                path = Path.Combine(AssetInstance.BaseFolder, path);
-            }
-
-            _DataRelativePath = path;
-            AssertHasBaseFolder(_DataRelativePath.Path);
+            _DataRelativePath = GetDataRelativePath(path);
         }
     }
 
@@ -80,9 +72,20 @@ public class AssetLinkGetter<TAssetType> :
         else
         {
             _givenPath = path;
-            _DataRelativePath = path;
+            _DataRelativePath = GetDataRelativePath(path.Path);
             AssertHasBaseFolder(_DataRelativePath.Path);
         }
+    }
+
+    protected static string GetDataRelativePath(string path)
+    {
+        if (!Bethesda.Assets.DataRelativePath.HasDataDirectory(path) 
+            && !HasBaseFolder(path))
+        {
+            path = Path.Combine(AssetInstance.BaseFolder, path);
+        }
+
+        return path;
     }
 
     protected static bool HasBaseFolder(string path)
@@ -245,8 +248,16 @@ public class AssetLink<TAssetType> :
         get => _givenPath;
         set
         {
-            _givenPath = value;
-            _DataRelativePath = new DataRelativePath(value);
+            if (value == Bethesda.Assets.DataRelativePath.NullPath)
+            {
+                _DataRelativePath = Bethesda.Assets.DataRelativePath.NullPath;
+                _givenPath = Bethesda.Assets.DataRelativePath.NullPath;
+            }
+            else
+            {
+                _givenPath = value;
+                _DataRelativePath = GetDataRelativePath(value);
+            }
         }
     }
 


### PR DESCRIPTION
When setting via GivenPath property or constructor with FilePath it was possible to create an AssetLink that doesn't have a data relative path.