### PR TITLE
Fix for some conditions not being marked as FormIDs properly

### DIFF
--- a/Mutagen.Bethesda.Fallout4/Records/Common Subrecords/Condition.cs
+++ b/Mutagen.Bethesda.Fallout4/Records/Common Subrecords/Condition.cs
@@ -879,13 +879,11 @@ public static class ParameterTypeMixIn
             case ParameterType.Float:
             case ParameterType.VariableName:
             case ParameterType.Sex:
-            case ParameterType.ActorValue:
             case ParameterType.CrimeType:
             case ParameterType.Axis:
             case ParameterType.QuestStage:
             case ParameterType.MiscStat:
             case ParameterType.Alignment:
-            case ParameterType.EquipType:
             case ParameterType.FormType:
             case ParameterType.CriticalStage:
             case ParameterType.VATSValueFunction:
@@ -931,6 +929,8 @@ public static class ParameterTypeMixIn
             case ParameterType.Scene:
             case ParameterType.EventData:
             case ParameterType.DamageType:
+            case ParameterType.ActorValue:
+            case ParameterType.EquipType:
                 return ParameterCategory.Form;
             case ParameterType.String:
                 return ParameterCategory.String;

--- a/Mutagen.Bethesda.Skyrim/Records/Common Subrecords/Condition.cs
+++ b/Mutagen.Bethesda.Skyrim/Records/Common Subrecords/Condition.cs
@@ -777,13 +777,11 @@ public static class ParameterTypeMixIn
             case ParameterType.Float:
             case ParameterType.VariableName:
             case ParameterType.Sex:
-            case ParameterType.ActorValue:
             case ParameterType.CrimeType:
             case ParameterType.Axis:
             case ParameterType.QuestStage:
             case ParameterType.MiscStat:
             case ParameterType.Alignment:
-            case ParameterType.EquipType:
             case ParameterType.FormType:
             case ParameterType.CriticalStage:
             case ParameterType.VATSValueFunction:
@@ -829,6 +827,8 @@ public static class ParameterTypeMixIn
             case ParameterType.Scene:
             case ParameterType.EventData:
             case ParameterType.Knowable:
+            case ParameterType.ActorValue:
+            case ParameterType.EquipType:
                 return ParameterCategory.Form;
             default:
                 throw new NotImplementedException();


### PR DESCRIPTION
closes #660

Skyrim has more robust condition suite, which doesn't use this call.  But fo4 still uses it because [that work isn't yet done](https://github.com/Mutagen-Modding/Mutagen/issues/411), and so it being wrong was causing misalignment issues.  