### PR TITLE
Make created object alias information more important than conditions

### DIFF
--- a/Mutagen.Bethesda.Skyrim/Records/Assets/VoiceType/VoiceTypeAssetLookup.cs
+++ b/Mutagen.Bethesda.Skyrim/Records/Assets/VoiceType/VoiceTypeAssetLookup.cs
@@ -671,18 +671,18 @@ public class VoiceTypeAssetLookup : IAssetCacheComponent
             }
         }
 
-        //Conditions
-        if (alias.Conditions.Any())
-        {
-            var voices = GetVoices(alias.Conditions, quest, currentMod);
-            if (additionalVoices != null) voices.Insert(additionalVoices);
-            return voices;
-        }
-
         //Created object
         if (alias.CreateReferenceToObject != null)
         {
             var voices = GetVoices(alias.CreateReferenceToObject.Object.FormKey);
+            if (additionalVoices != null) voices.Insert(additionalVoices);
+            return voices;
+        }
+
+        //Conditions
+        if (alias.Conditions.Any())
+        {
+            var voices = GetVoices(alias.Conditions, quest, currentMod);
             if (additionalVoices != null) voices.Insert(additionalVoices);
             return voices;
         }


### PR DESCRIPTION
Simple tweak I found we need when looking into some examples. Sometimes conditions are used for aliases using the create object fill type in something like WEs. In those cases the conditions were not the deciding factor for the voice, the created object is relevant.