### PR TITLE
Fix GetSpeakers edge cases for Shared Infos

### DIFF
--- a/Mutagen.Bethesda.Skyrim/Records/Assets/VoiceType/VoiceContainer.cs
+++ b/Mutagen.Bethesda.Skyrim/Records/Assets/VoiceType/VoiceContainer.cs
@@ -92,7 +92,7 @@ public class VoiceContainer : ICloneable, IEquatable<VoiceContainer>
             IsDefault = false;
             foreach (var (voiceType, npcs) in other.Voices)
             {
-                _voices.Add(voiceType, npcs);
+                _voices.Add(voiceType, [..npcs]);
             }
             return;
         }

--- a/Mutagen.Bethesda.Skyrim/Records/Assets/VoiceType/VoiceContainer.cs
+++ b/Mutagen.Bethesda.Skyrim/Records/Assets/VoiceType/VoiceContainer.cs
@@ -22,7 +22,7 @@ public class VoiceContainer : ICloneable, IEquatable<VoiceContainer>
     {
         foreach (var voiceType in voiceTypes)
         {
-            _voices.Add(voiceType, new HashSet<FormKey> { npc });
+            _voices.Add(voiceType, [npc]);
         }
     }
 
@@ -55,14 +55,14 @@ public class VoiceContainer : ICloneable, IEquatable<VoiceContainer>
 
     public VoiceContainer(string voiceType)
     {
-        _voices.Add(voiceType, new HashSet<FormKey>());
+        _voices.Add(voiceType, []);
     }
 
     public VoiceContainer(IEnumerable<string> voiceTypes)
     {
         foreach (var voiceType in voiceTypes)
         {
-            _voices.Add(voiceType, new HashSet<FormKey>());
+            _voices.Add(voiceType, []);
         }
     }
     #endregion
@@ -104,10 +104,10 @@ public class VoiceContainer : ICloneable, IEquatable<VoiceContainer>
         {
             if (other._voices.TryGetValue(voiceType, out var otherNpcs))
             {
-                if (npcs.Any())
+                if (npcs.Count > 0)
                 {
                     //We don't have all NPCs of this voice type
-                    if (otherNpcs.Any())
+                    if (otherNpcs.Count > 0)
                     {
                         //Only intersect if other doesn't have all NPCs, otherwise it stays the same
                         npcs.IntersectWith(otherNpcs);
@@ -146,9 +146,9 @@ public class VoiceContainer : ICloneable, IEquatable<VoiceContainer>
             if (_voices.TryGetValue(voiceType, out var otherNpcs))
             {
                 //Don't add anything when we have all NPCs of this voice type
-                if (!otherNpcs.Any()) continue;
+                if (otherNpcs.Count == 0) continue;
 
-                if (npcs.Any())
+                if (npcs.Count > 0)
                 {
                     //Insert as usual
                     foreach (var npc in npcs)
@@ -162,7 +162,7 @@ public class VoiceContainer : ICloneable, IEquatable<VoiceContainer>
                 }
             } else
             {
-                _voices.Add(voiceType, new HashSet<FormKey>(npcs));
+                _voices.Add(voiceType, [..npcs]);
             }
         }
 
@@ -196,7 +196,7 @@ public class VoiceContainer : ICloneable, IEquatable<VoiceContainer>
                     }
 
                     //If all npcs are gone, remove the voice type
-                    if (!npcs.Any())
+                    if (npcs.Count == 0)
                     {
                         removeVoiceTypes.Add(voiceType);
                     }
@@ -232,7 +232,7 @@ public class VoiceContainer : ICloneable, IEquatable<VoiceContainer>
 
         foreach (var (voice, npcs) in _voices)
         {
-            clone._voices.Add(voice, new HashSet<FormKey>(npcs));
+            clone._voices.Add(voice, [..npcs]);
         }
 
         return clone;

--- a/Mutagen.Bethesda.Skyrim/Records/Assets/VoiceType/VoiceTypeAssetLookup.cs
+++ b/Mutagen.Bethesda.Skyrim/Records/Assets/VoiceType/VoiceTypeAssetLookup.cs
@@ -257,7 +257,10 @@ public class VoiceTypeAssetLookup : IAssetCacheComponent
         //Get quest voices
         var questVoices = GetQuestVoices(topic, quest);
 
-        var voiceContainer = GetDialogVoiceContainer(topic, responses, quest, questVoices);
+        //If we have selected default voices, make sure the quest voices are being checked first - they might not be part of default voices
+        var voiceContainer = GetVoices(topic, responses, quest);
+        voiceContainer.IntersectWith(questVoices);
+
         if (voiceContainer.IsDefault)
         {
             voiceContainer = GetAllDefaultVoices();
@@ -265,7 +268,7 @@ public class VoiceTypeAssetLookup : IAssetCacheComponent
 
         foreach (var formKey in voiceContainer.Voices.SelectMany(x =>
                  {
-                     if (x.Value.Any()) return x.Value;
+                     if (x.Value.Count > 0) return x.Value;
 
                      // Get speakers with voice type when the whole voice type is used (there are no speakers)
                      return _speakerVoices
@@ -336,7 +339,6 @@ public class VoiceTypeAssetLookup : IAssetCacheComponent
             var userConditions = responseFormKeys
                 .Select(responseKey =>
                 {
-
                     var responseContext = _formLinkCache.ResolveSimpleContext<IDialogResponsesGetter>(responseKey);
                     if (responseContext is not { Parent.Record: not null }) return null;
 


### PR DESCRIPTION
Actually return speakers based on the conditions of the lines in GetSpeakers
- Don't return no voices when parsing responses that are using shared infos
- Don't return only voices limited to all usages when parsing shared infos