### PR TITLE
ILinkCache.TryGetLinkCacheForMod

### DIFF
--- a/Mutagen.Bethesda.Core/Mutagen.Bethesda.Core.csproj
+++ b/Mutagen.Bethesda.Core/Mutagen.Bethesda.Core.csproj
@@ -653,6 +653,7 @@
         <Compile Include="Plugins\FormLinkNullable.cs" />
         <Compile Include="Plugins\IFormLink.cs" />
         <Compile Include="Plugins\Cache\ILinkCache.cs" />
+        <Compile Include="Plugins\Cache\LinkCacheFromModMixIn.cs" />
         <Compile Include="Plugins\Cache\LinkCachePreferences.cs" />
         <Compile Include="Plugins\FormLinkTypelessComparer.cs" />
         <Compile Include="Plugins\Order\LoadOrder.cs" />

--- a/Mutagen.Bethesda.Core/Plugins/Cache/ILinkCache.cs
+++ b/Mutagen.Bethesda.Core/Plugins/Cache/ILinkCache.cs
@@ -131,8 +131,7 @@ public interface ILinkCache : IIdentifierLinkCache, IWinningOverrideProvider
     /// </exception>
     /// <returns>True if a matching record was found</returns>
     bool TryResolve(FormKey formKey, Type type, [MaybeNullWhen(false)] out IMajorRecordGetter majorRec, ResolveTarget target = ResolveTarget.Winner);
-
-
+    
     /// <summary>
     /// Retrieves the winning record that matches the FormKey relative to the source the package was attached to.<br/>
     /// <br/>
@@ -1065,6 +1064,17 @@ public interface ILinkCache : IIdentifierLinkCache, IWinningOverrideProvider
     void Warmup(IEnumerable<Type> types);
 
     /// <summary>
+    /// Retrieves the link cache scoped to a single mod within this cache, located by its ModKey.<br/>
+    /// <br/>
+    /// This allows resolution to be done against the contribution of one specific mod, rather than the
+    /// winning override or the origin definition.
+    /// </summary>
+    /// <param name="modKey">ModKey of the mod to retrieve the scoped link cache for</param>
+    /// <param name="cache">Out parameter containing the single-mod link cache if successful</param>
+    /// <returns>True if the cache contains a mod matching the given ModKey</returns>
+    bool TryGetLinkCacheForMod(ModKey modKey, [MaybeNullWhen(false)] out ILinkCache cache);
+
+    /// <summary>
     /// Iterates through the contained mods in the order they were listed, with the least prioritized mod first.
     /// </summary>
     IReadOnlyList<IModGetter> ListedOrder { get; }
@@ -1531,4 +1541,15 @@ public interface ILinkCache<TMod, TModGetter> : ILinkCache, IWinningOverrideProv
     /// <returns>Enumerable of all located record contexts that match the FormKey in the cache</returns>
     [Obsolete("This call is not as optimized as its generic typed counterpart.  Use as a last resort.")]
     IEnumerable<IModContext<TMod, TModGetter, IMajorRecord, IMajorRecordGetter>> ResolveAllContexts(FormKey formKey, ResolveTarget target = ResolveTarget.Winner);
+
+    /// <summary>
+    /// Retrieves the typed link cache scoped to a single mod within this cache, located by its ModKey.<br/>
+    /// <br/>
+    /// This allows resolution to be done against the contribution of one specific mod, rather than the
+    /// winning override or the origin definition.
+    /// </summary>
+    /// <param name="modKey">ModKey of the mod to retrieve the scoped link cache for</param>
+    /// <param name="cache">Out parameter containing the single-mod link cache if successful</param>
+    /// <returns>True if the cache contains a mod matching the given ModKey</returns>
+    bool TryGetTypedLinkCacheForMod(ModKey modKey, [MaybeNullWhen(false)] out ILinkCache<TMod, TModGetter> cache);
 }

--- a/Mutagen.Bethesda.Core/Plugins/Cache/Internals/Implementations/ImmutableLoadOrderLinkCache.cs
+++ b/Mutagen.Bethesda.Core/Plugins/Cache/Internals/Implementations/ImmutableLoadOrderLinkCache.cs
@@ -807,6 +807,13 @@ public sealed class ImmutableLoadOrderLinkCache : ILinkCache
     }
 
     /// <inheritdoc />
+    public bool TryGetLinkCacheForMod(ModKey modKey, [MaybeNullWhen(false)] out ILinkCache cache)
+    {
+        CheckDisposal();
+        return _modsByKey.TryGetValue(modKey, out cache);
+    }
+
+    /// <inheritdoc />
     public IReadOnlyList<IModGetter> ListedOrder
     {
         get
@@ -1595,6 +1602,27 @@ public sealed class ImmutableLoadOrderLinkCache<TMod, TModGetter> : ILinkCache<T
     {
         CheckDisposal();
         _cache.Warmup(types);
+    }
+
+    /// <inheritdoc />
+    public bool TryGetLinkCacheForMod(ModKey modKey, [MaybeNullWhen(false)] out ILinkCache cache)
+    {
+        CheckDisposal();
+        if (_modsByKey.TryGetValue(modKey, out var typed))
+        {
+            cache = typed;
+            return true;
+        }
+
+        cache = null;
+        return false;
+    }
+
+    /// <inheritdoc />
+    public bool TryGetTypedLinkCacheForMod(ModKey modKey, [MaybeNullWhen(false)] out ILinkCache<TMod, TModGetter> cache)
+    {
+        CheckDisposal();
+        return _modsByKey.TryGetValue(modKey, out cache);
     }
 
     /// <inheritdoc />

--- a/Mutagen.Bethesda.Core/Plugins/Cache/Internals/Implementations/ImmutableModLinkCache.cs
+++ b/Mutagen.Bethesda.Core/Plugins/Cache/Internals/Implementations/ImmutableModLinkCache.cs
@@ -729,6 +729,20 @@ public sealed class ImmutableModLinkCache : ILinkCache
     }
 
     /// <inheritdoc />
+    public bool TryGetLinkCacheForMod(ModKey modKey, [MaybeNullWhen(false)] out ILinkCache cache)
+    {
+        CheckDisposal();
+        if (modKey == _sourceMod.ModKey)
+        {
+            cache = this;
+            return true;
+        }
+
+        cache = null;
+        return false;
+    }
+
+    /// <inheritdoc />
     public IReadOnlyList<IModGetter> ListedOrder
     {
         get
@@ -1658,6 +1672,34 @@ public sealed class ImmutableModLinkCache<TMod, TModGetter> : ILinkCache<TMod, T
     {
         CheckDisposal();
         return PriorityOrder.Cast<TModGetter>().WinningContextOverrides<TMod, TModGetter>(linkCache, type, includeDeletedRecords: includeDeletedRecords);
+    }
+
+    /// <inheritdoc />
+    public bool TryGetLinkCacheForMod(ModKey modKey, [MaybeNullWhen(false)] out ILinkCache cache)
+    {
+        CheckDisposal();
+        if (modKey == _sourceMod.ModKey)
+        {
+            cache = this;
+            return true;
+        }
+
+        cache = null;
+        return false;
+    }
+
+    /// <inheritdoc />
+    public bool TryGetTypedLinkCacheForMod(ModKey modKey, [MaybeNullWhen(false)] out ILinkCache<TMod, TModGetter> cache)
+    {
+        CheckDisposal();
+        if (modKey == _sourceMod.ModKey)
+        {
+            cache = this;
+            return true;
+        }
+
+        cache = null;
+        return false;
     }
 
     public IReadOnlyList<IModGetter> ListedOrder

--- a/Mutagen.Bethesda.Core/Plugins/Cache/Internals/Implementations/MutableLoadOrderLinkCache.cs
+++ b/Mutagen.Bethesda.Core/Plugins/Cache/Internals/Implementations/MutableLoadOrderLinkCache.cs
@@ -10,6 +10,7 @@ public sealed class MutableLoadOrderLinkCache : ILinkCache
 {
     public ImmutableLoadOrderLinkCache? WrappedImmutableCache { get; }
     private readonly List<MutableModLinkCache> _mutableMods;
+    private readonly Dictionary<ModKey, MutableModLinkCache> _mutableModsByKey;
     private bool _disposed;
 
     /// <summary>
@@ -22,6 +23,7 @@ public sealed class MutableLoadOrderLinkCache : ILinkCache
     {
         WrappedImmutableCache = immutableBaseCache;
         _mutableMods = mutableMods.Select(m => m.ToUntypedMutableLinkCache()).ToList();
+        _mutableModsByKey = MakeModsByKey(_mutableMods);
         ListedOrder = WrappedImmutableCache.ListedOrder.Concat(_mutableMods.Select(x => x.SourceMod)).ToArray();
         PriorityOrder = ListedOrder.Reverse().ToArray();
     }
@@ -34,8 +36,20 @@ public sealed class MutableLoadOrderLinkCache : ILinkCache
     public MutableLoadOrderLinkCache(params IMod[] mutableMods)
     {
         _mutableMods = mutableMods.Select(m => m.ToUntypedMutableLinkCache()).ToList();
+        _mutableModsByKey = MakeModsByKey(_mutableMods);
         ListedOrder = _mutableMods.Select(x => x.SourceMod).ToArray();
         PriorityOrder = ListedOrder.Reverse().ToArray();
+    }
+
+    private static Dictionary<ModKey, MutableModLinkCache> MakeModsByKey(List<MutableModLinkCache> mutableMods)
+    {
+        var ret = new Dictionary<ModKey, MutableModLinkCache>();
+        foreach (var mod in mutableMods)
+        {
+            ret.TryAdd(mod.SourceMod.ModKey, mod);
+        }
+
+        return ret;
     }
 
     /// <inheritdoc />
@@ -50,6 +64,25 @@ public sealed class MutableLoadOrderLinkCache : ILinkCache
         {
             throw new ObjectDisposedException($"MutableLoadOrderLinkCache");
         }
+    }
+
+    /// <inheritdoc />
+    public bool TryGetLinkCacheForMod(ModKey modKey, [MaybeNullWhen(false)] out ILinkCache cache)
+    {
+        CheckDisposal();
+        if (_mutableModsByKey.TryGetValue(modKey, out var mod))
+        {
+            cache = mod;
+            return true;
+        }
+
+        if (WrappedImmutableCache != null)
+        {
+            return WrappedImmutableCache.TryGetLinkCacheForMod(modKey, out cache);
+        }
+
+        cache = null;
+        return false;
     }
 
     /// <inheritdoc />
@@ -242,7 +275,9 @@ public sealed class MutableLoadOrderLinkCache : ILinkCache
     public void Add(IMod mod)
     {
         CheckDisposal();
-        _mutableMods.Add(mod.ToUntypedMutableLinkCache());
+        var mutableCache = mod.ToUntypedMutableLinkCache();
+        _mutableMods.Add(mutableCache);
+        _mutableModsByKey.TryAdd(mutableCache.SourceMod.ModKey, mutableCache);
     }
     
     /// <inheritdoc />
@@ -1084,6 +1119,7 @@ public sealed class MutableLoadOrderLinkCache<TMod, TModGetter> : ILinkCache<TMo
 {
     public ImmutableLoadOrderLinkCache<TMod, TModGetter> WrappedImmutableCache { get; }
     private readonly List<MutableModLinkCache<TMod, TModGetter>> _mutableMods;
+    private readonly Dictionary<ModKey, MutableModLinkCache<TMod, TModGetter>> _mutableModsByKey;
     private bool _disposed;
 
     /// <summary>
@@ -1096,6 +1132,7 @@ public sealed class MutableLoadOrderLinkCache<TMod, TModGetter> : ILinkCache<TMo
     {
         WrappedImmutableCache = immutableBaseCache;
         _mutableMods = mutableMods.Select(m => m.ToMutableLinkCache<TMod, TModGetter>()).ToList();
+        _mutableModsByKey = MakeModsByKey(_mutableMods);
         ListedOrder = WrappedImmutableCache.ListedOrder.Concat(_mutableMods.Select(x => x.SourceMod)).ToArray();
         PriorityOrder = ListedOrder.Reverse().ToArray();
     }
@@ -1109,8 +1146,20 @@ public sealed class MutableLoadOrderLinkCache<TMod, TModGetter> : ILinkCache<TMo
     {
         WrappedImmutableCache = ImmutableLoadOrderLinkCache<TMod, TModGetter>.Empty;
         _mutableMods = mutableMods.Select(m => m.ToMutableLinkCache<TMod, TModGetter>()).ToList();
+        _mutableModsByKey = MakeModsByKey(_mutableMods);
         ListedOrder = _mutableMods.Select(x => x.SourceMod).ToArray();
         PriorityOrder = ListedOrder.Reverse().ToArray();
+    }
+
+    private static Dictionary<ModKey, MutableModLinkCache<TMod, TModGetter>> MakeModsByKey(List<MutableModLinkCache<TMod, TModGetter>> mutableMods)
+    {
+        var ret = new Dictionary<ModKey, MutableModLinkCache<TMod, TModGetter>>();
+        foreach (var mod in mutableMods)
+        {
+            ret.TryAdd(mod.SourceMod.ModKey, mod);
+        }
+
+        return ret;
     }
 
     /// <inheritdoc />
@@ -1125,6 +1174,32 @@ public sealed class MutableLoadOrderLinkCache<TMod, TModGetter> : ILinkCache<TMo
         {
             throw new ObjectDisposedException($"MutableLoadOrderLinkCache<{typeof(TMod)}, {typeof(TModGetter)}>");
         }
+    }
+
+    /// <inheritdoc />
+    public bool TryGetLinkCacheForMod(ModKey modKey, [MaybeNullWhen(false)] out ILinkCache cache)
+    {
+        CheckDisposal();
+        if (_mutableModsByKey.TryGetValue(modKey, out var mod))
+        {
+            cache = mod;
+            return true;
+        }
+
+        return WrappedImmutableCache.TryGetLinkCacheForMod(modKey, out cache);
+    }
+
+    /// <inheritdoc />
+    public bool TryGetTypedLinkCacheForMod(ModKey modKey, [MaybeNullWhen(false)] out ILinkCache<TMod, TModGetter> cache)
+    {
+        CheckDisposal();
+        if (_mutableModsByKey.TryGetValue(modKey, out var mod))
+        {
+            cache = mod;
+            return true;
+        }
+
+        return WrappedImmutableCache.TryGetTypedLinkCacheForMod(modKey, out cache);
     }
 
     /// <inheritdoc />
@@ -1310,7 +1385,9 @@ public sealed class MutableLoadOrderLinkCache<TMod, TModGetter> : ILinkCache<TMo
     public void Add(TMod mod)
     {
         CheckDisposal();
-        _mutableMods.Add(mod.ToMutableLinkCache<TMod, TModGetter>());
+        var mutableCache = mod.ToMutableLinkCache<TMod, TModGetter>();
+        _mutableMods.Add(mutableCache);
+        _mutableModsByKey.TryAdd(mutableCache.SourceMod.ModKey, mutableCache);
     }
 
     /// <inheritdoc />

--- a/Mutagen.Bethesda.Core/Plugins/Cache/Internals/Implementations/MutableModLinkCache.cs
+++ b/Mutagen.Bethesda.Core/Plugins/Cache/Internals/Implementations/MutableModLinkCache.cs
@@ -49,11 +49,25 @@ public sealed class MutableModLinkCache : ILinkCache
     }
 
     /// <inheritdoc />
+    public bool TryGetLinkCacheForMod(ModKey modKey, [MaybeNullWhen(false)] out ILinkCache cache)
+    {
+        CheckDisposal();
+        if (modKey == _sourceMod.ModKey)
+        {
+            cache = this;
+            return true;
+        }
+
+        cache = null;
+        return false;
+    }
+
+    /// <inheritdoc />
     [Obsolete("This call is not as optimized as its generic typed counterpart.  Use as a last resort.")]
     public bool TryResolve(FormKey formKey, [MaybeNullWhen(false)] out IMajorRecordGetter majorRec, ResolveTarget target = ResolveTarget.Winner)
     {
         CheckDisposal();
-            
+
         if (formKey.IsNull)
         {
             majorRec = default;
@@ -1136,11 +1150,39 @@ public sealed class MutableModLinkCache<TMod, TModGetter> : ILinkCache<TMod, TMo
     }
 
     /// <inheritdoc />
+    public bool TryGetLinkCacheForMod(ModKey modKey, [MaybeNullWhen(false)] out ILinkCache cache)
+    {
+        CheckDisposal();
+        if (modKey == _sourceMod.ModKey)
+        {
+            cache = this;
+            return true;
+        }
+
+        cache = null;
+        return false;
+    }
+
+    /// <inheritdoc />
+    public bool TryGetTypedLinkCacheForMod(ModKey modKey, [MaybeNullWhen(false)] out ILinkCache<TMod, TModGetter> cache)
+    {
+        CheckDisposal();
+        if (modKey == _sourceMod.ModKey)
+        {
+            cache = this;
+            return true;
+        }
+
+        cache = null;
+        return false;
+    }
+
+    /// <inheritdoc />
     [Obsolete("This call is not as optimized as its generic typed counterpart.  Use as a last resort.")]
     public bool TryResolve(FormKey formKey, [MaybeNullWhen(false)] out IMajorRecordGetter majorRec, ResolveTarget target = ResolveTarget.Winner)
     {
         CheckDisposal();
-            
+
         if (formKey.IsNull)
         {
             majorRec = default;

--- a/Mutagen.Bethesda.Core/Plugins/Cache/LinkCacheFromModMixIn.cs
+++ b/Mutagen.Bethesda.Core/Plugins/Cache/LinkCacheFromModMixIn.cs
@@ -1,0 +1,733 @@
+using System.Diagnostics.CodeAnalysis;
+using Mutagen.Bethesda.Plugins.Exceptions;
+using Mutagen.Bethesda.Plugins.Records;
+
+namespace Mutagen.Bethesda.Plugins.Cache;
+
+/// <summary>
+/// Extension methods that resolve records against the contribution of one specific mod within a cache,
+/// located by its ModKey.<br/>
+/// <br/>
+/// Unlike <see cref="ResolveTarget.Winner"/> or <see cref="ResolveTarget.Origin"/> resolution, these
+/// methods do not search the load order for the winning override or the origin definition.  They instead
+/// scope resolution to the record as it exists within the single mod matching the given ModKey.<br/>
+/// <br/>
+/// If the cache does not contain a mod matching the given ModKey, the Try variants return false and the
+/// throwing variants throw a <see cref="MissingRecordException"/>.
+/// </summary>
+public static class LinkCacheFromModMixIn
+{
+    #region TryResolveFromMod (Generic)
+
+    /// <summary>
+    /// Retrieves the record that matches the FormKey within the contribution of the mod matching the given ModKey.
+    /// </summary>
+    /// <param name="cache">LinkCache to resolve against</param>
+    /// <param name="formKey">FormKey to look for</param>
+    /// <param name="modKey">ModKey of the mod to scope resolution to</param>
+    /// <param name="majorRec">Out parameter containing the record if successful</param>
+    /// <returns>True if the mod was found and contained a matching record</returns>
+    /// <typeparam name="TMajor">The type of Major Record to look up</typeparam>
+    public static bool TryResolveFromMod<TMajor>(this ILinkCache cache, FormKey formKey, ModKey modKey, [MaybeNullWhen(false)] out TMajor majorRec)
+        where TMajor : class, IMajorRecordQueryableGetter
+    {
+        if (!cache.TryGetLinkCacheForMod(modKey, out var modCache))
+        {
+            majorRec = default;
+            return false;
+        }
+
+        return modCache.TryResolve(formKey, out majorRec);
+    }
+
+    /// <summary>
+    /// Retrieves the record that matches the FormLink within the contribution of the mod matching the given ModKey.
+    /// </summary>
+    /// <param name="cache">LinkCache to resolve against</param>
+    /// <param name="formLink">FormLink to look for</param>
+    /// <param name="modKey">ModKey of the mod to scope resolution to</param>
+    /// <param name="majorRec">Out parameter containing the record if successful</param>
+    /// <returns>True if the mod was found and contained a matching record</returns>
+    /// <typeparam name="TMajor">The type of Major Record to look up</typeparam>
+    public static bool TryResolveFromMod<TMajor>(this ILinkCache cache, IFormLinkGetter<TMajor> formLink, ModKey modKey, [MaybeNullWhen(false)] out TMajor majorRec)
+        where TMajor : class, IMajorRecordGetter
+    {
+        if (!cache.TryGetLinkCacheForMod(modKey, out var modCache))
+        {
+            majorRec = default;
+            return false;
+        }
+
+        return modCache.TryResolve(formLink, out majorRec);
+    }
+
+    /// <summary>
+    /// Retrieves the record that matches the EditorID within the contribution of the mod matching the given ModKey.
+    /// </summary>
+    /// <param name="cache">LinkCache to resolve against</param>
+    /// <param name="editorId">EditorID to look for</param>
+    /// <param name="modKey">ModKey of the mod to scope resolution to</param>
+    /// <param name="majorRec">Out parameter containing the record if successful</param>
+    /// <returns>True if the mod was found and contained a matching record</returns>
+    /// <typeparam name="TMajor">The type of Major Record to look up</typeparam>
+    public static bool TryResolveFromMod<TMajor>(this ILinkCache cache, string editorId, ModKey modKey, [MaybeNullWhen(false)] out TMajor majorRec)
+        where TMajor : class, IMajorRecordQueryableGetter
+    {
+        if (!cache.TryGetLinkCacheForMod(modKey, out var modCache))
+        {
+            majorRec = default;
+            return false;
+        }
+
+        return modCache.TryResolve(editorId, out majorRec);
+    }
+
+    #endregion
+
+    #region TryResolveFromMod (Type)
+
+    /// <summary>
+    /// Retrieves the record that matches the FormKey and Type within the contribution of the mod matching the given ModKey.
+    /// </summary>
+    /// <param name="cache">LinkCache to resolve against</param>
+    /// <param name="formKey">FormKey to look for</param>
+    /// <param name="type">Type of record to look up</param>
+    /// <param name="modKey">ModKey of the mod to scope resolution to</param>
+    /// <param name="majorRec">Out parameter containing the record if successful</param>
+    /// <returns>True if the mod was found and contained a matching record</returns>
+    public static bool TryResolveFromMod(this ILinkCache cache, FormKey formKey, Type type, ModKey modKey, [MaybeNullWhen(false)] out IMajorRecordGetter majorRec)
+    {
+        if (!cache.TryGetLinkCacheForMod(modKey, out var modCache))
+        {
+            majorRec = default;
+            return false;
+        }
+
+        return modCache.TryResolve(formKey, type, out majorRec);
+    }
+
+    /// <summary>
+    /// Retrieves the record that matches the FormLink within the contribution of the mod matching the given ModKey.
+    /// </summary>
+    /// <param name="cache">LinkCache to resolve against</param>
+    /// <param name="formLink">FormLink to look for</param>
+    /// <param name="modKey">ModKey of the mod to scope resolution to</param>
+    /// <param name="majorRec">Out parameter containing the record if successful</param>
+    /// <returns>True if the mod was found and contained a matching record</returns>
+    public static bool TryResolveFromMod(this ILinkCache cache, IFormLinkIdentifier formLink, ModKey modKey, [MaybeNullWhen(false)] out IMajorRecordGetter majorRec)
+    {
+        if (!cache.TryGetLinkCacheForMod(modKey, out var modCache))
+        {
+            majorRec = default;
+            return false;
+        }
+
+        return modCache.TryResolve(formLink, out majorRec);
+    }
+
+    /// <summary>
+    /// Retrieves the record that matches the EditorID and Type within the contribution of the mod matching the given ModKey.
+    /// </summary>
+    /// <param name="cache">LinkCache to resolve against</param>
+    /// <param name="editorId">EditorID to look for</param>
+    /// <param name="type">Type of record to look up</param>
+    /// <param name="modKey">ModKey of the mod to scope resolution to</param>
+    /// <param name="majorRec">Out parameter containing the record if successful</param>
+    /// <returns>True if the mod was found and contained a matching record</returns>
+    public static bool TryResolveFromMod(this ILinkCache cache, string editorId, Type type, ModKey modKey, [MaybeNullWhen(false)] out IMajorRecordGetter majorRec)
+    {
+        if (!cache.TryGetLinkCacheForMod(modKey, out var modCache))
+        {
+            majorRec = default;
+            return false;
+        }
+
+        return modCache.TryResolve(editorId, type, out majorRec);
+    }
+
+    #endregion
+
+    #region ResolveFromMod (Generic)
+
+    /// <summary>
+    /// Retrieves the record that matches the FormKey within the contribution of the mod matching the given ModKey.
+    /// </summary>
+    /// <param name="cache">LinkCache to resolve against</param>
+    /// <param name="formKey">FormKey to look for</param>
+    /// <param name="modKey">ModKey of the mod to scope resolution to</param>
+    /// <returns>Matching record</returns>
+    /// <typeparam name="TMajor">The type of Major Record to look up</typeparam>
+    /// <exception cref="MissingRecordException">If the mod was not found, or did not contain a matching record</exception>
+    public static TMajor ResolveFromMod<TMajor>(this ILinkCache cache, FormKey formKey, ModKey modKey)
+        where TMajor : class, IMajorRecordQueryableGetter
+    {
+        if (TryResolveFromMod<TMajor>(cache, formKey, modKey, out var majorRec)) return majorRec;
+        throw new MissingRecordException(formKey, typeof(TMajor));
+    }
+
+    /// <summary>
+    /// Retrieves the record that matches the FormLink within the contribution of the mod matching the given ModKey.
+    /// </summary>
+    /// <param name="cache">LinkCache to resolve against</param>
+    /// <param name="formLink">FormLink to look for</param>
+    /// <param name="modKey">ModKey of the mod to scope resolution to</param>
+    /// <returns>Matching record</returns>
+    /// <typeparam name="TMajor">The type of Major Record to look up</typeparam>
+    /// <exception cref="MissingRecordException">If the mod was not found, or did not contain a matching record</exception>
+    public static TMajor ResolveFromMod<TMajor>(this ILinkCache cache, IFormLinkGetter<TMajor> formLink, ModKey modKey)
+        where TMajor : class, IMajorRecordGetter
+    {
+        if (TryResolveFromMod<TMajor>(cache, formLink, modKey, out var majorRec)) return majorRec;
+        throw new MissingRecordException(formLink.FormKey, typeof(TMajor));
+    }
+
+    /// <summary>
+    /// Retrieves the record that matches the EditorID within the contribution of the mod matching the given ModKey.
+    /// </summary>
+    /// <param name="cache">LinkCache to resolve against</param>
+    /// <param name="editorId">EditorID to look for</param>
+    /// <param name="modKey">ModKey of the mod to scope resolution to</param>
+    /// <returns>Matching record</returns>
+    /// <typeparam name="TMajor">The type of Major Record to look up</typeparam>
+    /// <exception cref="MissingRecordException">If the mod was not found, or did not contain a matching record</exception>
+    public static TMajor ResolveFromMod<TMajor>(this ILinkCache cache, string editorId, ModKey modKey)
+        where TMajor : class, IMajorRecordQueryableGetter
+    {
+        if (TryResolveFromMod<TMajor>(cache, editorId, modKey, out var majorRec)) return majorRec;
+        throw new MissingRecordException(editorId, typeof(TMajor));
+    }
+
+    #endregion
+
+    #region ResolveFromMod (Type)
+
+    /// <summary>
+    /// Retrieves the record that matches the FormKey and Type within the contribution of the mod matching the given ModKey.
+    /// </summary>
+    /// <param name="cache">LinkCache to resolve against</param>
+    /// <param name="formKey">FormKey to look for</param>
+    /// <param name="type">Type of record to look up</param>
+    /// <param name="modKey">ModKey of the mod to scope resolution to</param>
+    /// <returns>Matching record</returns>
+    /// <exception cref="MissingRecordException">If the mod was not found, or did not contain a matching record</exception>
+    public static IMajorRecordGetter ResolveFromMod(this ILinkCache cache, FormKey formKey, Type type, ModKey modKey)
+    {
+        if (TryResolveFromMod(cache, formKey, type, modKey, out var majorRec)) return majorRec;
+        throw new MissingRecordException(formKey, type);
+    }
+
+    /// <summary>
+    /// Retrieves the record that matches the FormLink within the contribution of the mod matching the given ModKey.
+    /// </summary>
+    /// <param name="cache">LinkCache to resolve against</param>
+    /// <param name="formLink">FormLink to look for</param>
+    /// <param name="modKey">ModKey of the mod to scope resolution to</param>
+    /// <returns>Matching record</returns>
+    /// <exception cref="MissingRecordException">If the mod was not found, or did not contain a matching record</exception>
+    public static IMajorRecordGetter ResolveFromMod(this ILinkCache cache, IFormLinkIdentifier formLink, ModKey modKey)
+    {
+        if (TryResolveFromMod(cache, formLink, modKey, out var majorRec)) return majorRec;
+        throw new MissingRecordException(formLink);
+    }
+
+    /// <summary>
+    /// Retrieves the record that matches the EditorID and Type within the contribution of the mod matching the given ModKey.
+    /// </summary>
+    /// <param name="cache">LinkCache to resolve against</param>
+    /// <param name="editorId">EditorID to look for</param>
+    /// <param name="type">Type of record to look up</param>
+    /// <param name="modKey">ModKey of the mod to scope resolution to</param>
+    /// <returns>Matching record</returns>
+    /// <exception cref="MissingRecordException">If the mod was not found, or did not contain a matching record</exception>
+    public static IMajorRecordGetter ResolveFromMod(this ILinkCache cache, string editorId, Type type, ModKey modKey)
+    {
+        if (TryResolveFromMod(cache, editorId, type, modKey, out var majorRec)) return majorRec;
+        throw new MissingRecordException(editorId, type);
+    }
+
+    #endregion
+
+    #region TryResolveSimpleContextFromMod (Generic)
+
+    /// <summary>
+    /// Retrieves the record context that matches the FormKey within the contribution of the mod matching the given ModKey.
+    /// </summary>
+    /// <param name="cache">LinkCache to resolve against</param>
+    /// <param name="formKey">FormKey to look for</param>
+    /// <param name="modKey">ModKey of the mod to scope resolution to</param>
+    /// <param name="majorRec">Out parameter containing the record context if successful</param>
+    /// <returns>True if the mod was found and contained a matching record</returns>
+    /// <typeparam name="TMajor">The type of Major Record to look up</typeparam>
+    public static bool TryResolveSimpleContextFromMod<TMajor>(this ILinkCache cache, FormKey formKey, ModKey modKey, [MaybeNullWhen(false)] out IModContext<TMajor> majorRec)
+        where TMajor : class, IMajorRecordQueryableGetter
+    {
+        if (!cache.TryGetLinkCacheForMod(modKey, out var modCache))
+        {
+            majorRec = default;
+            return false;
+        }
+
+        return modCache.TryResolveSimpleContext(formKey, out majorRec);
+    }
+
+    /// <summary>
+    /// Retrieves the record context that matches the FormLink within the contribution of the mod matching the given ModKey.
+    /// </summary>
+    /// <param name="cache">LinkCache to resolve against</param>
+    /// <param name="formLink">FormLink to look for</param>
+    /// <param name="modKey">ModKey of the mod to scope resolution to</param>
+    /// <param name="majorRec">Out parameter containing the record context if successful</param>
+    /// <returns>True if the mod was found and contained a matching record</returns>
+    /// <typeparam name="TMajor">The type of Major Record to look up</typeparam>
+    public static bool TryResolveSimpleContextFromMod<TMajor>(this ILinkCache cache, IFormLinkGetter<TMajor> formLink, ModKey modKey, [MaybeNullWhen(false)] out IModContext<TMajor> majorRec)
+        where TMajor : class, IMajorRecordGetter
+    {
+        if (!cache.TryGetLinkCacheForMod(modKey, out var modCache))
+        {
+            majorRec = default;
+            return false;
+        }
+
+        return modCache.TryResolveSimpleContext(formLink, out majorRec);
+    }
+
+    /// <summary>
+    /// Retrieves the record context that matches the EditorID within the contribution of the mod matching the given ModKey.
+    /// </summary>
+    /// <param name="cache">LinkCache to resolve against</param>
+    /// <param name="editorId">EditorID to look for</param>
+    /// <param name="modKey">ModKey of the mod to scope resolution to</param>
+    /// <param name="majorRec">Out parameter containing the record context if successful</param>
+    /// <returns>True if the mod was found and contained a matching record</returns>
+    /// <typeparam name="TMajor">The type of Major Record to look up</typeparam>
+    public static bool TryResolveSimpleContextFromMod<TMajor>(this ILinkCache cache, string editorId, ModKey modKey, [MaybeNullWhen(false)] out IModContext<TMajor> majorRec)
+        where TMajor : class, IMajorRecordQueryableGetter
+    {
+        if (!cache.TryGetLinkCacheForMod(modKey, out var modCache))
+        {
+            majorRec = default;
+            return false;
+        }
+
+        return modCache.TryResolveSimpleContext(editorId, out majorRec);
+    }
+
+    #endregion
+
+    #region TryResolveSimpleContextFromMod (Type)
+
+    /// <summary>
+    /// Retrieves the record context that matches the FormKey and Type within the contribution of the mod matching the given ModKey.
+    /// </summary>
+    /// <param name="cache">LinkCache to resolve against</param>
+    /// <param name="formKey">FormKey to look for</param>
+    /// <param name="type">Type of record to look up</param>
+    /// <param name="modKey">ModKey of the mod to scope resolution to</param>
+    /// <param name="majorRec">Out parameter containing the record context if successful</param>
+    /// <returns>True if the mod was found and contained a matching record</returns>
+    public static bool TryResolveSimpleContextFromMod(this ILinkCache cache, FormKey formKey, Type type, ModKey modKey, [MaybeNullWhen(false)] out IModContext<IMajorRecordGetter> majorRec)
+    {
+        if (!cache.TryGetLinkCacheForMod(modKey, out var modCache))
+        {
+            majorRec = default;
+            return false;
+        }
+
+        return modCache.TryResolveSimpleContext(formKey, type, out majorRec);
+    }
+
+    /// <summary>
+    /// Retrieves the record context that matches the FormLink within the contribution of the mod matching the given ModKey.
+    /// </summary>
+    /// <param name="cache">LinkCache to resolve against</param>
+    /// <param name="formLink">FormLink to look for</param>
+    /// <param name="modKey">ModKey of the mod to scope resolution to</param>
+    /// <param name="majorRec">Out parameter containing the record context if successful</param>
+    /// <returns>True if the mod was found and contained a matching record</returns>
+    public static bool TryResolveSimpleContextFromMod(this ILinkCache cache, IFormLinkIdentifier formLink, ModKey modKey, [MaybeNullWhen(false)] out IModContext<IMajorRecordGetter> majorRec)
+    {
+        if (!cache.TryGetLinkCacheForMod(modKey, out var modCache))
+        {
+            majorRec = default;
+            return false;
+        }
+
+        return modCache.TryResolveSimpleContext(formLink, out majorRec);
+    }
+
+    /// <summary>
+    /// Retrieves the record context that matches the EditorID and Type within the contribution of the mod matching the given ModKey.
+    /// </summary>
+    /// <param name="cache">LinkCache to resolve against</param>
+    /// <param name="editorId">EditorID to look for</param>
+    /// <param name="type">Type of record to look up</param>
+    /// <param name="modKey">ModKey of the mod to scope resolution to</param>
+    /// <param name="majorRec">Out parameter containing the record context if successful</param>
+    /// <returns>True if the mod was found and contained a matching record</returns>
+    public static bool TryResolveSimpleContextFromMod(this ILinkCache cache, string editorId, Type type, ModKey modKey, [MaybeNullWhen(false)] out IModContext<IMajorRecordGetter> majorRec)
+    {
+        if (!cache.TryGetLinkCacheForMod(modKey, out var modCache))
+        {
+            majorRec = default;
+            return false;
+        }
+
+        return modCache.TryResolveSimpleContext(editorId, type, out majorRec);
+    }
+
+    #endregion
+
+    #region ResolveSimpleContextFromMod (Generic)
+
+    /// <summary>
+    /// Retrieves the record context that matches the FormKey within the contribution of the mod matching the given ModKey.
+    /// </summary>
+    /// <param name="cache">LinkCache to resolve against</param>
+    /// <param name="formKey">FormKey to look for</param>
+    /// <param name="modKey">ModKey of the mod to scope resolution to</param>
+    /// <returns>Matching record context</returns>
+    /// <typeparam name="TMajor">The type of Major Record to look up</typeparam>
+    /// <exception cref="MissingRecordException">If the mod was not found, or did not contain a matching record</exception>
+    public static IModContext<TMajor> ResolveSimpleContextFromMod<TMajor>(this ILinkCache cache, FormKey formKey, ModKey modKey)
+        where TMajor : class, IMajorRecordQueryableGetter
+    {
+        if (TryResolveSimpleContextFromMod<TMajor>(cache, formKey, modKey, out var majorRec)) return majorRec;
+        throw new MissingRecordException(formKey, typeof(TMajor));
+    }
+
+    /// <summary>
+    /// Retrieves the record context that matches the FormLink within the contribution of the mod matching the given ModKey.
+    /// </summary>
+    /// <param name="cache">LinkCache to resolve against</param>
+    /// <param name="formLink">FormLink to look for</param>
+    /// <param name="modKey">ModKey of the mod to scope resolution to</param>
+    /// <returns>Matching record context</returns>
+    /// <typeparam name="TMajor">The type of Major Record to look up</typeparam>
+    /// <exception cref="MissingRecordException">If the mod was not found, or did not contain a matching record</exception>
+    public static IModContext<TMajor> ResolveSimpleContextFromMod<TMajor>(this ILinkCache cache, IFormLinkGetter<TMajor> formLink, ModKey modKey)
+        where TMajor : class, IMajorRecordGetter
+    {
+        if (TryResolveSimpleContextFromMod<TMajor>(cache, formLink, modKey, out var majorRec)) return majorRec;
+        throw new MissingRecordException(formLink.FormKey, typeof(TMajor));
+    }
+
+    /// <summary>
+    /// Retrieves the record context that matches the EditorID within the contribution of the mod matching the given ModKey.
+    /// </summary>
+    /// <param name="cache">LinkCache to resolve against</param>
+    /// <param name="editorId">EditorID to look for</param>
+    /// <param name="modKey">ModKey of the mod to scope resolution to</param>
+    /// <returns>Matching record context</returns>
+    /// <typeparam name="TMajor">The type of Major Record to look up</typeparam>
+    /// <exception cref="MissingRecordException">If the mod was not found, or did not contain a matching record</exception>
+    public static IModContext<TMajor> ResolveSimpleContextFromMod<TMajor>(this ILinkCache cache, string editorId, ModKey modKey)
+        where TMajor : class, IMajorRecordQueryableGetter
+    {
+        if (TryResolveSimpleContextFromMod<TMajor>(cache, editorId, modKey, out var majorRec)) return majorRec;
+        throw new MissingRecordException(editorId, typeof(TMajor));
+    }
+
+    #endregion
+
+    #region ResolveSimpleContextFromMod (Type)
+
+    /// <summary>
+    /// Retrieves the record context that matches the FormKey and Type within the contribution of the mod matching the given ModKey.
+    /// </summary>
+    /// <param name="cache">LinkCache to resolve against</param>
+    /// <param name="formKey">FormKey to look for</param>
+    /// <param name="type">Type of record to look up</param>
+    /// <param name="modKey">ModKey of the mod to scope resolution to</param>
+    /// <returns>Matching record context</returns>
+    /// <exception cref="MissingRecordException">If the mod was not found, or did not contain a matching record</exception>
+    public static IModContext<IMajorRecordGetter> ResolveSimpleContextFromMod(this ILinkCache cache, FormKey formKey, Type type, ModKey modKey)
+    {
+        if (TryResolveSimpleContextFromMod(cache, formKey, type, modKey, out var majorRec)) return majorRec;
+        throw new MissingRecordException(formKey, type);
+    }
+
+    /// <summary>
+    /// Retrieves the record context that matches the FormLink within the contribution of the mod matching the given ModKey.
+    /// </summary>
+    /// <param name="cache">LinkCache to resolve against</param>
+    /// <param name="formLink">FormLink to look for</param>
+    /// <param name="modKey">ModKey of the mod to scope resolution to</param>
+    /// <returns>Matching record context</returns>
+    /// <exception cref="MissingRecordException">If the mod was not found, or did not contain a matching record</exception>
+    public static IModContext<IMajorRecordGetter> ResolveSimpleContextFromMod(this ILinkCache cache, IFormLinkIdentifier formLink, ModKey modKey)
+    {
+        if (TryResolveSimpleContextFromMod(cache, formLink, modKey, out var majorRec)) return majorRec;
+        throw new MissingRecordException(formLink);
+    }
+
+    /// <summary>
+    /// Retrieves the record context that matches the EditorID and Type within the contribution of the mod matching the given ModKey.
+    /// </summary>
+    /// <param name="cache">LinkCache to resolve against</param>
+    /// <param name="editorId">EditorID to look for</param>
+    /// <param name="type">Type of record to look up</param>
+    /// <param name="modKey">ModKey of the mod to scope resolution to</param>
+    /// <returns>Matching record context</returns>
+    /// <exception cref="MissingRecordException">If the mod was not found, or did not contain a matching record</exception>
+    public static IModContext<IMajorRecordGetter> ResolveSimpleContextFromMod(this ILinkCache cache, string editorId, Type type, ModKey modKey)
+    {
+        if (TryResolveSimpleContextFromMod(cache, editorId, type, modKey, out var majorRec)) return majorRec;
+        throw new MissingRecordException(editorId, type);
+    }
+
+    #endregion
+
+    #region TryResolveContextFromMod (Generic)
+
+    /// <summary>
+    /// Retrieves the record context that matches the FormKey within the contribution of the mod matching the given ModKey.
+    /// </summary>
+    /// <param name="cache">LinkCache to resolve against</param>
+    /// <param name="formKey">FormKey to look for</param>
+    /// <param name="modKey">ModKey of the mod to scope resolution to</param>
+    /// <param name="majorRec">Out parameter containing the record context if successful</param>
+    /// <returns>True if the mod was found and contained a matching record</returns>
+    public static bool TryResolveContextFromMod<TMod, TModGetter, TMajor, TMajorGetter>(this ILinkCache<TMod, TModGetter> cache, FormKey formKey, ModKey modKey, [MaybeNullWhen(false)] out IModContext<TMod, TModGetter, TMajor, TMajorGetter> majorRec)
+        where TModGetter : class, IModGetter
+        where TMod : class, TModGetter, IMod
+        where TMajor : class, IMajorRecordQueryable, TMajorGetter
+        where TMajorGetter : class, IMajorRecordQueryableGetter
+    {
+        if (!cache.TryGetTypedLinkCacheForMod(modKey, out var modCache))
+        {
+            majorRec = default;
+            return false;
+        }
+
+        return modCache.TryResolveContext<TMajor, TMajorGetter>(formKey, out majorRec);
+    }
+
+    /// <summary>
+    /// Retrieves the record context that matches the FormLink within the contribution of the mod matching the given ModKey.
+    /// </summary>
+    /// <param name="cache">LinkCache to resolve against</param>
+    /// <param name="formLink">FormLink to look for</param>
+    /// <param name="modKey">ModKey of the mod to scope resolution to</param>
+    /// <param name="majorRec">Out parameter containing the record context if successful</param>
+    /// <returns>True if the mod was found and contained a matching record</returns>
+    public static bool TryResolveContextFromMod<TMod, TModGetter, TMajor, TMajorGetter>(this ILinkCache<TMod, TModGetter> cache, IFormLinkGetter<TMajorGetter> formLink, ModKey modKey, [MaybeNullWhen(false)] out IModContext<TMod, TModGetter, TMajor, TMajorGetter> majorRec)
+        where TModGetter : class, IModGetter
+        where TMod : class, TModGetter, IMod
+        where TMajor : class, IMajorRecord, TMajorGetter
+        where TMajorGetter : class, IMajorRecordGetter
+    {
+        if (!cache.TryGetTypedLinkCacheForMod(modKey, out var modCache))
+        {
+            majorRec = default;
+            return false;
+        }
+
+        return modCache.TryResolveContext<TMajor, TMajorGetter>(formLink, out majorRec);
+    }
+
+    /// <summary>
+    /// Retrieves the record context that matches the EditorID within the contribution of the mod matching the given ModKey.
+    /// </summary>
+    /// <param name="cache">LinkCache to resolve against</param>
+    /// <param name="editorId">EditorID to look for</param>
+    /// <param name="modKey">ModKey of the mod to scope resolution to</param>
+    /// <param name="majorRec">Out parameter containing the record context if successful</param>
+    /// <returns>True if the mod was found and contained a matching record</returns>
+    public static bool TryResolveContextFromMod<TMod, TModGetter, TMajor, TMajorGetter>(this ILinkCache<TMod, TModGetter> cache, string editorId, ModKey modKey, [MaybeNullWhen(false)] out IModContext<TMod, TModGetter, TMajor, TMajorGetter> majorRec)
+        where TModGetter : class, IModGetter
+        where TMod : class, TModGetter, IMod
+        where TMajor : class, IMajorRecordQueryable, TMajorGetter
+        where TMajorGetter : class, IMajorRecordQueryableGetter
+    {
+        if (!cache.TryGetTypedLinkCacheForMod(modKey, out var modCache))
+        {
+            majorRec = default;
+            return false;
+        }
+
+        return modCache.TryResolveContext<TMajor, TMajorGetter>(editorId, out majorRec);
+    }
+
+    #endregion
+
+    #region TryResolveContextFromMod (Type)
+
+    /// <summary>
+    /// Retrieves the record context that matches the FormKey and Type within the contribution of the mod matching the given ModKey.
+    /// </summary>
+    /// <param name="cache">LinkCache to resolve against</param>
+    /// <param name="formKey">FormKey to look for</param>
+    /// <param name="type">Type of record to look up</param>
+    /// <param name="modKey">ModKey of the mod to scope resolution to</param>
+    /// <param name="majorRec">Out parameter containing the record context if successful</param>
+    /// <returns>True if the mod was found and contained a matching record</returns>
+    public static bool TryResolveContextFromMod<TMod, TModGetter>(this ILinkCache<TMod, TModGetter> cache, FormKey formKey, Type type, ModKey modKey, [MaybeNullWhen(false)] out IModContext<TMod, TModGetter, IMajorRecord, IMajorRecordGetter> majorRec)
+        where TModGetter : class, IModGetter
+        where TMod : class, TModGetter, IMod
+    {
+        if (!cache.TryGetTypedLinkCacheForMod(modKey, out var modCache))
+        {
+            majorRec = default;
+            return false;
+        }
+
+        return modCache.TryResolveContext(formKey, type, out majorRec);
+    }
+
+    /// <summary>
+    /// Retrieves the record context that matches the FormLink within the contribution of the mod matching the given ModKey.
+    /// </summary>
+    /// <param name="cache">LinkCache to resolve against</param>
+    /// <param name="formLink">FormLink to look for</param>
+    /// <param name="modKey">ModKey of the mod to scope resolution to</param>
+    /// <param name="majorRec">Out parameter containing the record context if successful</param>
+    /// <returns>True if the mod was found and contained a matching record</returns>
+    public static bool TryResolveContextFromMod<TMod, TModGetter>(this ILinkCache<TMod, TModGetter> cache, IFormLinkIdentifier formLink, ModKey modKey, [MaybeNullWhen(false)] out IModContext<TMod, TModGetter, IMajorRecord, IMajorRecordGetter> majorRec)
+        where TModGetter : class, IModGetter
+        where TMod : class, TModGetter, IMod
+    {
+        if (!cache.TryGetTypedLinkCacheForMod(modKey, out var modCache))
+        {
+            majorRec = default;
+            return false;
+        }
+
+        return modCache.TryResolveContext(formLink, out majorRec);
+    }
+
+    /// <summary>
+    /// Retrieves the record context that matches the EditorID and Type within the contribution of the mod matching the given ModKey.
+    /// </summary>
+    /// <param name="cache">LinkCache to resolve against</param>
+    /// <param name="editorId">EditorID to look for</param>
+    /// <param name="type">Type of record to look up</param>
+    /// <param name="modKey">ModKey of the mod to scope resolution to</param>
+    /// <param name="majorRec">Out parameter containing the record context if successful</param>
+    /// <returns>True if the mod was found and contained a matching record</returns>
+    public static bool TryResolveContextFromMod<TMod, TModGetter>(this ILinkCache<TMod, TModGetter> cache, string editorId, Type type, ModKey modKey, [MaybeNullWhen(false)] out IModContext<TMod, TModGetter, IMajorRecord, IMajorRecordGetter> majorRec)
+        where TModGetter : class, IModGetter
+        where TMod : class, TModGetter, IMod
+    {
+        if (!cache.TryGetTypedLinkCacheForMod(modKey, out var modCache))
+        {
+            majorRec = default;
+            return false;
+        }
+
+        return modCache.TryResolveContext(editorId, type, out majorRec);
+    }
+
+    #endregion
+
+    #region ResolveContextFromMod (Generic)
+
+    /// <summary>
+    /// Retrieves the record context that matches the FormKey within the contribution of the mod matching the given ModKey.
+    /// </summary>
+    /// <param name="cache">LinkCache to resolve against</param>
+    /// <param name="formKey">FormKey to look for</param>
+    /// <param name="modKey">ModKey of the mod to scope resolution to</param>
+    /// <returns>Matching record context</returns>
+    /// <exception cref="MissingRecordException">If the mod was not found, or did not contain a matching record</exception>
+    public static IModContext<TMod, TModGetter, TMajor, TMajorGetter> ResolveContextFromMod<TMod, TModGetter, TMajor, TMajorGetter>(this ILinkCache<TMod, TModGetter> cache, FormKey formKey, ModKey modKey)
+        where TModGetter : class, IModGetter
+        where TMod : class, TModGetter, IMod
+        where TMajor : class, IMajorRecordQueryable, TMajorGetter
+        where TMajorGetter : class, IMajorRecordQueryableGetter
+    {
+        if (TryResolveContextFromMod<TMod, TModGetter, TMajor, TMajorGetter>(cache, formKey, modKey, out var majorRec)) return majorRec;
+        throw new MissingRecordException(formKey, typeof(TMajorGetter));
+    }
+
+    /// <summary>
+    /// Retrieves the record context that matches the FormLink within the contribution of the mod matching the given ModKey.
+    /// </summary>
+    /// <param name="cache">LinkCache to resolve against</param>
+    /// <param name="formLink">FormLink to look for</param>
+    /// <param name="modKey">ModKey of the mod to scope resolution to</param>
+    /// <returns>Matching record context</returns>
+    /// <exception cref="MissingRecordException">If the mod was not found, or did not contain a matching record</exception>
+    public static IModContext<TMod, TModGetter, TMajor, TMajorGetter> ResolveContextFromMod<TMod, TModGetter, TMajor, TMajorGetter>(this ILinkCache<TMod, TModGetter> cache, IFormLinkGetter<TMajorGetter> formLink, ModKey modKey)
+        where TModGetter : class, IModGetter
+        where TMod : class, TModGetter, IMod
+        where TMajor : class, IMajorRecord, TMajorGetter
+        where TMajorGetter : class, IMajorRecordGetter
+    {
+        if (TryResolveContextFromMod<TMod, TModGetter, TMajor, TMajorGetter>(cache, formLink, modKey, out var majorRec)) return majorRec;
+        throw new MissingRecordException(formLink.FormKey, typeof(TMajorGetter));
+    }
+
+    /// <summary>
+    /// Retrieves the record context that matches the EditorID within the contribution of the mod matching the given ModKey.
+    /// </summary>
+    /// <param name="cache">LinkCache to resolve against</param>
+    /// <param name="editorId">EditorID to look for</param>
+    /// <param name="modKey">ModKey of the mod to scope resolution to</param>
+    /// <returns>Matching record context</returns>
+    /// <exception cref="MissingRecordException">If the mod was not found, or did not contain a matching record</exception>
+    public static IModContext<TMod, TModGetter, TMajor, TMajorGetter> ResolveContextFromMod<TMod, TModGetter, TMajor, TMajorGetter>(this ILinkCache<TMod, TModGetter> cache, string editorId, ModKey modKey)
+        where TModGetter : class, IModGetter
+        where TMod : class, TModGetter, IMod
+        where TMajor : class, IMajorRecordQueryable, TMajorGetter
+        where TMajorGetter : class, IMajorRecordQueryableGetter
+    {
+        if (TryResolveContextFromMod<TMod, TModGetter, TMajor, TMajorGetter>(cache, editorId, modKey, out var majorRec)) return majorRec;
+        throw new MissingRecordException(editorId, typeof(TMajorGetter));
+    }
+
+    #endregion
+
+    #region ResolveContextFromMod (Type)
+
+    /// <summary>
+    /// Retrieves the record context that matches the FormKey and Type within the contribution of the mod matching the given ModKey.
+    /// </summary>
+    /// <param name="cache">LinkCache to resolve against</param>
+    /// <param name="formKey">FormKey to look for</param>
+    /// <param name="type">Type of record to look up</param>
+    /// <param name="modKey">ModKey of the mod to scope resolution to</param>
+    /// <returns>Matching record context</returns>
+    /// <exception cref="MissingRecordException">If the mod was not found, or did not contain a matching record</exception>
+    public static IModContext<TMod, TModGetter, IMajorRecord, IMajorRecordGetter> ResolveContextFromMod<TMod, TModGetter>(this ILinkCache<TMod, TModGetter> cache, FormKey formKey, Type type, ModKey modKey)
+        where TModGetter : class, IModGetter
+        where TMod : class, TModGetter, IMod
+    {
+        if (TryResolveContextFromMod(cache, formKey, type, modKey, out var majorRec)) return majorRec;
+        throw new MissingRecordException(formKey, type);
+    }
+
+    /// <summary>
+    /// Retrieves the record context that matches the FormLink within the contribution of the mod matching the given ModKey.
+    /// </summary>
+    /// <param name="cache">LinkCache to resolve against</param>
+    /// <param name="formLink">FormLink to look for</param>
+    /// <param name="modKey">ModKey of the mod to scope resolution to</param>
+    /// <returns>Matching record context</returns>
+    /// <exception cref="MissingRecordException">If the mod was not found, or did not contain a matching record</exception>
+    public static IModContext<TMod, TModGetter, IMajorRecord, IMajorRecordGetter> ResolveContextFromMod<TMod, TModGetter>(this ILinkCache<TMod, TModGetter> cache, IFormLinkIdentifier formLink, ModKey modKey)
+        where TModGetter : class, IModGetter
+        where TMod : class, TModGetter, IMod
+    {
+        if (TryResolveContextFromMod(cache, formLink, modKey, out var majorRec)) return majorRec;
+        throw new MissingRecordException(formLink);
+    }
+
+    /// <summary>
+    /// Retrieves the record context that matches the EditorID and Type within the contribution of the mod matching the given ModKey.
+    /// </summary>
+    /// <param name="cache">LinkCache to resolve against</param>
+    /// <param name="editorId">EditorID to look for</param>
+    /// <param name="type">Type of record to look up</param>
+    /// <param name="modKey">ModKey of the mod to scope resolution to</param>
+    /// <returns>Matching record context</returns>
+    /// <exception cref="MissingRecordException">If the mod was not found, or did not contain a matching record</exception>
+    public static IModContext<TMod, TModGetter, IMajorRecord, IMajorRecordGetter> ResolveContextFromMod<TMod, TModGetter>(this ILinkCache<TMod, TModGetter> cache, string editorId, Type type, ModKey modKey)
+        where TModGetter : class, IModGetter
+        where TMod : class, TModGetter, IMod
+    {
+        if (TryResolveContextFromMod(cache, editorId, type, modKey, out var majorRec)) return majorRec;
+        throw new MissingRecordException(editorId, type);
+    }
+
+    #endregion
+}

--- a/Mutagen.Bethesda.Core/Plugins/Cache/LinkCacheFromModMixIn.cs
+++ b/Mutagen.Bethesda.Core/Plugins/Cache/LinkCacheFromModMixIn.cs
@@ -730,4 +730,319 @@ public static class LinkCacheFromModMixIn
     }
 
     #endregion
+
+    #region TryResolveIdentifierFromMod (Generic)
+
+    /// <summary>
+    /// Retrieves the EditorID that matches the FormKey within the contribution of the mod matching the given ModKey.
+    /// </summary>
+    /// <param name="cache">LinkCache to resolve against</param>
+    /// <param name="formKey">FormKey to look for</param>
+    /// <param name="modKey">ModKey of the mod to scope resolution to</param>
+    /// <param name="editorId">Out parameter containing the EditorID if successful</param>
+    /// <returns>True if the mod was found and contained a matching record</returns>
+    /// <typeparam name="TMajor">The type of Major Record to look up</typeparam>
+    public static bool TryResolveIdentifierFromMod<TMajor>(this ILinkCache cache, FormKey formKey, ModKey modKey, [MaybeNullWhen(false)] out string? editorId)
+        where TMajor : class, IMajorRecordQueryableGetter
+    {
+        if (!cache.TryGetLinkCacheForMod(modKey, out var modCache))
+        {
+            editorId = default;
+            return false;
+        }
+
+        return modCache.TryResolveIdentifier<TMajor>(formKey, out editorId);
+    }
+
+    /// <summary>
+    /// Retrieves the FormKey that matches the EditorID within the contribution of the mod matching the given ModKey.
+    /// </summary>
+    /// <param name="cache">LinkCache to resolve against</param>
+    /// <param name="editorId">EditorID to look for</param>
+    /// <param name="modKey">ModKey of the mod to scope resolution to</param>
+    /// <param name="formKey">Out parameter containing the FormKey if successful</param>
+    /// <returns>True if the mod was found and contained a matching record</returns>
+    /// <typeparam name="TMajor">The type of Major Record to look up</typeparam>
+    public static bool TryResolveIdentifierFromMod<TMajor>(this ILinkCache cache, string editorId, ModKey modKey, [MaybeNullWhen(false)] out FormKey formKey)
+        where TMajor : class, IMajorRecordQueryableGetter
+    {
+        if (!cache.TryGetLinkCacheForMod(modKey, out var modCache))
+        {
+            formKey = default;
+            return false;
+        }
+
+        return modCache.TryResolveIdentifier<TMajor>(editorId, out formKey);
+    }
+
+    #endregion
+
+    #region TryResolveIdentifierFromMod (Type)
+
+    /// <summary>
+    /// Retrieves the EditorID that matches the FormKey and Type within the contribution of the mod matching the given ModKey.
+    /// </summary>
+    /// <param name="cache">LinkCache to resolve against</param>
+    /// <param name="formKey">FormKey to look for</param>
+    /// <param name="type">Type of record to look up</param>
+    /// <param name="modKey">ModKey of the mod to scope resolution to</param>
+    /// <param name="editorId">Out parameter containing the EditorID if successful</param>
+    /// <returns>True if the mod was found and contained a matching record</returns>
+    public static bool TryResolveIdentifierFromMod(this ILinkCache cache, FormKey formKey, Type type, ModKey modKey, [MaybeNullWhen(false)] out string? editorId)
+    {
+        if (!cache.TryGetLinkCacheForMod(modKey, out var modCache))
+        {
+            editorId = default;
+            return false;
+        }
+
+        return modCache.TryResolveIdentifier(formKey, type, out editorId);
+    }
+
+    /// <summary>
+    /// Retrieves the EditorID that matches the FormLink within the contribution of the mod matching the given ModKey.
+    /// </summary>
+    /// <param name="cache">LinkCache to resolve against</param>
+    /// <param name="formLink">FormLink to look for</param>
+    /// <param name="modKey">ModKey of the mod to scope resolution to</param>
+    /// <param name="editorId">Out parameter containing the EditorID if successful</param>
+    /// <returns>True if the mod was found and contained a matching record</returns>
+    public static bool TryResolveIdentifierFromMod(this ILinkCache cache, IFormLinkIdentifier formLink, ModKey modKey, [MaybeNullWhen(false)] out string? editorId)
+    {
+        if (!cache.TryGetLinkCacheForMod(modKey, out var modCache))
+        {
+            editorId = default;
+            return false;
+        }
+
+        return modCache.TryResolveIdentifier(formLink, out editorId);
+    }
+
+    /// <summary>
+    /// Retrieves the FormKey that matches the EditorID and Type within the contribution of the mod matching the given ModKey.
+    /// </summary>
+    /// <param name="cache">LinkCache to resolve against</param>
+    /// <param name="editorId">EditorID to look for</param>
+    /// <param name="type">Type of record to look up</param>
+    /// <param name="modKey">ModKey of the mod to scope resolution to</param>
+    /// <param name="formKey">Out parameter containing the FormKey if successful</param>
+    /// <returns>True if the mod was found and contained a matching record</returns>
+    public static bool TryResolveIdentifierFromMod(this ILinkCache cache, string editorId, Type type, ModKey modKey, [MaybeNullWhen(false)] out FormKey formKey)
+    {
+        if (!cache.TryGetLinkCacheForMod(modKey, out var modCache))
+        {
+            formKey = default;
+            return false;
+        }
+
+        return modCache.TryResolveIdentifier(editorId, type, out formKey);
+    }
+
+    #endregion
+
+    #region TryResolveIdentifierFromMod (Types)
+
+    /// <summary>
+    /// Retrieves the EditorID that matches the FormKey and Types within the contribution of the mod matching the given ModKey.
+    /// </summary>
+    /// <param name="cache">LinkCache to resolve against</param>
+    /// <param name="formKey">FormKey to look for</param>
+    /// <param name="types">Types of records to look up</param>
+    /// <param name="modKey">ModKey of the mod to scope resolution to</param>
+    /// <param name="editorId">Out parameter containing the EditorID if successful</param>
+    /// <returns>True if the mod was found and contained a matching record</returns>
+    public static bool TryResolveIdentifierFromMod(this ILinkCache cache, FormKey formKey, IEnumerable<Type> types, ModKey modKey, [MaybeNullWhen(false)] out string? editorId)
+    {
+        if (!cache.TryGetLinkCacheForMod(modKey, out var modCache))
+        {
+            editorId = default;
+            return false;
+        }
+
+        return modCache.TryResolveIdentifier(formKey, types, out editorId);
+    }
+
+    /// <summary>
+    /// Retrieves the EditorID that matches the FormKey and Types within the contribution of the mod matching the given ModKey.
+    /// </summary>
+    /// <param name="cache">LinkCache to resolve against</param>
+    /// <param name="formKey">FormKey to look for</param>
+    /// <param name="types">Types of records to look up</param>
+    /// <param name="modKey">ModKey of the mod to scope resolution to</param>
+    /// <param name="editorId">Out parameter containing the EditorID if successful</param>
+    /// <param name="matchedType">Out parameter containing the type matched to, if successful</param>
+    /// <returns>True if the mod was found and contained a matching record</returns>
+    public static bool TryResolveIdentifierFromMod(this ILinkCache cache, FormKey formKey, IEnumerable<Type> types, ModKey modKey, [MaybeNullWhen(false)] out string? editorId, [MaybeNullWhen(false)] out Type matchedType)
+    {
+        if (!cache.TryGetLinkCacheForMod(modKey, out var modCache))
+        {
+            editorId = default;
+            matchedType = default;
+            return false;
+        }
+
+        return modCache.TryResolveIdentifier(formKey, types, out editorId, out matchedType);
+    }
+
+    /// <summary>
+    /// Retrieves the FormKey that matches the EditorID and Types within the contribution of the mod matching the given ModKey.
+    /// </summary>
+    /// <param name="cache">LinkCache to resolve against</param>
+    /// <param name="editorId">EditorID to look for</param>
+    /// <param name="types">Types of records to look up</param>
+    /// <param name="modKey">ModKey of the mod to scope resolution to</param>
+    /// <param name="formKey">Out parameter containing the FormKey if successful</param>
+    /// <returns>True if the mod was found and contained a matching record</returns>
+    public static bool TryResolveIdentifierFromMod(this ILinkCache cache, string editorId, IEnumerable<Type> types, ModKey modKey, [MaybeNullWhen(false)] out FormKey formKey)
+    {
+        if (!cache.TryGetLinkCacheForMod(modKey, out var modCache))
+        {
+            formKey = default;
+            return false;
+        }
+
+        return modCache.TryResolveIdentifier(editorId, types, out formKey);
+    }
+
+    /// <summary>
+    /// Retrieves the FormKey that matches the EditorID and Types within the contribution of the mod matching the given ModKey.
+    /// </summary>
+    /// <param name="cache">LinkCache to resolve against</param>
+    /// <param name="editorId">EditorID to look for</param>
+    /// <param name="types">Types of records to look up</param>
+    /// <param name="modKey">ModKey of the mod to scope resolution to</param>
+    /// <param name="formKey">Out parameter containing the FormKey if successful</param>
+    /// <param name="matchedType">Out parameter containing the type matched to, if successful</param>
+    /// <returns>True if the mod was found and contained a matching record</returns>
+    public static bool TryResolveIdentifierFromMod(this ILinkCache cache, string editorId, IEnumerable<Type> types, ModKey modKey, [MaybeNullWhen(false)] out FormKey formKey, [MaybeNullWhen(false)] out Type matchedType)
+    {
+        if (!cache.TryGetLinkCacheForMod(modKey, out var modCache))
+        {
+            formKey = default;
+            matchedType = default;
+            return false;
+        }
+
+        return modCache.TryResolveIdentifier(editorId, types, out formKey, out matchedType);
+    }
+
+    #endregion
+
+    #region ResolveIdentifierFromMod (Generic)
+
+    /// <summary>
+    /// Retrieves the EditorID that matches the FormKey within the contribution of the mod matching the given ModKey.
+    /// </summary>
+    /// <param name="cache">LinkCache to resolve against</param>
+    /// <param name="formKey">FormKey to look for</param>
+    /// <param name="modKey">ModKey of the mod to scope resolution to</param>
+    /// <returns>The EditorID</returns>
+    /// <typeparam name="TMajor">The type of Major Record to look up</typeparam>
+    /// <exception cref="MissingRecordException">If the mod was not found, or did not contain a matching record</exception>
+    public static string? ResolveIdentifierFromMod<TMajor>(this ILinkCache cache, FormKey formKey, ModKey modKey)
+        where TMajor : class, IMajorRecordQueryableGetter
+    {
+        if (TryResolveIdentifierFromMod<TMajor>(cache, formKey, modKey, out var editorId)) return editorId;
+        throw new MissingRecordException(formKey, typeof(TMajor));
+    }
+
+    /// <summary>
+    /// Retrieves the FormKey that matches the EditorID within the contribution of the mod matching the given ModKey.
+    /// </summary>
+    /// <param name="cache">LinkCache to resolve against</param>
+    /// <param name="editorId">EditorID to look for</param>
+    /// <param name="modKey">ModKey of the mod to scope resolution to</param>
+    /// <returns>The FormKey</returns>
+    /// <typeparam name="TMajor">The type of Major Record to look up</typeparam>
+    /// <exception cref="MissingRecordException">If the mod was not found, or did not contain a matching record</exception>
+    public static FormKey ResolveIdentifierFromMod<TMajor>(this ILinkCache cache, string editorId, ModKey modKey)
+        where TMajor : class, IMajorRecordQueryableGetter
+    {
+        if (TryResolveIdentifierFromMod<TMajor>(cache, editorId, modKey, out var formKey)) return formKey;
+        throw new MissingRecordException(editorId, typeof(TMajor));
+    }
+
+    #endregion
+
+    #region ResolveIdentifierFromMod (Type)
+
+    /// <summary>
+    /// Retrieves the EditorID that matches the FormKey and Type within the contribution of the mod matching the given ModKey.
+    /// </summary>
+    /// <param name="cache">LinkCache to resolve against</param>
+    /// <param name="formKey">FormKey to look for</param>
+    /// <param name="type">Type of record to look up</param>
+    /// <param name="modKey">ModKey of the mod to scope resolution to</param>
+    /// <returns>The EditorID</returns>
+    /// <exception cref="MissingRecordException">If the mod was not found, or did not contain a matching record</exception>
+    public static string? ResolveIdentifierFromMod(this ILinkCache cache, FormKey formKey, Type type, ModKey modKey)
+    {
+        if (TryResolveIdentifierFromMod(cache, formKey, type, modKey, out var editorId)) return editorId;
+        throw new MissingRecordException(formKey, type);
+    }
+
+    /// <summary>
+    /// Retrieves the EditorID that matches the FormLink within the contribution of the mod matching the given ModKey.
+    /// </summary>
+    /// <param name="cache">LinkCache to resolve against</param>
+    /// <param name="formLink">FormLink to look for</param>
+    /// <param name="modKey">ModKey of the mod to scope resolution to</param>
+    /// <returns>The EditorID</returns>
+    /// <exception cref="MissingRecordException">If the mod was not found, or did not contain a matching record</exception>
+    public static string? ResolveIdentifierFromMod(this ILinkCache cache, IFormLinkIdentifier formLink, ModKey modKey)
+    {
+        if (TryResolveIdentifierFromMod(cache, formLink, modKey, out var editorId)) return editorId;
+        throw new MissingRecordException(formLink);
+    }
+
+    /// <summary>
+    /// Retrieves the FormKey that matches the EditorID and Type within the contribution of the mod matching the given ModKey.
+    /// </summary>
+    /// <param name="cache">LinkCache to resolve against</param>
+    /// <param name="editorId">EditorID to look for</param>
+    /// <param name="type">Type of record to look up</param>
+    /// <param name="modKey">ModKey of the mod to scope resolution to</param>
+    /// <returns>The FormKey</returns>
+    /// <exception cref="MissingRecordException">If the mod was not found, or did not contain a matching record</exception>
+    public static FormKey ResolveIdentifierFromMod(this ILinkCache cache, string editorId, Type type, ModKey modKey)
+    {
+        if (TryResolveIdentifierFromMod(cache, editorId, type, modKey, out var formKey)) return formKey;
+        throw new MissingRecordException(editorId, type);
+    }
+
+    #endregion
+
+    #region ResolveIdentifierFromMod (Types)
+
+    /// <summary>
+    /// Retrieves the EditorID that matches the FormKey and Types within the contribution of the mod matching the given ModKey.
+    /// </summary>
+    /// <param name="cache">LinkCache to resolve against</param>
+    /// <param name="formKey">FormKey to look for</param>
+    /// <param name="types">Types of records to look up</param>
+    /// <param name="modKey">ModKey of the mod to scope resolution to</param>
+    /// <returns>The EditorID</returns>
+    /// <exception cref="MissingRecordException">If the mod was not found, or did not contain a matching record</exception>
+    public static string? ResolveIdentifierFromMod(this ILinkCache cache, FormKey formKey, IEnumerable<Type> types, ModKey modKey)
+    {
+        if (TryResolveIdentifierFromMod(cache, formKey, types, modKey, out var editorId)) return editorId;
+        throw new MissingRecordException(formKey, types.ToArray());
+    }
+
+    /// <summary>
+    /// Retrieves the FormKey that matches the EditorID and Types within the contribution of the mod matching the given ModKey.
+    /// </summary>
+    /// <param name="cache">LinkCache to resolve against</param>
+    /// <param name="editorId">EditorID to look for</param>
+    /// <param name="types">Types of records to look up</param>
+    /// <param name="modKey">ModKey of the mod to scope resolution to</param>
+    /// <returns>The FormKey</returns>
+    /// <exception cref="MissingRecordException">If the mod was not found, or did not contain a matching record</exception>
+    public static FormKey ResolveIdentifierFromMod(this ILinkCache cache, string editorId, IEnumerable<Type> types, ModKey modKey)
+    {
+        if (TryResolveIdentifierFromMod(cache, editorId, types, modKey, out var formKey)) return formKey;
+        throw new MissingRecordException(editorId, types.ToArray());
+    }
+
+    #endregion
 }

--- a/Mutagen.Bethesda.UnitTests/Plugins/Cache/Linking/LinkCacheFromModTests.cs
+++ b/Mutagen.Bethesda.UnitTests/Plugins/Cache/Linking/LinkCacheFromModTests.cs
@@ -133,6 +133,49 @@ public class LinkCacheFromModTests
     }
 
     [Fact]
+    public void LoadOrder_ResolvesIdentifierScopedToRequestedMod()
+    {
+        var setup = BuildLoadOrder();
+
+        setup.Cache.TryResolveIdentifierFromMod<INpcGetter>(setup.MasterNpc.FormKey, TestConstants.MasterModKey, out var fromMaster)
+            .ShouldBeTrue();
+        fromMaster.ShouldBe("SharedNpc");
+
+        // Both the master and the plugin contribute this record's identifier
+        setup.Cache.TryResolveIdentifierFromMod<INpcGetter>(setup.MasterNpc.FormKey, TestConstants.PluginModKey, out _)
+            .ShouldBeTrue();
+
+        // The plugin does not contribute the master-only record
+        setup.Cache.TryResolveIdentifierFromMod<INpcGetter>(setup.MasterOnlyNpc.FormKey, TestConstants.PluginModKey, out _)
+            .ShouldBeFalse();
+    }
+
+    [Fact]
+    public void LoadOrder_ResolvesIdentifierByEditorId()
+    {
+        var setup = BuildLoadOrder();
+
+        setup.Cache.TryResolveIdentifierFromMod<INpcGetter>("SharedNpc", TestConstants.MasterModKey, out var fromMaster)
+            .ShouldBeTrue();
+        fromMaster.ShouldBe(setup.MasterNpc.FormKey);
+
+        setup.Cache.TryResolveIdentifierFromMod<INpcGetter>("MasterOnlyNpc", TestConstants.PluginModKey, out _)
+            .ShouldBeFalse();
+    }
+
+    [Fact]
+    public void LoadOrder_ResolveIdentifierThrowsWhenMissing()
+    {
+        var setup = BuildLoadOrder();
+
+        setup.Cache.ResolveIdentifierFromMod<INpcGetter>(setup.MasterNpc.FormKey, TestConstants.MasterModKey)
+            .ShouldBe("SharedNpc");
+
+        Should.Throw<MissingRecordException>(() =>
+            setup.Cache.ResolveIdentifierFromMod<INpcGetter>(setup.MasterNpc.FormKey, TestConstants.PluginModKey2));
+    }
+
+    [Fact]
     public void TryGetLinkCacheForMod_ReturnsScopedCache()
     {
         var setup = BuildLoadOrder();

--- a/Mutagen.Bethesda.UnitTests/Plugins/Cache/Linking/LinkCacheFromModTests.cs
+++ b/Mutagen.Bethesda.UnitTests/Plugins/Cache/Linking/LinkCacheFromModTests.cs
@@ -1,0 +1,196 @@
+using Shouldly;
+using Mutagen.Bethesda.Plugins;
+using Mutagen.Bethesda.Plugins.Cache;
+using Mutagen.Bethesda.Plugins.Cache.Internals.Implementations;
+using Mutagen.Bethesda.Plugins.Exceptions;
+using Mutagen.Bethesda.Plugins.Order;
+using Mutagen.Bethesda.Plugins.Records;
+using Mutagen.Bethesda.Skyrim;
+using Mutagen.Bethesda.Testing;
+using Xunit;
+
+namespace Mutagen.Bethesda.UnitTests.Plugins.Cache.Linking;
+
+public class LinkCacheFromModTests
+{
+    private record LoadOrderSetup(
+        SkyrimMod Master,
+        INpc MasterNpc,
+        INpc MasterOnlyNpc,
+        SkyrimMod Plugin,
+        INpc PluginOverride,
+        ILinkCache<ISkyrimMod, ISkyrimModGetter> Cache);
+
+    /// <summary>
+    /// Builds a load order where a master defines two NPCs, and a plugin overrides only one of them.
+    /// </summary>
+    private static LoadOrderSetup BuildLoadOrder()
+    {
+        var master = new SkyrimMod(TestConstants.MasterModKey, SkyrimRelease.SkyrimSE);
+        var masterNpc = master.Npcs.AddNew();
+        masterNpc.EditorID = "SharedNpc";
+        var masterOnlyNpc = master.Npcs.AddNew();
+        masterOnlyNpc.EditorID = "MasterOnlyNpc";
+
+        var plugin = new SkyrimMod(TestConstants.PluginModKey, SkyrimRelease.SkyrimSE);
+        var pluginOverride = plugin.Npcs.GetOrAddAsOverride(masterNpc);
+
+        var loadOrder = new LoadOrder<ISkyrimModGetter>()
+        {
+            master,
+            plugin,
+        };
+        var cache = loadOrder.ToImmutableLinkCache<ISkyrimMod, ISkyrimModGetter>();
+        return new LoadOrderSetup(master, masterNpc, masterOnlyNpc, plugin, pluginOverride, cache);
+    }
+
+    [Fact]
+    public void LoadOrder_ResolvesScopedToRequestedMod()
+    {
+        var setup = BuildLoadOrder();
+
+        setup.Cache.TryResolveFromMod<INpcGetter>(setup.MasterNpc.FormKey, TestConstants.MasterModKey, out var fromMaster)
+            .ShouldBeTrue();
+        fromMaster.ShouldBeSameAs(setup.MasterNpc);
+
+        setup.Cache.TryResolveFromMod<INpcGetter>(setup.MasterNpc.FormKey, TestConstants.PluginModKey, out var fromPlugin)
+            .ShouldBeTrue();
+        fromPlugin.ShouldBeSameAs(setup.PluginOverride);
+    }
+
+    [Fact]
+    public void LoadOrder_ReturnsFalseWhenModNotOverriding()
+    {
+        var setup = BuildLoadOrder();
+
+        // The plugin does not contribute this record, even though it is present in the load order
+        setup.Cache.TryResolveFromMod<INpcGetter>(setup.MasterOnlyNpc.FormKey, TestConstants.PluginModKey, out _)
+            .ShouldBeFalse();
+
+        setup.Cache.TryResolveFromMod<INpcGetter>(setup.MasterOnlyNpc.FormKey, TestConstants.MasterModKey, out var fromMaster)
+            .ShouldBeTrue();
+        fromMaster.ShouldBeSameAs(setup.MasterOnlyNpc);
+    }
+
+    [Fact]
+    public void LoadOrder_ReturnsFalseWhenModNotInCache()
+    {
+        var setup = BuildLoadOrder();
+
+        setup.Cache.TryResolveFromMod<INpcGetter>(setup.MasterNpc.FormKey, TestConstants.PluginModKey2, out _)
+            .ShouldBeFalse();
+    }
+
+    [Fact]
+    public void LoadOrder_ReturnsFalseWhenTypeMismatch()
+    {
+        var setup = BuildLoadOrder();
+
+        setup.Cache.TryResolveFromMod<IWeaponGetter>(setup.MasterNpc.FormKey, TestConstants.MasterModKey, out _)
+            .ShouldBeFalse();
+    }
+
+    [Fact]
+    public void LoadOrder_ResolvesByEditorId()
+    {
+        var setup = BuildLoadOrder();
+
+        setup.Cache.TryResolveFromMod<INpcGetter>("SharedNpc", TestConstants.MasterModKey, out var fromMaster)
+            .ShouldBeTrue();
+        fromMaster.ShouldBeSameAs(setup.MasterNpc);
+
+        setup.Cache.TryResolveFromMod<INpcGetter>("SharedNpc", TestConstants.PluginModKey, out var fromPlugin)
+            .ShouldBeTrue();
+        fromPlugin.ShouldBeSameAs(setup.PluginOverride);
+    }
+
+    [Fact]
+    public void LoadOrder_ResolveThrowsWhenMissing()
+    {
+        var setup = BuildLoadOrder();
+
+        setup.Cache.ResolveFromMod<INpcGetter>(setup.MasterNpc.FormKey, TestConstants.MasterModKey)
+            .ShouldBeSameAs(setup.MasterNpc);
+
+        Should.Throw<MissingRecordException>(() =>
+            setup.Cache.ResolveFromMod<INpcGetter>(setup.MasterNpc.FormKey, TestConstants.PluginModKey2));
+    }
+
+    [Fact]
+    public void LoadOrder_ResolvesContextScopedToRequestedMod()
+    {
+        var setup = BuildLoadOrder();
+
+        setup.Cache.TryResolveContextFromMod<ISkyrimMod, ISkyrimModGetter, INpc, INpcGetter>(setup.MasterNpc.FormKey, TestConstants.MasterModKey, out var fromMaster)
+            .ShouldBeTrue();
+        fromMaster.Record.ShouldBeSameAs(setup.MasterNpc);
+        fromMaster.ModKey.ShouldBe(TestConstants.MasterModKey);
+
+        setup.Cache.TryResolveContextFromMod<ISkyrimMod, ISkyrimModGetter, INpc, INpcGetter>(setup.MasterNpc.FormKey, TestConstants.PluginModKey, out var fromPlugin)
+            .ShouldBeTrue();
+        fromPlugin.Record.ShouldBeSameAs(setup.PluginOverride);
+        fromPlugin.ModKey.ShouldBe(TestConstants.PluginModKey);
+    }
+
+    [Fact]
+    public void TryGetLinkCacheForMod_ReturnsScopedCache()
+    {
+        var setup = BuildLoadOrder();
+
+        setup.Cache.TryGetLinkCacheForMod(TestConstants.MasterModKey, out var modCache).ShouldBeTrue();
+        modCache.ListedOrder.ShouldHaveSingleItem().ModKey.ShouldBe(TestConstants.MasterModKey);
+
+        setup.Cache.TryGetTypedLinkCacheForMod(TestConstants.PluginModKey, out var typedModCache).ShouldBeTrue();
+        typedModCache.ListedOrder.ShouldHaveSingleItem().ModKey.ShouldBe(TestConstants.PluginModKey);
+
+        setup.Cache.TryGetLinkCacheForMod(TestConstants.PluginModKey2, out _).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void SingleMod_ResolvesWhenModKeyMatches()
+    {
+        var mod = new SkyrimMod(TestConstants.MasterModKey, SkyrimRelease.SkyrimSE);
+        var npc = mod.Npcs.AddNew();
+        var cache = mod.ToImmutableLinkCache<ISkyrimMod, ISkyrimModGetter>();
+
+        cache.TryResolveFromMod<INpcGetter>(npc.FormKey, TestConstants.MasterModKey, out var resolved)
+            .ShouldBeTrue();
+        resolved.ShouldBeSameAs(npc);
+    }
+
+    [Fact]
+    public void SingleMod_ReturnsFalseWhenModKeyDiffers()
+    {
+        var mod = new SkyrimMod(TestConstants.MasterModKey, SkyrimRelease.SkyrimSE);
+        var npc = mod.Npcs.AddNew();
+        var cache = mod.ToImmutableLinkCache<ISkyrimMod, ISkyrimModGetter>();
+
+        cache.TryGetLinkCacheForMod(TestConstants.PluginModKey, out _).ShouldBeFalse();
+        cache.TryResolveFromMod<INpcGetter>(npc.FormKey, TestConstants.PluginModKey, out _)
+            .ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Mutable_ResolvesScopedToRequestedMod()
+    {
+        var master = new SkyrimMod(TestConstants.MasterModKey, SkyrimRelease.SkyrimSE);
+        var masterNpc = master.Npcs.AddNew();
+        var mutablePlugin = new SkyrimMod(TestConstants.PluginModKey, SkyrimRelease.SkyrimSE);
+        var pluginOverride = mutablePlugin.Npcs.GetOrAddAsOverride(masterNpc);
+
+        var immutableBase = new LoadOrder<ISkyrimModGetter>() { master }
+            .ToImmutableLinkCache<ISkyrimMod, ISkyrimModGetter>();
+        var cache = new MutableLoadOrderLinkCache<ISkyrimMod, ISkyrimModGetter>(immutableBase, mutablePlugin);
+
+        cache.TryResolveFromMod<INpcGetter>(masterNpc.FormKey, TestConstants.MasterModKey, out var fromMaster)
+            .ShouldBeTrue();
+        fromMaster.ShouldBeSameAs(masterNpc);
+
+        cache.TryResolveFromMod<INpcGetter>(masterNpc.FormKey, TestConstants.PluginModKey, out var fromPlugin)
+            .ShouldBeTrue();
+        fromPlugin.ShouldBeSameAs(pluginOverride);
+
+        cache.TryResolveFromMod<INpcGetter>(masterNpc.FormKey, TestConstants.PluginModKey2, out _)
+            .ShouldBeFalse();
+    }
+}


### PR DESCRIPTION
Adds the ability to get an ILinkCache that is scoped to a single mod from an existing link cache.

First user: https://github.com/Mutagen-Modding/Mutagen.Bethesda.Analyzers/pull/608