### PR TITLE
Load Order Merged Location Fields Extension Methods

### DIFF
--- a/Mutagen.Bethesda.Core/Mutagen.Bethesda.Core.csproj
+++ b/Mutagen.Bethesda.Core/Mutagen.Bethesda.Core.csproj
@@ -285,6 +285,7 @@
         <Compile Include="Plugins\Cache\Internals\Implementations\MutableModLinkCache.cs" />
         <Compile Include="Plugins\Cache\Internals\OverrideMaskRegistrations.cs" />
         <Compile Include="Plugins\Cache\ILinkUsageCache.cs" />
+        <Compile Include="Plugins\Cache\LinkCacheOverridesMixIn.cs" />
         <Compile Include="Plugins\Cache\ResolveTarget.cs" />
         <Compile Include="Plugins\Converters\FormKeyTypeConverter.cs" />
         <Compile Include="Plugins\Converters\ModKeyTypeConverter.cs" />

--- a/Mutagen.Bethesda.Core/Plugins/Cache/LinkCacheOverridesMixIn.cs
+++ b/Mutagen.Bethesda.Core/Plugins/Cache/LinkCacheOverridesMixIn.cs
@@ -4,6 +4,138 @@ namespace Mutagen.Bethesda.Plugins.Cache;
 
 public static class LinkCacheOverridesMixIn
 {
+	#region GetPreviousOverrideContexts
+	/// <summary>
+	/// Gets all previous overrides of a record in the link cache, based on the specified override mod key and resolve target.
+	/// </summary>
+	/// <param name="cache">Link cache to search for previous overrides</param>
+	/// <param name="record">The record for which to find previous overrides</param>
+	/// <param name="overrideModKey">The mod key of the override to start searching from</param>
+	/// <param name="target">Resolution target to look up previous overrides from</param>
+	/// <typeparam name="TMod">The type of Mod to look up</typeparam>
+	/// <typeparam name="TModGetter">The getter type of Mod to look up</typeparam>
+	/// <typeparam name="TMajor">The type of Major Record to look up</typeparam>
+	/// <typeparam name="TMajorGetter">The getter type of Major Record to look up</typeparam>
+	/// <returns>Enumerable of all previous overrides of the record, based on the specified override mod key and resolve target</returns>
+	public static IEnumerable<IModContext<TMod, TModGetter, TMajor, TMajorGetter>> GetPreviousOverrideContexts<TMod, TModGetter, TMajor, TMajorGetter>(this ILinkCache<TMod, TModGetter> cache, TMajor record, ModKey overrideModKey, ResolveTarget target = ResolveTarget.Winner)
+		where TMod : class, TModGetter, IMod
+		where TModGetter : class, IModGetter
+		where TMajor : class, TMajorGetter, IMajorRecord
+		where TMajorGetter : class, IMajorRecordGetter
+	{
+		return target switch
+		{
+			ResolveTarget.Winner => cache.ResolveAllContexts<TMajor, TMajorGetter>(record)
+				.SkipWhile(x => x.ModKey != overrideModKey)
+				.Skip(1),
+			_ => cache.ResolveAllContexts<TMajor, TMajorGetter>(record, ResolveTarget.Origin)
+				.TakeWhile(x => x.ModKey != overrideModKey)
+		};
+	}
+
+	/// <summary>
+	/// Gets all previous overrides of a record in the link cache, based on the specified override mod key and resolve target.
+	/// </summary>
+	/// <param name="cache">Link cache to search for previous overrides</param>
+	/// <param name="formKey">FormKey to find previous overrides for</param>
+	/// <param name="overrideModKey">The mod key of the override to start searching from</param>
+	/// <param name="target">Resolution target to look up previous overrides from</param>
+	/// <typeparam name="TMod">The type of Mod to look up</typeparam>
+	/// <typeparam name="TModGetter">The getter type of Mod to look up</typeparam>
+	/// <typeparam name="TMajor">The type of Major Record to look up</typeparam>
+	/// <typeparam name="TMajorGetter">The getter type of Major Record to look up</typeparam>
+	/// <returns>Enumerable of all previous overrides of the record, based on the specified override mod key and resolve target</returns>
+	public static IEnumerable<IModContext<TMod, TModGetter, IMajorRecord, IMajorRecordGetter>> GetPreviousOverrideContexts<TMod, TModGetter, TMajor, TMajorGetter>(this ILinkCache<TMod, TModGetter> cache, FormKey formKey, ModKey overrideModKey, ResolveTarget target = ResolveTarget.Winner)
+		where TMod : class, TModGetter, IMod
+		where TModGetter : class, IModGetter
+		where TMajor : class, TMajorGetter, IMajorRecord
+		where TMajorGetter : class, IMajorRecordGetter
+	{
+		return target switch
+		{
+			ResolveTarget.Winner => cache.ResolveAllContexts<TMajor, TMajorGetter>(formKey)
+				.SkipWhile(x => x.ModKey != overrideModKey)
+				.Skip(1),
+			_ => cache.ResolveAllContexts<TMajor, TMajorGetter>(formKey, ResolveTarget.Origin)
+				.TakeWhile(x => x.ModKey != overrideModKey)
+		};
+	}
+
+	/// <summary>
+	/// Gets all previous overrides of a record in the link cache, based on the specified override mod key and resolve target.
+	/// </summary>
+	/// <param name="cache">Link cache to search for previous overrides</param>
+	/// <param name="formLink">FormLink to find previous overrides for</param>
+	/// <param name="overrideModKey">The mod key of the override to start searching from</param>
+	/// <param name="target">Resolution target to look up previous overrides from</param>
+	/// <typeparam name="TMod">The type of Mod to look up</typeparam>
+	/// <typeparam name="TModGetter">The getter type of Mod to look up</typeparam>
+	/// <returns>Enumerable of all previous overrides of the record, based on the specified override mod key and resolve target</returns>
+	public static IEnumerable<IModContext<TMod, TModGetter, IMajorRecord, IMajorRecordGetter>> GetPreviousOverrideContexts<TMod, TModGetter>(this ILinkCache<TMod, TModGetter> cache, IFormLinkIdentifier formLink, ModKey overrideModKey, ResolveTarget target = ResolveTarget.Winner)
+		where TMod : class, TModGetter, IMod
+		where TModGetter : class, IModGetter
+	{
+		return target switch
+		{
+			ResolveTarget.Winner => cache.ResolveAllContexts(formLink)
+				.SkipWhile(x => x.ModKey != overrideModKey)
+				.Skip(1),
+			_ => cache.ResolveAllContexts(formLink, ResolveTarget.Origin)
+				.TakeWhile(x => x.ModKey != overrideModKey)
+		};
+	}
+
+	/// <summary>
+	/// Gets all previous overrides of a record in the link cache, based on the specified override mod key and resolve target.
+	/// </summary>
+	/// <param name="cache">Link cache to search for previous overrides</param>
+	/// <param name="formKey">FormKey to find previous overrides for</param>
+	/// <param name="type">The type of record to look up</param>
+	/// <param name="overrideModKey">The mod key of the override to start searching from</param>
+	/// <param name="target">Resolution target to look up previous overrides from</param>
+	/// <typeparam name="TMod">The type of Mod to look up</typeparam>
+	/// <typeparam name="TModGetter">The getter type of Mod to look up</typeparam>
+	/// <returns>Enumerable of all previous overrides of the record, based on the specified override mod key and resolve target</returns>
+	public static IEnumerable<IModContext<TMod, TModGetter, IMajorRecord, IMajorRecordGetter>> GetPreviousOverrideContexts<TMod, TModGetter>(this ILinkCache<TMod, TModGetter> cache, FormKey formKey, Type type, ModKey overrideModKey, ResolveTarget target = ResolveTarget.Winner)
+		where TMod : class, TModGetter, IMod
+		where TModGetter : class, IModGetter
+	{
+		return target switch
+		{
+			ResolveTarget.Winner => cache.ResolveAllContexts(formKey, type)
+				.SkipWhile(x => x.ModKey != overrideModKey)
+				.Skip(1),
+			_ => cache.ResolveAllContexts(formKey, type, ResolveTarget.Origin)
+				.TakeWhile(x => x.ModKey != overrideModKey)
+		};
+	}
+
+	/// <summary>
+	/// Gets all previous overrides of a record in the link cache, based on the specified override mod key and resolve target.
+	/// </summary>
+	/// <param name="cache">Link cache to search for previous overrides</param>
+	/// <param name="formKey">FormKey to find previous overrides for</param>
+	/// <param name="overrideModKey">The mod key of the override to start searching from</param>
+	/// <param name="target">Resolution target to look up previous overrides from</param>
+	/// <typeparam name="TMod">The type of Mod to look up</typeparam>
+	/// <typeparam name="TModGetter">The getter type of Mod to look up</typeparam>
+	/// <returns>Enumerable of all previous overrides of the record, based on the specified override mod key and resolve target</returns>
+	[Obsolete("This call is not as optimized as its generic typed counterpart.  Use as a last resort.")]
+	public static IEnumerable<IModContext<TMod, TModGetter, IMajorRecord, IMajorRecordGetter>> GetPreviousOverrideContexts<TMod, TModGetter>(this ILinkCache<TMod, TModGetter> cache, FormKey formKey, ModKey overrideModKey, ResolveTarget target = ResolveTarget.Winner)
+		where TMod : class, TModGetter, IMod
+		where TModGetter : class, IModGetter
+	{
+		return target switch
+		{
+			ResolveTarget.Winner => cache.ResolveAllContexts(formKey)
+				.SkipWhile(x => x.ModKey != overrideModKey)
+				.Skip(1),
+			_ => cache.ResolveAllContexts(formKey, ResolveTarget.Origin)
+				.TakeWhile(x => x.ModKey != overrideModKey)
+		};
+	}
+	#endregion
+
 	#region GetPreviousOverrideSimpleContexts
 	/// <summary>
 	/// Gets all previous overrides of a record in the link cache, based on the specified override mod key and resolve target.

--- a/Mutagen.Bethesda.Core/Plugins/Cache/LinkCacheOverridesMixIn.cs
+++ b/Mutagen.Bethesda.Core/Plugins/Cache/LinkCacheOverridesMixIn.cs
@@ -1,0 +1,113 @@
+﻿using Mutagen.Bethesda.Plugins.Records;
+namespace Mutagen.Bethesda.Plugins.Cache;
+
+public static class LinkCacheOverridesMixIn
+{
+	#region GetPreviousOverrides
+	/// <summary>
+	/// Gets all previous overrides of a record in the link cache, based on the specified override mod key and resolve target.
+	/// </summary>
+	/// <param name="cache">Link cache to search for previous overrides</param>
+	/// <param name="record">The record for which to find previous overrides</param>
+	/// <param name="overrideModKey">The mod key of the override to start searching from</param>
+	/// <param name="target">Resolution target to look up previous overrides from</param>
+	/// <typeparam name="TMajor">The type of Major Record to look up</typeparam>
+	/// <returns>Enumerable of all previous overrides of the record, based on the specified override mod key and resolve target</returns>
+	public static IEnumerable<IModContext<TMajor>> GetPreviousOverrides<TMajor>(this ILinkCache cache, TMajor record, ModKey overrideModKey, ResolveTarget target = ResolveTarget.Winner)
+		where TMajor : class, IMajorRecordGetter
+	{
+		return target switch
+		{
+			ResolveTarget.Winner => cache.ResolveAllSimpleContexts(record)
+				.SkipWhile(x => x.ModKey != overrideModKey)
+				.Skip(1),
+			_ => cache.ResolveAllSimpleContexts(record, ResolveTarget.Origin)
+				.TakeWhile(x => x.ModKey != overrideModKey)
+		};
+	}
+
+	/// <summary>
+	/// Gets all previous overrides of a record in the link cache, based on the specified override mod key and resolve target.
+	/// </summary>
+	/// <param name="cache">Link cache to search for previous overrides</param>
+	/// <param name="formKey">FormKey to find previous overrides for</param>
+	/// <param name="overrideModKey">The mod key of the override to start searching from</param>
+	/// <param name="target">Resolution target to look up previous overrides from</param>
+	/// <typeparam name="TMajor">The type of Major Record to look up</typeparam>
+	/// <returns>Enumerable of all previous overrides of the record, based on the specified override mod key and resolve target</returns>
+	public static IEnumerable<IModContext<TMajor>> GetPreviousOverrides<TMajor>(this ILinkCache cache, FormKey formKey, ModKey overrideModKey, ResolveTarget target = ResolveTarget.Winner)
+		where TMajor : class, IMajorRecordGetter
+	{
+		return target switch
+		{
+			ResolveTarget.Winner => cache.ResolveAllSimpleContexts<TMajor>(formKey)
+				.SkipWhile(x => x.ModKey != overrideModKey)
+				.Skip(1),
+			_ => cache.ResolveAllSimpleContexts<TMajor>(formKey, ResolveTarget.Origin)
+				.TakeWhile(x => x.ModKey != overrideModKey)
+		};
+	}
+
+	/// <summary>
+	/// Gets all previous overrides of a record in the link cache, based on the specified override mod key and resolve target.
+	/// </summary>
+	/// <param name="cache">Link cache to search for previous overrides</param>
+	/// <param name="formLink">FormLink to find previous overrides for</param>
+	/// <param name="overrideModKey">The mod key of the override to start searching from</param>
+	/// <param name="target">Resolution target to look up previous overrides from</param>
+	/// <returns>Enumerable of all previous overrides of the record, based on the specified override mod key and resolve target</returns>
+	public static IEnumerable<IModContext> GetPreviousOverrides(this ILinkCache cache, IFormLinkIdentifier formLink, ModKey overrideModKey, ResolveTarget target = ResolveTarget.Winner)
+	{
+		return target switch
+		{
+			ResolveTarget.Winner => cache.ResolveAllSimpleContexts(formLink)
+				.SkipWhile(x => x.ModKey != overrideModKey)
+				.Skip(1),
+			_ => cache.ResolveAllSimpleContexts(formLink, ResolveTarget.Origin)
+				.TakeWhile(x => x.ModKey != overrideModKey)
+		};
+	}
+
+	/// <summary>
+	/// Gets all previous overrides of a record in the link cache, based on the specified override mod key and resolve target.
+	/// </summary>
+	/// <param name="cache">Link cache to search for previous overrides</param>
+	/// <param name="formKey">FormKey to find previous overrides for</param>
+	/// <param name="type">The type of record to look up</param>
+	/// <param name="overrideModKey">The mod key of the override to start searching from</param>
+	/// <param name="target">Resolution target to look up previous overrides from</param>
+	/// <returns>Enumerable of all previous overrides of the record, based on the specified override mod key and resolve target</returns>
+	public static IEnumerable<IModContext> GetPreviousOverrides(this ILinkCache cache, FormKey formKey, Type type, ModKey overrideModKey, ResolveTarget target = ResolveTarget.Winner)
+	{
+		return target switch
+		{
+			ResolveTarget.Winner => cache.ResolveAllSimpleContexts(formKey, type)
+				.SkipWhile(x => x.ModKey != overrideModKey)
+				.Skip(1),
+			_ => cache.ResolveAllSimpleContexts(formKey, type, ResolveTarget.Origin)
+				.TakeWhile(x => x.ModKey != overrideModKey)
+		};
+	}
+
+	/// <summary>
+	/// Gets all previous overrides of a record in the link cache, based on the specified override mod key and resolve target.
+	/// </summary>
+	/// <param name="cache">Link cache to search for previous overrides</param>
+	/// <param name="formKey">FormKey to find previous overrides for</param>
+	/// <param name="overrideModKey">The mod key of the override to start searching from</param>
+	/// <param name="target">Resolution target to look up previous overrides from</param>
+	/// <returns>Enumerable of all previous overrides of the record, based on the specified override mod key and resolve target</returns>
+	[Obsolete("This call is not as optimized as its generic typed counterpart.  Use as a last resort.")]
+	public static IEnumerable<IModContext> GetPreviousOverrides(this ILinkCache cache, FormKey formKey, ModKey overrideModKey, ResolveTarget target = ResolveTarget.Winner)
+	{
+		return target switch
+		{
+			ResolveTarget.Winner => cache.ResolveAllSimpleContexts(formKey)
+				.SkipWhile(x => x.ModKey != overrideModKey)
+				.Skip(1),
+			_ => cache.ResolveAllSimpleContexts(formKey, ResolveTarget.Origin)
+				.TakeWhile(x => x.ModKey != overrideModKey)
+		};
+	}
+	#endregion
+}

--- a/Mutagen.Bethesda.Core/Plugins/Cache/LinkCacheOverridesMixIn.cs
+++ b/Mutagen.Bethesda.Core/Plugins/Cache/LinkCacheOverridesMixIn.cs
@@ -1,9 +1,10 @@
-﻿using Mutagen.Bethesda.Plugins.Records;
+using Mutagen.Bethesda.Plugins.Records;
+
 namespace Mutagen.Bethesda.Plugins.Cache;
 
 public static class LinkCacheOverridesMixIn
 {
-	#region GetPreviousOverrides
+	#region GetPreviousOverridesContext
 	/// <summary>
 	/// Gets all previous overrides of a record in the link cache, based on the specified override mod key and resolve target.
 	/// </summary>
@@ -13,7 +14,7 @@ public static class LinkCacheOverridesMixIn
 	/// <param name="target">Resolution target to look up previous overrides from</param>
 	/// <typeparam name="TMajor">The type of Major Record to look up</typeparam>
 	/// <returns>Enumerable of all previous overrides of the record, based on the specified override mod key and resolve target</returns>
-	public static IEnumerable<IModContext<TMajor>> GetPreviousOverrides<TMajor>(this ILinkCache cache, TMajor record, ModKey overrideModKey, ResolveTarget target = ResolveTarget.Winner)
+	public static IEnumerable<IModContext<TMajor>> GetPreviousOverridesContext<TMajor>(this ILinkCache cache, TMajor record, ModKey overrideModKey, ResolveTarget target = ResolveTarget.Winner)
 		where TMajor : class, IMajorRecordGetter
 	{
 		return target switch
@@ -35,7 +36,7 @@ public static class LinkCacheOverridesMixIn
 	/// <param name="target">Resolution target to look up previous overrides from</param>
 	/// <typeparam name="TMajor">The type of Major Record to look up</typeparam>
 	/// <returns>Enumerable of all previous overrides of the record, based on the specified override mod key and resolve target</returns>
-	public static IEnumerable<IModContext<TMajor>> GetPreviousOverrides<TMajor>(this ILinkCache cache, FormKey formKey, ModKey overrideModKey, ResolveTarget target = ResolveTarget.Winner)
+	public static IEnumerable<IModContext<TMajor>> GetPreviousOverridesContext<TMajor>(this ILinkCache cache, FormKey formKey, ModKey overrideModKey, ResolveTarget target = ResolveTarget.Winner)
 		where TMajor : class, IMajorRecordGetter
 	{
 		return target switch
@@ -56,7 +57,7 @@ public static class LinkCacheOverridesMixIn
 	/// <param name="overrideModKey">The mod key of the override to start searching from</param>
 	/// <param name="target">Resolution target to look up previous overrides from</param>
 	/// <returns>Enumerable of all previous overrides of the record, based on the specified override mod key and resolve target</returns>
-	public static IEnumerable<IModContext> GetPreviousOverrides(this ILinkCache cache, IFormLinkIdentifier formLink, ModKey overrideModKey, ResolveTarget target = ResolveTarget.Winner)
+	public static IEnumerable<IModContext<IMajorRecordGetter>> GetPreviousOverridesContext(this ILinkCache cache, IFormLinkIdentifier formLink, ModKey overrideModKey, ResolveTarget target = ResolveTarget.Winner)
 	{
 		return target switch
 		{
@@ -77,7 +78,7 @@ public static class LinkCacheOverridesMixIn
 	/// <param name="overrideModKey">The mod key of the override to start searching from</param>
 	/// <param name="target">Resolution target to look up previous overrides from</param>
 	/// <returns>Enumerable of all previous overrides of the record, based on the specified override mod key and resolve target</returns>
-	public static IEnumerable<IModContext> GetPreviousOverrides(this ILinkCache cache, FormKey formKey, Type type, ModKey overrideModKey, ResolveTarget target = ResolveTarget.Winner)
+	public static IEnumerable<IModContext<IMajorRecordGetter>> GetPreviousOverridesContext(this ILinkCache cache, FormKey formKey, Type type, ModKey overrideModKey, ResolveTarget target = ResolveTarget.Winner)
 	{
 		return target switch
 		{
@@ -98,7 +99,7 @@ public static class LinkCacheOverridesMixIn
 	/// <param name="target">Resolution target to look up previous overrides from</param>
 	/// <returns>Enumerable of all previous overrides of the record, based on the specified override mod key and resolve target</returns>
 	[Obsolete("This call is not as optimized as its generic typed counterpart.  Use as a last resort.")]
-	public static IEnumerable<IModContext> GetPreviousOverrides(this ILinkCache cache, FormKey formKey, ModKey overrideModKey, ResolveTarget target = ResolveTarget.Winner)
+	public static IEnumerable<IModContext<IMajorRecordGetter>> GetPreviousOverridesContext(this ILinkCache cache, FormKey formKey, ModKey overrideModKey, ResolveTarget target = ResolveTarget.Winner)
 	{
 		return target switch
 		{
@@ -108,6 +109,84 @@ public static class LinkCacheOverridesMixIn
 			_ => cache.ResolveAllSimpleContexts(formKey, ResolveTarget.Origin)
 				.TakeWhile(x => x.ModKey != overrideModKey)
 		};
+	}
+	#endregion
+
+	#region GetPreviousOverrides
+	/// <summary>
+	/// Gets all previous overrides of a record in the link cache, based on the specified override mod key and resolve target.
+	/// </summary>
+	/// <param name="cache">Link cache to search for previous overrides</param>
+	/// <param name="record">The record for which to find previous overrides</param>
+	/// <param name="overrideModKey">The mod key of the override to start searching from</param>
+	/// <param name="target">Resolution target to look up previous overrides from</param>
+	/// <typeparam name="TMajor">The type of Major Record to look up</typeparam>
+	/// <returns>Enumerable of all previous overrides of the record, based on the specified override mod key and resolve target</returns>
+	public static IEnumerable<TMajor> GetPreviousOverrides<TMajor>(this ILinkCache cache, TMajor record, ModKey overrideModKey, ResolveTarget target = ResolveTarget.Winner)
+		where TMajor : class, IMajorRecordGetter
+	{
+		return cache.GetPreviousOverridesContext(record, overrideModKey, target)
+			.Select(x => x.Record);
+	}
+
+	/// <summary>
+	/// Gets all previous overrides of a record in the link cache, based on the specified override mod key and resolve target.
+	/// </summary>
+	/// <param name="cache">Link cache to search for previous overrides</param>
+	/// <param name="formKey">FormKey to find previous overrides for</param>
+	/// <param name="overrideModKey">The mod key of the override to start searching from</param>
+	/// <param name="target">Resolution target to look up previous overrides from</param>
+	/// <typeparam name="TMajor">The type of Major Record to look up</typeparam>
+	/// <returns>Enumerable of all previous overrides of the record, based on the specified override mod key and resolve target</returns>
+	public static IEnumerable<TMajor> GetPreviousOverrides<TMajor>(this ILinkCache cache, FormKey formKey, ModKey overrideModKey, ResolveTarget target = ResolveTarget.Winner)
+		where TMajor : class, IMajorRecordGetter
+	{
+		return cache.GetPreviousOverridesContext<TMajor>(formKey, overrideModKey, target)
+			.Select(x => x.Record);
+	}
+
+	/// <summary>
+	/// Gets all previous overrides of a record in the link cache, based on the specified override mod key and resolve target.
+	/// </summary>
+	/// <param name="cache">Link cache to search for previous overrides</param>
+	/// <param name="formLink">FormLink to find previous overrides for</param>
+	/// <param name="overrideModKey">The mod key of the override to start searching from</param>
+	/// <param name="target">Resolution target to look up previous overrides from</param>
+	/// <returns>Enumerable of all previous overrides of the record, based on the specified override mod key and resolve target</returns>
+	public static IEnumerable<IMajorRecordGetter> GetPreviousOverrides(this ILinkCache cache, IFormLinkIdentifier formLink, ModKey overrideModKey, ResolveTarget target = ResolveTarget.Winner)
+	{
+		return cache.GetPreviousOverridesContext(formLink, overrideModKey, target)
+			.Select(x => x.Record);
+	}
+
+	/// <summary>
+	/// Gets all previous overrides of a record in the link cache, based on the specified override mod key and resolve target.
+	/// </summary>
+	/// <param name="cache">Link cache to search for previous overrides</param>
+	/// <param name="formKey">FormKey to find previous overrides for</param>
+	/// <param name="type">The type of record to look up</param>
+	/// <param name="overrideModKey">The mod key of the override to start searching from</param>
+	/// <param name="target">Resolution target to look up previous overrides from</param>
+	/// <returns>Enumerable of all previous overrides of the record, based on the specified override mod key and resolve target</returns>
+	public static IEnumerable<IMajorRecordGetter> GetPreviousOverrides(this ILinkCache cache, FormKey formKey, Type type, ModKey overrideModKey, ResolveTarget target = ResolveTarget.Winner)
+	{
+		return cache.GetPreviousOverridesContext(formKey, type, overrideModKey, target)
+			.Select(x => x.Record);
+	}
+
+	/// <summary>
+	/// Gets all previous overrides of a record in the link cache, based on the specified override mod key and resolve target.
+	/// </summary>
+	/// <param name="cache">Link cache to search for previous overrides</param>
+	/// <param name="formKey">FormKey to find previous overrides for</param>
+	/// <param name="overrideModKey">The mod key of the override to start searching from</param>
+	/// <param name="target">Resolution target to look up previous overrides from</param>
+	/// <returns>Enumerable of all previous overrides of the record, based on the specified override mod key and resolve target</returns>
+	[Obsolete("This call is not as optimized as its generic typed counterpart.  Use as a last resort.")]
+	public static IEnumerable<IMajorRecordGetter> GetPreviousOverrides(this ILinkCache cache, FormKey formKey, ModKey overrideModKey, ResolveTarget target = ResolveTarget.Winner)
+	{
+		return cache.GetPreviousOverridesContext(formKey, overrideModKey, target)
+			.Select(x => x.Record);
 	}
 	#endregion
 }

--- a/Mutagen.Bethesda.Core/Plugins/Cache/LinkCacheOverridesMixIn.cs
+++ b/Mutagen.Bethesda.Core/Plugins/Cache/LinkCacheOverridesMixIn.cs
@@ -4,7 +4,7 @@ namespace Mutagen.Bethesda.Plugins.Cache;
 
 public static class LinkCacheOverridesMixIn
 {
-	#region GetPreviousOverridesContext
+	#region GetPreviousOverrideSimpleContexts
 	/// <summary>
 	/// Gets all previous overrides of a record in the link cache, based on the specified override mod key and resolve target.
 	/// </summary>
@@ -14,7 +14,7 @@ public static class LinkCacheOverridesMixIn
 	/// <param name="target">Resolution target to look up previous overrides from</param>
 	/// <typeparam name="TMajor">The type of Major Record to look up</typeparam>
 	/// <returns>Enumerable of all previous overrides of the record, based on the specified override mod key and resolve target</returns>
-	public static IEnumerable<IModContext<TMajor>> GetPreviousOverridesContext<TMajor>(this ILinkCache cache, TMajor record, ModKey overrideModKey, ResolveTarget target = ResolveTarget.Winner)
+	public static IEnumerable<IModContext<TMajor>> GetPreviousOverrideSimpleContexts<TMajor>(this ILinkCache cache, TMajor record, ModKey overrideModKey, ResolveTarget target = ResolveTarget.Winner)
 		where TMajor : class, IMajorRecordGetter
 	{
 		return target switch
@@ -36,7 +36,7 @@ public static class LinkCacheOverridesMixIn
 	/// <param name="target">Resolution target to look up previous overrides from</param>
 	/// <typeparam name="TMajor">The type of Major Record to look up</typeparam>
 	/// <returns>Enumerable of all previous overrides of the record, based on the specified override mod key and resolve target</returns>
-	public static IEnumerable<IModContext<TMajor>> GetPreviousOverridesContext<TMajor>(this ILinkCache cache, FormKey formKey, ModKey overrideModKey, ResolveTarget target = ResolveTarget.Winner)
+	public static IEnumerable<IModContext<TMajor>> GetPreviousOverrideSimpleContexts<TMajor>(this ILinkCache cache, FormKey formKey, ModKey overrideModKey, ResolveTarget target = ResolveTarget.Winner)
 		where TMajor : class, IMajorRecordGetter
 	{
 		return target switch
@@ -57,7 +57,7 @@ public static class LinkCacheOverridesMixIn
 	/// <param name="overrideModKey">The mod key of the override to start searching from</param>
 	/// <param name="target">Resolution target to look up previous overrides from</param>
 	/// <returns>Enumerable of all previous overrides of the record, based on the specified override mod key and resolve target</returns>
-	public static IEnumerable<IModContext<IMajorRecordGetter>> GetPreviousOverridesContext(this ILinkCache cache, IFormLinkIdentifier formLink, ModKey overrideModKey, ResolveTarget target = ResolveTarget.Winner)
+	public static IEnumerable<IModContext<IMajorRecordGetter>> GetPreviousOverrideSimpleContexts(this ILinkCache cache, IFormLinkIdentifier formLink, ModKey overrideModKey, ResolveTarget target = ResolveTarget.Winner)
 	{
 		return target switch
 		{
@@ -78,7 +78,7 @@ public static class LinkCacheOverridesMixIn
 	/// <param name="overrideModKey">The mod key of the override to start searching from</param>
 	/// <param name="target">Resolution target to look up previous overrides from</param>
 	/// <returns>Enumerable of all previous overrides of the record, based on the specified override mod key and resolve target</returns>
-	public static IEnumerable<IModContext<IMajorRecordGetter>> GetPreviousOverridesContext(this ILinkCache cache, FormKey formKey, Type type, ModKey overrideModKey, ResolveTarget target = ResolveTarget.Winner)
+	public static IEnumerable<IModContext<IMajorRecordGetter>> GetPreviousOverrideSimpleContexts(this ILinkCache cache, FormKey formKey, Type type, ModKey overrideModKey, ResolveTarget target = ResolveTarget.Winner)
 	{
 		return target switch
 		{
@@ -99,7 +99,7 @@ public static class LinkCacheOverridesMixIn
 	/// <param name="target">Resolution target to look up previous overrides from</param>
 	/// <returns>Enumerable of all previous overrides of the record, based on the specified override mod key and resolve target</returns>
 	[Obsolete("This call is not as optimized as its generic typed counterpart.  Use as a last resort.")]
-	public static IEnumerable<IModContext<IMajorRecordGetter>> GetPreviousOverridesContext(this ILinkCache cache, FormKey formKey, ModKey overrideModKey, ResolveTarget target = ResolveTarget.Winner)
+	public static IEnumerable<IModContext<IMajorRecordGetter>> GetPreviousOverrideSimpleContexts(this ILinkCache cache, FormKey formKey, ModKey overrideModKey, ResolveTarget target = ResolveTarget.Winner)
 	{
 		return target switch
 		{
@@ -125,7 +125,7 @@ public static class LinkCacheOverridesMixIn
 	public static IEnumerable<TMajor> GetPreviousOverrides<TMajor>(this ILinkCache cache, TMajor record, ModKey overrideModKey, ResolveTarget target = ResolveTarget.Winner)
 		where TMajor : class, IMajorRecordGetter
 	{
-		return cache.GetPreviousOverridesContext(record, overrideModKey, target)
+		return cache.GetPreviousOverrideSimpleContexts(record, overrideModKey, target)
 			.Select(x => x.Record);
 	}
 
@@ -141,7 +141,7 @@ public static class LinkCacheOverridesMixIn
 	public static IEnumerable<TMajor> GetPreviousOverrides<TMajor>(this ILinkCache cache, FormKey formKey, ModKey overrideModKey, ResolveTarget target = ResolveTarget.Winner)
 		where TMajor : class, IMajorRecordGetter
 	{
-		return cache.GetPreviousOverridesContext<TMajor>(formKey, overrideModKey, target)
+		return cache.GetPreviousOverrideSimpleContexts<TMajor>(formKey, overrideModKey, target)
 			.Select(x => x.Record);
 	}
 
@@ -155,7 +155,7 @@ public static class LinkCacheOverridesMixIn
 	/// <returns>Enumerable of all previous overrides of the record, based on the specified override mod key and resolve target</returns>
 	public static IEnumerable<IMajorRecordGetter> GetPreviousOverrides(this ILinkCache cache, IFormLinkIdentifier formLink, ModKey overrideModKey, ResolveTarget target = ResolveTarget.Winner)
 	{
-		return cache.GetPreviousOverridesContext(formLink, overrideModKey, target)
+		return cache.GetPreviousOverrideSimpleContexts(formLink, overrideModKey, target)
 			.Select(x => x.Record);
 	}
 
@@ -170,7 +170,7 @@ public static class LinkCacheOverridesMixIn
 	/// <returns>Enumerable of all previous overrides of the record, based on the specified override mod key and resolve target</returns>
 	public static IEnumerable<IMajorRecordGetter> GetPreviousOverrides(this ILinkCache cache, FormKey formKey, Type type, ModKey overrideModKey, ResolveTarget target = ResolveTarget.Winner)
 	{
-		return cache.GetPreviousOverridesContext(formKey, type, overrideModKey, target)
+		return cache.GetPreviousOverrideSimpleContexts(formKey, type, overrideModKey, target)
 			.Select(x => x.Record);
 	}
 
@@ -185,7 +185,7 @@ public static class LinkCacheOverridesMixIn
 	[Obsolete("This call is not as optimized as its generic typed counterpart.  Use as a last resort.")]
 	public static IEnumerable<IMajorRecordGetter> GetPreviousOverrides(this ILinkCache cache, FormKey formKey, ModKey overrideModKey, ResolveTarget target = ResolveTarget.Winner)
 	{
-		return cache.GetPreviousOverridesContext(formKey, overrideModKey, target)
+		return cache.GetPreviousOverrideSimpleContexts(formKey, overrideModKey, target)
 			.Select(x => x.Record);
 	}
 	#endregion

--- a/Mutagen.Bethesda.Skyrim/Extensions/LocationExt.cs
+++ b/Mutagen.Bethesda.Skyrim/Extensions/LocationExt.cs
@@ -5,6 +5,11 @@ namespace Mutagen.Bethesda.Skyrim;
 
 public static class LocationExt
 {
+    /// <summary>
+    /// Gets the location's reference type references, including added static entries and excluding removed entries.
+    /// </summary>
+    /// <param name="location">Location to inspect</param>
+    /// <returns>Active reference type references</returns>
     public static IEnumerable<ILocationRefTypeReferenceGetter> LocationRefTypesReferences(this ILocationGetter location)
     {
         IEnumerable<ILocationRefTypeReferenceGetter> Added()
@@ -35,16 +40,18 @@ public static class LocationExt
             .Where(x => !removed.Contains(x.Ref.FormKey));
     }
 
-    public static IEnumerable<ILocationRefTypeReferenceGetter> AllLocationRefTypesReferences(this ILocationGetter location, ILinkCache linkCache)
+    /// <summary>
+    /// Gets all location reference type references across the override chain up to the specified mod key.
+    /// Starting from the first definition of the location, it aggregates all added references and removes any that are marked as removed in subsequent overrides.
+    /// </summary>
+    /// <param name="location">Location to inspect</param>
+    /// <param name="linkCache">Link cache used to walk overrides</param>
+    /// <param name="highestOverrideModKey">Highest override mod key to include</param>
+    /// <returns>Aggregated location reference type references</returns>
+    public static IEnumerable<ILocationRefTypeReferenceGetter> AllLocationRefTypesReferences(this ILocationGetter location, ILinkCache linkCache, ModKey highestOverrideModKey)
     {
-        var previousOverrides = linkCache
-            .ResolveAll(location, ResolveTarget.Origin)
-            .TakeWhile(x => !Equals(x, location))
-            .Append(location)
-            .ToArray();
-
         var refTypes = new HashSet<ILocationRefTypeReferenceGetter>();
-        foreach (var previousOverride in previousOverrides)
+        foreach (var previousOverride in linkCache.GetPreviousOverrides(location, highestOverrideModKey))
         {
             refTypes.Add(Added(previousOverride));
             var removed = Removed(previousOverride).Select(x => x.FormKey).ToHashSet();
@@ -70,6 +77,11 @@ public static class LocationExt
         }
     }
 
+    /// <summary>
+    /// Gets the location's persistent actor references, including added static entries and excluding removed entries.
+    /// </summary>
+    /// <param name="location">Location to inspect</param>
+    /// <returns>Active persistent actor references</returns>
     public static IEnumerable<IPersistentActorReferenceGetter> PersistentActorReferences(this ILocationGetter location)
     {
         IEnumerable<IPersistentActorReferenceGetter> Added()
@@ -100,16 +112,18 @@ public static class LocationExt
             .Where(x => !removed.Contains(x.Actor.FormKey));
     }
 
-    public static IEnumerable<IPersistentActorReferenceGetter> AllPersistentActorReferences(this ILocationGetter location, ILinkCache linkCache)
+    /// <summary>
+    /// Gets all persistent actor references across the override chain up to the specified mod key.
+    /// Starting from the first definition of the location, it aggregates all added references and removes any that are marked as removed in subsequent overrides.
+    /// </summary>
+    /// <param name="location">Location to inspect</param>
+    /// <param name="linkCache">Link cache used to walk overrides</param>
+    /// <param name="highestOverrideModKey">Highest override mod key to include</param>
+    /// <returns>Aggregated persistent actor references</returns>
+    public static IEnumerable<IPersistentActorReferenceGetter> AllPersistentActorReferences(this ILocationGetter location, ILinkCache linkCache, ModKey highestOverrideModKey)
     {
-        var previousOverrides = linkCache
-            .ResolveAll(location, ResolveTarget.Origin)
-            .TakeWhile(x => !Equals(x, location))
-            .Append(location)
-            .ToArray();
-
         var actors = new HashSet<IPersistentActorReferenceGetter>();
-        foreach (var previousOverride in previousOverrides)
+        foreach (var previousOverride in linkCache.GetPreviousOverrides(location, highestOverrideModKey))
         {
             actors.Add(Added(previousOverride));
             var removed = Removed(previousOverride).Select(x => x.FormKey).ToHashSet();
@@ -135,6 +149,11 @@ public static class LocationExt
         }
     }
 
+    /// <summary>
+    /// Gets the location's unique actor references, including added static entries and excluding removed entries.
+    /// </summary>
+    /// <param name="location">Location to inspect</param>
+    /// <returns>Active unique actor references</returns>
     public static IEnumerable<IUniqueActorReferenceGetter> UniqueActorReferences(this ILocationGetter location)
     {
         IEnumerable<IUniqueActorReferenceGetter> Added()
@@ -165,16 +184,18 @@ public static class LocationExt
             .Where(x => !removed.Contains(x.Actor.FormKey));
     }
 
-    public static IEnumerable<IUniqueActorReferenceGetter> AllUniqueActorReferences(this ILocationGetter location, ILinkCache linkCache)
+    /// <summary>
+    /// Gets all unique actor references across the override chain up to the specified mod key.
+    /// Starting from the first definition of the location, it aggregates all added references and removes any that are marked as removed in subsequent overrides.
+    /// </summary>
+    /// <param name="location">Location to inspect</param>
+    /// <param name="linkCache">Link cache used to walk overrides</param>
+    /// <param name="highestOverrideModKey">Highest override mod key to include</param>
+    /// <returns>Aggregated unique actor references</returns>
+    public static IEnumerable<IUniqueActorReferenceGetter> AllUniqueActorReferences(this ILocationGetter location, ILinkCache linkCache, ModKey highestOverrideModKey)
     {
-        var previousOverrides = linkCache
-            .ResolveAll(location, ResolveTarget.Origin)
-            .TakeWhile(x => !Equals(x, location))
-            .Append(location)
-            .ToArray();
-
         var actors = new HashSet<IUniqueActorReferenceGetter>();
-        foreach (var previousOverride in previousOverrides)
+        foreach (var previousOverride in linkCache.GetPreviousOverrides(location, highestOverrideModKey))
         {
             actors.Add(Added(previousOverride));
             var removed = Removed(previousOverride).Select(x => x.FormKey).ToHashSet();
@@ -200,6 +221,11 @@ public static class LocationExt
         }
     }
 
+    /// <summary>
+    /// Gets the location's initially disabled references.
+    /// </summary>
+    /// <param name="location">Location to inspect</param>
+    /// <returns>Initially disabled references</returns>
     public static IEnumerable<IFormLinkGetter<IPlacedGetter>> InitiallyDisabledReferences(this ILocationGetter location)
     {
         var staticReferences = location.InitiallyDisabledReferencesAdded;
@@ -221,16 +247,18 @@ public static class LocationExt
         }
     }
 
-    public static IEnumerable<IFormLinkGetter<IPlacedGetter>> AllInitiallyDisabledReferences(this ILocationGetter location, ILinkCache linkCache)
+    /// <summary>
+    /// Gets all initially disabled references across the override chain up to the specified mod key.
+    /// Starting from the first definition of the location, it aggregates all added references and removes any that are marked as removed in subsequent overrides.
+    /// </summary>
+    /// <param name="location">Location to inspect</param>
+    /// <param name="linkCache">Link cache used to walk overrides</param>
+    /// <param name="highestOverrideModKey">Highest override mod key to include</param>
+    /// <returns>Aggregated initially disabled references</returns>
+    public static IEnumerable<IFormLinkGetter<IPlacedGetter>> AllInitiallyDisabledReferences(this ILocationGetter location, ILinkCache linkCache, ModKey highestOverrideModKey)
     {
-        var previousOverrides = linkCache
-            .ResolveAll(location, ResolveTarget.Origin)
-            .TakeWhile(x => !Equals(x, location))
-            .Append(location)
-            .ToArray();
-
         var actors = new HashSet<IFormLinkGetter<IPlacedGetter>>();
-        foreach (var previousOverride in previousOverrides)
+        foreach (var previousOverride in linkCache.GetPreviousOverrides(location, highestOverrideModKey))
         {
             actors.Add(Added(previousOverride));
         }
@@ -246,6 +274,11 @@ public static class LocationExt
         }
     }
 
+    /// <summary>
+    /// Gets the location's enable-parent references.
+    /// </summary>
+    /// <param name="location">Location to inspect</param>
+    /// <returns>Enable-parent references</returns>
     public static IEnumerable<IEnableParentReferenceGetter> EnableParentReferences(this ILocationGetter location)
     {
         var staticReferences = location.EnableParentReferencesStatic;
@@ -267,16 +300,18 @@ public static class LocationExt
         }
     }
 
-    public static IEnumerable<IEnableParentReferenceGetter> AllEnableParentReferences(this ILocationGetter location, ILinkCache linkCache)
+    /// <summary>
+    /// Gets all enable-parent references across the override chain up to the specified mod key.
+    /// Starting from the first definition of the location, it aggregates all added references and removes any that are marked as removed in subsequent overrides.
+    /// </summary>
+    /// <param name="location">Location to inspect</param>
+    /// <param name="linkCache">Link cache used to walk overrides</param>
+    /// <param name="highestOverrideModKey">Highest override mod key to include</param>
+    /// <returns>Aggregated enable-parent references</returns>
+    public static IEnumerable<IEnableParentReferenceGetter> AllEnableParentReferences(this ILocationGetter location, ILinkCache linkCache, ModKey highestOverrideModKey)
     {
-        var previousOverrides = linkCache
-            .ResolveAll(location, ResolveTarget.Origin)
-            .TakeWhile(x => !Equals(x, location))
-            .Append(location)
-            .ToArray();
-
         var actors = new HashSet<IEnableParentReferenceGetter>();
-        foreach (var previousOverride in previousOverrides)
+        foreach (var previousOverride in linkCache.GetPreviousOverrides(location, highestOverrideModKey))
         {
             actors.Add(Added(previousOverride));
         }

--- a/Mutagen.Bethesda.Skyrim/Extensions/LocationExt.cs
+++ b/Mutagen.Bethesda.Skyrim/Extensions/LocationExt.cs
@@ -1,4 +1,6 @@
 ﻿using Mutagen.Bethesda.Plugins;
+using Mutagen.Bethesda.Plugins.Cache;
+using Noggog;
 namespace Mutagen.Bethesda.Skyrim;
 
 public static class LocationExt
@@ -33,6 +35,41 @@ public static class LocationExt
             .Where(x => !removed.Contains(x.Ref.FormKey));
     }
 
+    public static IEnumerable<ILocationRefTypeReferenceGetter> AllLocationRefTypesReferences(this ILocationGetter location, ILinkCache linkCache)
+    {
+        var previousOverrides = linkCache
+            .ResolveAll(location, ResolveTarget.Origin)
+            .TakeWhile(x => !Equals(x, location))
+            .Append(location)
+            .ToArray();
+
+        var refTypes = new HashSet<ILocationRefTypeReferenceGetter>();
+        foreach (var previousOverride in previousOverrides)
+        {
+            refTypes.Add(Added(previousOverride));
+            var removed = Removed(previousOverride);
+            refTypes.RemoveWhere(x => removed.Any(r => r.FormKey == x.Ref.FormKey));
+        }
+        return refTypes;
+
+        IEnumerable<ILocationRefTypeReferenceGetter> Added(ILocationGetter loc)
+        {
+            var referencesStatic = loc.LocationRefTypeReferencesStatic;
+            if (referencesStatic is not null) return referencesStatic;
+
+            var typeReferencesAdded = loc.LocationRefTypeReferencesAdded;
+            return typeReferencesAdded ?? [];
+        }
+
+        IReadOnlyList<IFormLinkGetter<IPlacedSimpleGetter>> Removed(ILocationGetter loc)
+        {
+            var referencesRemoved = loc.LocationRefTypeReferencesRemoved;
+            if (referencesRemoved is not null) return referencesRemoved;
+
+            return [];
+        }
+    }
+
     public static IEnumerable<IPersistentActorReferenceGetter> PersistentActorReferences(this ILocationGetter location)
     {
         IEnumerable<IPersistentActorReferenceGetter> Added()
@@ -61,6 +98,41 @@ public static class LocationExt
 
         return Added()
             .Where(x => !removed.Contains(x.Actor.FormKey));
+    }
+
+    public static HashSet<IPersistentActorReferenceGetter> AllPersistentActorReferences(this ILocationGetter location, ILinkCache linkCache)
+    {
+        var previousOverrides = linkCache
+            .ResolveAll(location, ResolveTarget.Origin)
+            .TakeWhile(x => !Equals(x, location))
+            .Append(location)
+            .ToArray();
+
+        var actors = new HashSet<IPersistentActorReferenceGetter>();
+        foreach (var previousOverride in previousOverrides)
+        {
+            actors.Add(Added(previousOverride));
+            var removed = Removed(previousOverride);
+            actors.RemoveWhere(x => removed.Any(r => r.FormKey == x.Actor.FormKey));
+        }
+        return actors;
+
+        IEnumerable<IPersistentActorReferenceGetter> Added(ILocationGetter loc)
+        {
+            var referencesStatic = loc.PersistentActorReferencesStatic;
+            if (referencesStatic is not null) return referencesStatic;
+
+            var typeReferencesAdded = loc.PersistentActorReferencesAdded;
+            return typeReferencesAdded ?? [];
+        }
+
+        IReadOnlyList<IFormLinkGetter<IPlacedSimpleGetter>> Removed(ILocationGetter loc)
+        {
+            var referencesRemoved = loc.PersistentActorReferencesRemoved;
+            if (referencesRemoved is not null) return referencesRemoved;
+
+            return [];
+        }
     }
 
     public static IEnumerable<IUniqueActorReferenceGetter> UniqueActorReferences(this ILocationGetter location)
@@ -93,6 +165,41 @@ public static class LocationExt
             .Where(x => !removed.Contains(x.Actor.FormKey));
     }
 
+    public static HashSet<IUniqueActorReferenceGetter> AllUniqueActorReferences(this ILocationGetter location, ILinkCache linkCache)
+    {
+        var previousOverrides = linkCache
+            .ResolveAll(location, ResolveTarget.Origin)
+            .TakeWhile(x => !Equals(x, location))
+            .Append(location)
+            .ToArray();
+
+        var actors = new HashSet<IUniqueActorReferenceGetter>();
+        foreach (var previousOverride in previousOverrides)
+        {
+            actors.Add(Added(previousOverride));
+            var removed = Removed(previousOverride);
+            actors.RemoveWhere(x => removed.Any(r => r.FormKey == x.Actor.FormKey));
+        }
+        return actors;
+
+        IReadOnlyList<IUniqueActorReferenceGetter> Added(ILocationGetter loc)
+        {
+            var referencesStatic = loc.UniqueActorReferencesStatic;
+            if (referencesStatic is not null) return referencesStatic;
+
+            var typeReferencesAdded = loc.UniqueActorReferencesAdded;
+            return typeReferencesAdded ?? [];
+        }
+
+        IReadOnlyList<IFormLinkGetter<INpcGetter>> Removed(ILocationGetter loc)
+        {
+            var referencesRemoved = loc.UniqueActorReferencesRemoved;
+            if (referencesRemoved is not null) return referencesRemoved;
+
+            return [];
+        }
+    }
+
     public static IEnumerable<IFormLinkGetter<IPlacedGetter>> InitiallyDisabledReferences(this ILocationGetter location)
     {
         var staticReferences = location.InitiallyDisabledReferencesAdded;
@@ -114,6 +221,31 @@ public static class LocationExt
         }
     }
 
+    public static HashSet<IFormLinkGetter<IPlacedGetter>> AllInitiallyDisabledReferences(this ILocationGetter location, ILinkCache linkCache)
+    {
+        var previousOverrides = linkCache
+            .ResolveAll(location, ResolveTarget.Origin)
+            .TakeWhile(x => !Equals(x, location))
+            .Append(location)
+            .ToArray();
+
+        var actors = new HashSet<IFormLinkGetter<IPlacedGetter>>();
+        foreach (var previousOverride in previousOverrides)
+        {
+            actors.Add(Added(previousOverride));
+        }
+        return actors;
+
+        IReadOnlyList<IFormLinkGetter<IPlacedGetter>> Added(ILocationGetter loc)
+        {
+            var referencesStatic = loc.InitiallyDisabledReferencesStatic;
+            if (referencesStatic is not null) return referencesStatic;
+
+            var typeReferencesAdded = loc.InitiallyDisabledReferencesAdded;
+            return typeReferencesAdded ?? [];
+        }
+    }
+
     public static IEnumerable<IEnableParentReferenceGetter> EnableParentReferences(this ILocationGetter location)
     {
         var staticReferences = location.EnableParentReferencesStatic;
@@ -132,6 +264,31 @@ public static class LocationExt
             {
                 yield return reference;
             }
+        }
+    }
+
+    public static HashSet<IEnableParentReferenceGetter> AllEnableParentReferences(this ILocationGetter location, ILinkCache linkCache)
+    {
+        var previousOverrides = linkCache
+            .ResolveAll(location, ResolveTarget.Origin)
+            .TakeWhile(x => !Equals(x, location))
+            .Append(location)
+            .ToArray();
+
+        var actors = new HashSet<IEnableParentReferenceGetter>();
+        foreach (var previousOverride in previousOverrides)
+        {
+            actors.Add(Added(previousOverride));
+        }
+        return actors;
+
+        IReadOnlyList<IEnableParentReferenceGetter> Added(ILocationGetter loc)
+        {
+            var referencesStatic = loc.EnableParentReferencesStatic;
+            if (referencesStatic is not null) return referencesStatic;
+
+            var typeReferencesAdded = loc.EnableParentReferencesAdded;
+            return typeReferencesAdded ?? [];
         }
     }
 }

--- a/Mutagen.Bethesda.Skyrim/Extensions/LocationExt.cs
+++ b/Mutagen.Bethesda.Skyrim/Extensions/LocationExt.cs
@@ -47,8 +47,8 @@ public static class LocationExt
         foreach (var previousOverride in previousOverrides)
         {
             refTypes.Add(Added(previousOverride));
-            var removed = Removed(previousOverride);
-            refTypes.RemoveWhere(x => removed.Any(r => r.FormKey == x.Ref.FormKey));
+            var removed = Removed(previousOverride).Select(x => x.FormKey).ToHashSet();
+            refTypes.RemoveWhere(x => removed.Contains(x.Ref.FormKey));
         }
         return refTypes;
 
@@ -112,8 +112,8 @@ public static class LocationExt
         foreach (var previousOverride in previousOverrides)
         {
             actors.Add(Added(previousOverride));
-            var removed = Removed(previousOverride);
-            actors.RemoveWhere(x => removed.Any(r => r.FormKey == x.Actor.FormKey));
+            var removed = Removed(previousOverride).Select(x => x.FormKey).ToHashSet();
+            actors.RemoveWhere(x => removed.Contains(x.Actor.FormKey));
         }
         return actors;
 
@@ -177,8 +177,8 @@ public static class LocationExt
         foreach (var previousOverride in previousOverrides)
         {
             actors.Add(Added(previousOverride));
-            var removed = Removed(previousOverride);
-            actors.RemoveWhere(x => removed.Any(r => r.FormKey == x.Actor.FormKey));
+            var removed = Removed(previousOverride).Select(x => x.FormKey).ToHashSet();
+            actors.RemoveWhere(x => removed.Contains(x.Actor.FormKey));
         }
         return actors;
 

--- a/Mutagen.Bethesda.Skyrim/Extensions/LocationExt.cs
+++ b/Mutagen.Bethesda.Skyrim/Extensions/LocationExt.cs
@@ -100,7 +100,7 @@ public static class LocationExt
             .Where(x => !removed.Contains(x.Actor.FormKey));
     }
 
-    public static HashSet<IPersistentActorReferenceGetter> AllPersistentActorReferences(this ILocationGetter location, ILinkCache linkCache)
+    public static IEnumerable<IPersistentActorReferenceGetter> AllPersistentActorReferences(this ILocationGetter location, ILinkCache linkCache)
     {
         var previousOverrides = linkCache
             .ResolveAll(location, ResolveTarget.Origin)
@@ -165,7 +165,7 @@ public static class LocationExt
             .Where(x => !removed.Contains(x.Actor.FormKey));
     }
 
-    public static HashSet<IUniqueActorReferenceGetter> AllUniqueActorReferences(this ILocationGetter location, ILinkCache linkCache)
+    public static IEnumerable<IUniqueActorReferenceGetter> AllUniqueActorReferences(this ILocationGetter location, ILinkCache linkCache)
     {
         var previousOverrides = linkCache
             .ResolveAll(location, ResolveTarget.Origin)
@@ -221,7 +221,7 @@ public static class LocationExt
         }
     }
 
-    public static HashSet<IFormLinkGetter<IPlacedGetter>> AllInitiallyDisabledReferences(this ILocationGetter location, ILinkCache linkCache)
+    public static IEnumerable<IFormLinkGetter<IPlacedGetter>> AllInitiallyDisabledReferences(this ILocationGetter location, ILinkCache linkCache)
     {
         var previousOverrides = linkCache
             .ResolveAll(location, ResolveTarget.Origin)
@@ -267,7 +267,7 @@ public static class LocationExt
         }
     }
 
-    public static HashSet<IEnableParentReferenceGetter> AllEnableParentReferences(this ILocationGetter location, ILinkCache linkCache)
+    public static IEnumerable<IEnableParentReferenceGetter> AllEnableParentReferences(this ILocationGetter location, ILinkCache linkCache)
     {
         var previousOverrides = linkCache
             .ResolveAll(location, ResolveTarget.Origin)


### PR DESCRIPTION
Add variants of location extensions which look at the load order to merge the states of special fields in the location record which are also merged at runtime