### PR TITLE
[FormKeyJsonConverter] Always write the type, even for generic types

### DIFF
--- a/Mutagen.Bethesda.Core.UnitTests/Json/JsonConverterTests.cs
+++ b/Mutagen.Bethesda.Core.UnitTests/Json/JsonConverterTests.cs
@@ -1,3 +1,4 @@
+using Loqui;
 using Shouldly;
 using Mutagen.Bethesda.Json;
 using Mutagen.Bethesda.Plugins;
@@ -16,6 +17,12 @@ public class JsonConverterTests
     class FormKeyClass
     {
         public FormKey Member { get; set; } = TestConstants.Form1;
+    }
+
+    static JsonConverterTests()
+    {
+        Warmup.Init();
+        LoquiRegistration.Register(TestMajorRecord_Registration.Instance);
     }
 
     [Fact]
@@ -174,7 +181,7 @@ public class JsonConverterTests
             Getter = new FormLink<ITestMajorRecordGetter>(TestConstants.Form2)
         };
         JsonConvert.SerializeObject(toSerialize, settings)
-            .ShouldBe($"{{\"Direct\":\"{toSerialize.Direct.FormKey}\",\"Setter\":\"{toSerialize.Direct.FormKey}\",\"Getter\":\"{toSerialize.Direct.FormKey}\"}}");
+            .ShouldBe($"{{\"Direct\":\"{toSerialize.Direct.FormKey}<TestGame.TestMajorRecord>\",\"Setter\":\"{toSerialize.Direct.FormKey}<TestGame.TestMajorRecord>\",\"Getter\":\"{toSerialize.Direct.FormKey}<TestGame.TestMajorRecord>\"}}");
     }
 
     [Fact]
@@ -188,7 +195,7 @@ public class JsonConverterTests
             Setter = new FormLink<ITestMajorRecordGetter>(TestConstants.Form2),
             Getter = new FormLink<ITestMajorRecordGetter>(TestConstants.Form2)
         };
-        var toDeserialize = $"{{\"Direct\":\"{target.Direct.FormKey}\",\"Setter\":\"{target.Direct.FormKey}\",\"Getter\":\"{target.Direct.FormKey}\"}}";
+        var toDeserialize = $"{{\"Direct\":\"{target.Direct.FormKey}<TestGame.TestMajorRecord>\",\"Setter\":\"{target.Direct.FormKey}<TestGame.TestMajorRecord>\",\"Getter\":\"{target.Direct.FormKey}<TestGame.TestMajorRecord>\"}}";
         JsonConvert.DeserializeObject<FormLinkClass>(toDeserialize, settings)!
             .Direct
             .ShouldBe(target.Direct);
@@ -217,7 +224,7 @@ public class JsonConverterTests
             Setter = new FormLink<ITestMajorRecordGetter>(FormKey.Null),
             Getter = new FormLink<ITestMajorRecordGetter>(FormKey.Null)
         };
-        var toDeserialize = $"{{\"Direct\":\"Null\",\"Setter\":\"Null\",\"Getter\":\"Null\"}}";
+        var toDeserialize = $"{{\"Direct\":\"Null<TestGame.TestMajorRecord>\",\"Setter\":\"Null<TestGame.TestMajorRecord>\",\"Getter\":\"Null<TestGame.TestMajorRecord>\"}}";
         JsonConvert.DeserializeObject<FormLinkClass>(toDeserialize, settings)!
             .Direct
             .ShouldBe(target.Direct);
@@ -283,7 +290,7 @@ public class JsonConverterTests
     //         Member = new FormLink<ITestMajorRecordGetter>(FormKey.Null)
     //     };
     //     JsonConvert.SerializeObject(toSerialize, settings)
-    //         .ShouldBe($"{{\"Member\":\"Null\"}}");
+    //         .ShouldBe($"{{\"Member\":\"Null<TestGame.TestMajorRecord>\"}}");
     // }
     //
     // [Fact]
@@ -295,7 +302,7 @@ public class JsonConverterTests
     //     {
     //         Member = new FormLink<ITestMajorRecordGetter>(TestConstants.Form2)
     //     };
-    //     var toDeserialize = $"{{\"Member\":\"{target.Member.FormKey}\"}}";
+    //     var toDeserialize = $"{{\"Member\":\"{target.Member.FormKey}<TestGame.TestMajorRecord>\"}}";
     //     JsonConvert.DeserializeObject<NullableFormLinkClass>(toDeserialize, settings)!
     //         .Member
     //         .ShouldBe(target.Member);
@@ -329,7 +336,7 @@ public class JsonConverterTests
     // {
     //     var settings = new JsonSerializerSettings();
     //     settings.Converters.Add(new FormKeyJsonConverter());
-    //     var toDeserialize = $"{{\"Member\":\"Null\"}}";
+    //     var toDeserialize = $"{{\"Member\":\"Null<TestGame.TestMajorRecord>\"}}";
     //     JsonConvert.DeserializeObject<NullableFormLinkClass>(toDeserialize, settings)!
     //         .Member!.IsNull
     //         .ShouldBeTrue();
@@ -352,7 +359,7 @@ public class JsonConverterTests
             Member = new FormLinkNullable<ITestMajorRecordGetter>(TestConstants.Form2)
         };
         JsonConvert.SerializeObject(toSerialize, settings)
-            .ShouldBe($"{{\"Member\":\"{toSerialize.Member.FormKey}\"}}");
+            .ShouldBe($"{{\"Member\":\"{toSerialize.Member.FormKey}<TestGame.TestMajorRecord>\"}}");
     }
 
     [Fact]
@@ -365,7 +372,7 @@ public class JsonConverterTests
             Member = new FormLinkNullable<ITestMajorRecordGetter>(default(FormKey?))
         };
         JsonConvert.SerializeObject(toSerialize, settings)
-            .ShouldBe($"{{\"Member\":null}}");
+            .ShouldBe($"{{\"Member\":\"Null<TestGame.TestMajorRecord>\"}}");
     }
 
     [Fact]
@@ -378,7 +385,7 @@ public class JsonConverterTests
             Member = new FormLinkNullable<ITestMajorRecordGetter>(FormKey.Null)
         };
         JsonConvert.SerializeObject(toSerialize, settings)
-            .ShouldBe($"{{\"Member\":\"Null\"}}");
+            .ShouldBe($"{{\"Member\":\"Null<TestGame.TestMajorRecord>\"}}");
     }
 
     [Fact]
@@ -390,7 +397,7 @@ public class JsonConverterTests
         {
             Member = new FormLinkNullable<ITestMajorRecordGetter>(TestConstants.Form2)
         };
-        var toDeserialize = $"{{\"Member\":\"{target.Member.FormKey}\"}}";
+        var toDeserialize = $"{{\"Member\":\"{target.Member.FormKey}<TestGame.TestMajorRecord>\"}}";
         JsonConvert.DeserializeObject<FormLinkNullableClass>(toDeserialize, settings)!
             .Member
             .ShouldBe(target.Member);
@@ -447,7 +454,7 @@ public class JsonConverterTests
         {
             Member = new FormLinkNullable<ITestMajorRecordGetter>(FormKey.Null)
         };
-        var toDeserialize = $"{{\"Member\":\"Null\"}}";
+        var toDeserialize = $"{{\"Member\":\"Null<TestGame.TestMajorRecord>\"}}";
         JsonConvert.DeserializeObject<FormLinkNullableClass>(toDeserialize, settings)!
             .Member
             .ShouldBe(target.Member);
@@ -547,15 +554,14 @@ public class JsonConverterTests
     [Fact]
     public void FormLinkInformationConverter_FormLink_Deserialize_Null()
     {
-        Warmup.Init();
         var settings = new JsonSerializerSettings();
         settings.Converters.Add(new FormKeyJsonConverter());
         var target = new FormLinkInformationClass()
         {
-            Interface = new FormLinkInformation(FormKey.Null, typeof(IMajorRecordGetter)),
-            Direct = new FormLinkInformation(FormKey.Null, typeof(IMajorRecordGetter)),
+            Interface = new FormLinkInformation(FormKey.Null, typeof(ITestMajorRecordGetter)),
+            Direct = new FormLinkInformation(FormKey.Null, typeof(ITestMajorRecordGetter)),
         };
-        var toDeserialize = $"{{\"Direct\":\"Null\",\"Interface\":\"Null\"}}";
+        var toDeserialize = $"{{\"Direct\":\"Null<TestGame.TestMajorRecord>\",\"Interface\":\"Null<TestGame.TestMajorRecord>\"}}";
         JsonConvert.DeserializeObject<FormLinkInformationClass>(toDeserialize, settings)!
             .Direct
             .ShouldBe(target.Direct);
@@ -565,9 +571,24 @@ public class JsonConverterTests
     }
     
     [Fact]
+    public void FormLinkInformationConverter_FormLink_Serialize_Deserialize_Generic_Interface()
+    {
+        var settings = new JsonSerializerSettings();
+        settings.Converters.Add(new FormKeyJsonConverter());
+        var formKey = FormKey.Factory("123456:Mod.esm");
+        var target = new FormLinkInformationClass()
+        {
+            Interface = new FormLink<ITestMajorRecordGetter>(formKey),
+        };
+        var serialize = JsonConvert.SerializeObject(target, settings);
+        JsonConvert.DeserializeObject<FormLinkInformationClass>(serialize, settings)!
+            .Interface
+            .ShouldBe(target.Interface);
+    }
+    
+    [Fact]
     public void FormLinkInformationConverter_FormLink_Deserialize()
     {
-        Warmup.Init();
         var settings = new JsonSerializerSettings();
         settings.Converters.Add(new FormKeyJsonConverter());
         var target = new FormLinkInformationClass()
@@ -587,7 +608,6 @@ public class JsonConverterTests
     [Fact]
     public void FormLinkInformationConverter_FormLink_Serialize_Null()
     {
-        Warmup.Init();
         var settings = new JsonSerializerSettings();
         settings.Converters.Add(new FormKeyJsonConverter());
         var target = new FormLinkInformationClass()
@@ -603,7 +623,6 @@ public class JsonConverterTests
     [Fact]
     public void FormLinkInformationConverter_FormLink_Serialize()
     {
-        Warmup.Init();
         var settings = new JsonSerializerSettings();
         settings.Converters.Add(new FormKeyJsonConverter());
         var target = new FormLinkInformationClass()
@@ -619,7 +638,6 @@ public class JsonConverterTests
     [Fact]
     public void FormLinkInformationConverter_FormLink_Deserialize_Empty()
     {
-        Warmup.Init();
         var settings = new JsonSerializerSettings();
         settings.Converters.Add(new FormKeyJsonConverter());
         var target = new FormLinkInformationClass()

--- a/Mutagen.Bethesda.Core.UnitTests/Placeholders/TestMajorRecord_Registration.cs
+++ b/Mutagen.Bethesda.Core.UnitTests/Placeholders/TestMajorRecord_Registration.cs
@@ -1,0 +1,32 @@
+﻿using Loqui;
+using Noggog;
+namespace Mutagen.Bethesda.UnitTests.Placeholders;
+
+internal class TestMajorRecord_Registration : ILoquiRegistration
+{
+    public static TestMajorRecord_Registration Instance { get; } = new();
+
+    public string GetNthName(ushort index) => throw new NotImplementedException();
+    public bool GetNthIsLoqui(ushort index) => throw new NotImplementedException();
+    public bool GetNthIsEnumerable(ushort index) => throw new NotImplementedException();
+    public bool GetNthIsSingleton(ushort index) => throw new NotImplementedException();
+    public bool IsNthDerivative(ushort index) => throw new NotImplementedException();
+    public Type GetNthType(ushort index) => throw new NotImplementedException();
+    public ushort? GetNameIndex(StringCaseAgnostic name) => throw new NotImplementedException();
+    public bool IsProtected(ushort index) => throw new NotImplementedException();
+    public ProtocolKey ProtocolKey { get; } = new("TestGame");
+    public ushort AdditionalFieldCount { get; }
+    public ushort FieldCount { get; }
+    public Type MaskType => null!;
+    public Type ErrorMaskType => null!;
+    public Type ClassType { get; } = typeof(TestMajorRecord);
+    public Type GetterType { get; } = typeof(ITestMajorRecordGetter);
+    public Type SetterType { get; } = typeof(ITestMajorRecord);
+    public Type? InternalGetterType { get; }
+    public Type? InternalSetterType { get; }
+    public string FullName => "Mutagen.Bethesda.TestGame.TestMajorRecord";
+    public string Name => "TestMajorRecord";
+    public string Namespace => "Mutagen.Bethesda";
+    public byte GenericCount { get; }
+    public Type? GenericRegistrationType { get; }
+}

--- a/Mutagen.Bethesda.Json/FormKeyJsonConverter.cs
+++ b/Mutagen.Bethesda.Json/FormKeyJsonConverter.cs
@@ -50,7 +50,7 @@ public sealed class FormKeyJsonConverter : JsonConverter
         else
         {
             var str = obj.ToString();
-                
+
             if (objectType == typeof(FormKey))
             {
                 if (str.IsNullOrWhitespace())
@@ -85,24 +85,23 @@ public sealed class FormKeyJsonConverter : JsonConverter
                 if (str.IsNullOrWhitespace())
                 {
                     key = FormKey.Null;
-                }
-                else
-                {
-                    key = FormKey.Factory(str);
+                    if (objectType.GenericTypeArguments.Length == 0)
+                    {
+                        throw new ArgumentException("Empty string to parse to a generic type without a given type argument is not supported");
+                    }
+                    else
+                    {
+                        return GetFormLink(objectType.GenericTypeArguments[0], key);
+                    }
                 }
                 
-                if (IsNullableLink(objectType))
-                {
-                    return Activator.CreateInstance(
-                        typeof(FormLinkNullable<>).MakeGenericType(objectType.GenericTypeArguments[0]),
-                        key);
-                }
-                else
-                {
-                    return Activator.CreateInstance(
-                        typeof(FormLink<>).MakeGenericType(objectType.GenericTypeArguments[0]),
-                        key);
-                }
+                (key, var regis) = ParseFormKeyAndType(str);
+                
+                var type = objectType.GenericTypeArguments.Length == 0
+                    ? regis.GetterType
+                    : objectType.GenericTypeArguments[0];
+                
+                return GetFormLink(type, key);
             }
             else
             {
@@ -111,39 +110,61 @@ public sealed class FormKeyJsonConverter : JsonConverter
                     return new FormLinkInformation(FormKey.Null, typeof(IMajorRecordGetter));
                 }
                 
-                var span = str.AsSpan();
-                var startIndex = span.IndexOf('<');
-                if (startIndex == -1)
-                {
-                    throw new ArgumentException();
-                }
-
-                var endIndex = span.IndexOf('>');
-                if (endIndex == -1)
-                {
-                    throw new ArgumentException();
-                }
-
-                var typeName = span.Slice(startIndex + 1, endIndex - 1 - startIndex).ToString();
-
-                var lastPeriod = typeName.LastIndexOf(".", StringComparison.Ordinal);
-                if (lastPeriod != -1 && typeName[(lastPeriod + 1)..] == "MajorRecord")
-                {
-                    typeName = "Mutagen.Bethesda.Plugins.Records.MajorRecord";
-                }
-                else if (!typeName.StartsWith("Mutagen.Bethesda."))
-                {
-                    typeName = "Mutagen.Bethesda." + typeName;
-                }
-                var regis = LoquiRegistration.GetRegisterByFullName(typeName);
-                if (regis == null)
-                {
-                    throw new ArgumentException($"Unknown object type: {typeName}");
-                }
-
+                var (key, regis) = ParseFormKeyAndType(str);
+                
                 return new FormLinkInformation(
-                    FormKey.Factory(span.Slice(0, startIndex)),
+                    key,
                     regis.GetterType);
+            }
+        }
+        
+        (FormKey FormKey, ILoquiRegistration Registration) ParseFormKeyAndType(string str) {
+            var span = str.AsSpan();
+            var startIndex = span.IndexOf('<');
+            if (startIndex == -1)
+            {
+                throw new ArgumentException();
+            }
+            
+            var endIndex = span.IndexOf('>');
+            if (endIndex == -1)
+            {
+                throw new ArgumentException();
+            }
+            
+            var key = FormKey.Factory(span[..startIndex]);
+            var typeName = span.Slice(startIndex + 1, endIndex - 1 - startIndex).ToString();
+            
+            var lastPeriod = typeName.LastIndexOf('.');
+            if (lastPeriod != -1 && typeName[(lastPeriod + 1)..] == "MajorRecord")
+            {
+                typeName = "Mutagen.Bethesda.Plugins.Records.MajorRecord";
+            }
+            else if (!typeName.StartsWith("Mutagen.Bethesda."))
+            {
+                typeName = "Mutagen.Bethesda." + typeName;
+            }
+            var regis = LoquiRegistration.GetRegisterByFullName(typeName);
+            if (regis == null)
+            {
+                throw new ArgumentException($"Unknown object type: {typeName}");
+            }
+            
+            return (key, regis);
+        }
+        
+        object? GetFormLink(Type type, FormKey key) {
+            if (IsNullableLink(objectType))
+            {
+                return Activator.CreateInstance(
+                    typeof(FormLinkNullable<>).MakeGenericType(type),
+                    key);
+            }
+            else
+            {
+                return Activator.CreateInstance(
+                    typeof(FormLink<>).MakeGenericType(type),
+                    key);
             }
         }
     }
@@ -160,9 +181,6 @@ public sealed class FormKeyJsonConverter : JsonConverter
         {
             case FormKey fk:
                 writer.WriteValue(fk.ToString());
-                break;
-            case IFormLinkGetter fl when fl.GetType().IsGenericType:
-                writer.WriteValue(fl.FormKeyNullable?.ToString());
                 break;
             case IFormLinkIdentifier ident:
                 writer.WriteValue(IFormLinkIdentifier.GetString(ident, simpleType: true));


### PR DESCRIPTION
The problem is when the given type is a `IFormLinkGetter` without any generics which is set to a form link with an interface type like `IFormLinkGetter<INpcGetter>`. This would make the converter write a form key without any type info because it sees that the given type is actually a generic type even though the member type is just `IFormLinkGetter` .
But when trying to deserialize the form link again to a `IFormLinkGetter` it doesn't recognize this as a generic type and will expect a type info at the end of the string it reads, resulting in an exception.

Always adding the type info fixes this behavior, and due to Mutagen's handling of interface types this still works well. I hope this doesn't break anything else though! Tests seems to be fine after modifying them to the new behavior.

One change that there is due to this is that null form keys will also write a null form key with type, and not the actual null object.