### PR TITLE
Add missing ShowAllText flag

### DIFF
--- a/Mutagen.Bethesda.Skyrim/Records/Major Records/Scene.cs
+++ b/Mutagen.Bethesda.Skyrim/Records/Major Records/Scene.cs
@@ -7,6 +7,7 @@ public partial class Scene
     {
         BeginOnQuestStart = 0x001,
         StopQuestOnEnd = 0x002,
+        ShowAllText = 0x004,
         RepeatConditionsWhileTrue = 0x008,
         Interruptable = 0x010,
     }


### PR DESCRIPTION
This is an editor flag to say if all text in a scene should be previewed