### PR TITLE
VoiceTypeLookup: Fix leveled npcs contributing to GetIsRace and GetIsSex conditions

### DIFF
--- a/Mutagen.Bethesda.Skyrim/Records/Assets/VoiceType/VoiceTypeAssetLookup.cs
+++ b/Mutagen.Bethesda.Skyrim/Records/Assets/VoiceType/VoiceTypeAssetLookup.cs
@@ -15,7 +15,7 @@ public class VoiceTypeAssetLookup : IAssetCacheComponent
     private readonly Dictionary<FormKey, HashSet<FormKey>> _factionNPCs = new();
     private readonly Dictionary<FormKey, HashSet<FormKey>> _classNPCs = new();
     private readonly Dictionary<FormKey, HashSet<FormKey>> _raceNPCs = new();
-    private readonly Dictionary<bool, HashSet<FormKey>> _genderNPCs = new();
+    private readonly Dictionary<MaleFemaleGender, HashSet<FormKey>> _genderNPCs = new();
     private HashSet<FormKey> _childNPCs = null!;
     private readonly Dictionary<FormKey, int> _dialogueSceneAliasIndex = new();
     private readonly Dictionary<FormKey, HashSet<FormKey>> _sharedInfoUsages = new();
@@ -532,8 +532,7 @@ public class VoiceTypeAssetLookup : IAssetCacheComponent
 
                 break;
             case IGetIsSexConditionDataGetter sexConditionDataGetter:
-                var isFemale = sexConditionDataGetter.MaleFemaleGender == MaleFemaleGender.Female;
-                if (_genderNPCs.TryGetValue(isFemale, out var genderNpcFormKeys))
+                if (_genderNPCs.TryGetValue(sexConditionDataGetter.MaleFemaleGender, out var genderNpcFormKeys))
                 {
                     voices = new VoiceContainer(genderNpcFormKeys.ToDictionary(npc => npc, GetVoiceTypes));
                 }
@@ -937,11 +936,11 @@ public class VoiceTypeAssetLookup : IAssetCacheComponent
     #endregion
 
     #region Gender Parser
-    private HashSet<bool> GetGenders(INpcGetter npc)
+    private HashSet<MaleFemaleGender> GetGenders(INpcGetter npc)
     {
         if ((npc.Configuration.TemplateFlags & NpcConfiguration.TemplateFlag.Traits) == 0)
         {
-            return [(npc.Configuration.Flags & NpcConfiguration.Flag.Female) != 0];
+            return [(npc.Configuration.Flags & NpcConfiguration.Flag.Female) != 0 ? MaleFemaleGender.Female : MaleFemaleGender.Male];
         }
 
         return [];

--- a/Mutagen.Bethesda.Skyrim/Records/Assets/VoiceType/VoiceTypeAssetLookup.cs
+++ b/Mutagen.Bethesda.Skyrim/Records/Assets/VoiceType/VoiceTypeAssetLookup.cs
@@ -941,31 +941,10 @@ public class VoiceTypeAssetLookup : IAssetCacheComponent
     {
         if ((npc.Configuration.TemplateFlags & NpcConfiguration.TemplateFlag.Traits) == 0)
         {
-            return new HashSet<bool> { (npc.Configuration.Flags & NpcConfiguration.Flag.Female) != 0 };
+            return [(npc.Configuration.Flags & NpcConfiguration.Flag.Female) != 0];
         }
 
-        return npc.Template.IsNull ? new HashSet<bool>() : GetGenders(npc.Template);
-
-    }
-
-    private HashSet<bool> GetGenders(IFormLinkGetter<INpcSpawnGetter> npcTemplate)
-    {
-        if (npcTemplate.IsNull) return new HashSet<bool>();
-
-        //NPC
-        var npc = npcTemplate.TryResolve<INpcGetter>(_formLinkCache);
-        if (npc != null) return GetGenders(npc);
-
-        //Levelled NPC
-        var leveledNpc = npcTemplate.TryResolve<ILeveledNpcGetter>(_formLinkCache);
-        if (leveledNpc is { Entries: {} })
-        {
-            return leveledNpc.Entries
-                .Select(entry => entry.Data?.Reference).NotNull()
-                .SelectMany(GetGenders).ToHashSet();
-        }
-
-        return new HashSet<bool>();
+        return [];
     }
     #endregion
 
@@ -977,28 +956,7 @@ public class VoiceTypeAssetLookup : IAssetCacheComponent
             return new HashSet<FormKey> { npc.Race.FormKey };
         }
 
-        return npc.Template.IsNull ? new HashSet<FormKey>() : GetRaces(npc.Template);
-
-    }
-
-    private HashSet<FormKey> GetRaces(IFormLinkGetter<INpcSpawnGetter> npcTemplate)
-    {
-        if (npcTemplate.IsNull) return new HashSet<FormKey>();
-
-        //NPC
-        var npc = npcTemplate.TryResolve<INpcGetter>(_formLinkCache);
-        if (npc != null) return GetRaces(npc);
-
-        //Levelled NPC
-        var leveledNpc = npcTemplate.TryResolve<ILeveledNpcGetter>(_formLinkCache);
-        if (leveledNpc is { Entries: {} })
-        {
-            return leveledNpc.Entries
-                .Select(entry => entry.Data?.Reference).NotNull()
-                .SelectMany(GetRaces).ToHashSet();
-        }
-
-        return new HashSet<FormKey>();
+        return [];
     }
     #endregion
 }


### PR DESCRIPTION
Leveled npcs that potentially have a certain race or sex contributing all their potential voice types of races they could be to the GetIsRace condition. This cannot be the case for leveled npcs as the voice type is tied to the race and sex.