### PR TITLE
Fix Game Environment Construction

### DIFF
--- a/Mutagen.Bethesda.Core/Environments/DI/GameEnvironmentProvider.cs
+++ b/Mutagen.Bethesda.Core/Environments/DI/GameEnvironmentProvider.cs
@@ -58,7 +58,7 @@ public sealed class GameEnvironmentProvider : IGameEnvironmentProvider
             loadOrderFilePath: _pluginListingsPathContext.Path,
             creationClubListingsFilePath: _cccPath.Path,
             loadOrder: loadOrder,
-            linkCache: loadOrder.ToUntypedImmutableLinkCache(linkCachePrefs),
+            linkCache: loadOrder.ToUntypedImmutableLinkCache(_gameReleaseContext.Release.ToCategory(), linkCachePrefs),
             assetProvider: _assetProvider,
             dispose: true);
     }
@@ -100,7 +100,7 @@ public sealed class GameEnvironmentProvider<TMod> : IGameEnvironmentProvider<TMo
             loadOrderFilePath: _pluginListingsPathContext.Path,
             creationClubListingsFilePath: _cccPath.Path,
             loadOrder: loadOrder,
-            linkCache: loadOrder.ToUntypedImmutableLinkCache(linkCachePrefs),
+            linkCache: loadOrder.ToUntypedImmutableLinkCache(_gameReleaseContext.Release.ToCategory(), linkCachePrefs),
             assetProvider: _assetProvider,
             dispose: true);
     }


### PR DESCRIPTION
Pass category when known to fix the impossibility to infer the GameCategory from the mods in some load orders, like those without mods or those using the generic IModGetter.

Fixes test error we encountered in https://github.com/Mutagen-Modding/Mutagen.Bethesda.Analyzers/pull/596