### PR TITLE
VoiceTypeAssetLookup optimisations

### DIFF
--- a/Mutagen.Bethesda.Skyrim/Records/Assets/VoiceType/VoiceTypeAssetLookup.cs
+++ b/Mutagen.Bethesda.Skyrim/Records/Assets/VoiceType/VoiceTypeAssetLookup.cs
@@ -31,136 +31,126 @@ public class VoiceTypeAssetLookup : IAssetCacheComponent
     {
         _formLinkCache = linkCache.FormLinkCache;
 
-        var childRaces = new HashSet<FormKey>();
-        foreach (var mod in _formLinkCache.PriorityOrder)
+        foreach (var quest in _formLinkCache.WinningOverrides<IQuestGetter>())
         {
-            foreach (var quest in mod.EnumerateMajorRecords<IQuestGetter>())
+            foreach (var alias in quest.Aliases)
             {
-                foreach (var alias in quest.Aliases)
-                {
-                    var uniqueActor = alias.UniqueActor.FormKey;
-                    if (uniqueActor.IsNull) continue;
+                var uniqueActor = alias.UniqueActor.FormKey;
+                if (uniqueActor.IsNull) continue;
 
-                    foreach (var faction in alias.Factions)
+                foreach (var faction in alias.Factions)
+                {
+                    if (!faction.IsNull)
                     {
-                        if (!faction.IsNull)
-                        {
-                            _factionNPCs
-                                .GetOrAdd(faction.FormKey)
-                                .Add(uniqueActor);
-                        }
-                    }
-                }
-            }
-
-            foreach (var leveledNpc in mod.EnumerateMajorRecords<ILeveledNpcGetter>())
-            {
-                if (leveledNpc.Entries is null) continue;
-
-                var voiceTypes = leveledNpc.Entries
-                    .Select(x => x.Data?.Reference)
-                    .WhereNotNull()
-                    .SelectMany(GetVoiceTypes)
-                    .ToHashSet();
-
-                _speakerVoices
-                    .GetOrAdd(leveledNpc.FormKey)
-                    .Add(voiceTypes);
-            }
-
-            foreach (var npc in mod.EnumerateMajorRecords<INpcGetter>())
-            {
-                _speakerVoices.GetOrAdd(npc.FormKey, () => GetVoiceTypes(npc).ToHashSet());
-
-                foreach (var factionKey in GetFactions(npc))
-                {
-                    _factionNPCs
-                        .GetOrAdd(factionKey.FormKey)
-                        .Add(npc.FormKey);
-                }
-
-                foreach (var classKey in GetClasses(npc))
-                {
-                    _classNPCs
-                        .GetOrAdd(classKey.FormKey)
-                        .Add(npc.FormKey);
-                }
-
-                foreach (var gender in GetGenders(npc))
-                {
-                    _genderNPCs
-                        .GetOrAdd(gender)
-                        .Add(npc.FormKey);
-                }
-
-                foreach (var raceKey in GetRaces(npc))
-                {
-                    _raceNPCs
-                        .GetOrAdd(raceKey.FormKey)
-                        .Add(npc.FormKey);
-                }
-            }
-
-            foreach (var response in mod.EnumerateMajorRecords<IDialogResponsesGetter>())
-            {
-                if (!response.ResponseData.IsNull)
-                {
-                    _sharedInfoUsages
-                        .GetOrAdd(response.ResponseData.FormKey)
-                        .Add(response.FormKey);
-                }
-            }
-
-            foreach (var talkingActivator in mod.EnumerateMajorRecords<ITalkingActivatorGetter>())
-            {
-                if (!_speakerVoices.ContainsKey(talkingActivator.FormKey))
-                {
-                    var voice = GetVoiceType(talkingActivator);
-                    if (voice != null)
-                        _speakerVoices.Add(talkingActivator.FormKey, [voice]);
-                }
-            }
-
-            foreach (var race in mod.EnumerateMajorRecords<IRaceGetter>())
-            {
-                if ((race.Flags & Race.Flag.Child) != 0)
-                {
-                    childRaces.Add(race.FormKey);
-                }
-            }
-
-            foreach (var scene in mod.EnumerateMajorRecords<ISceneGetter>())
-            {
-                foreach (var action in scene.Actions)
-                {
-                    if (action.Type == SceneAction.TypeEnum.Dialog && !action.Topic.IsNull && action.ActorID != null && !_dialogueSceneAliasIndex.ContainsKey(action.Topic.FormKey))
-                    {
-                        _dialogueSceneAliasIndex.Add(action.Topic.FormKey, action.ActorID.Value);
-                    }
-                }
-            }
-
-            var defaultVoiceTypes = new HashSet<string>();
-            _defaultVoiceTypes.Add(mod.ModKey, defaultVoiceTypes);
-            foreach (var voiceType in mod.EnumerateMajorRecords<IVoiceTypeGetter>())
-            {
-                if (voiceType.EditorID != null)
-                {
-                    if ((voiceType.Flags & Skyrim.VoiceType.Flag.AllowDefaultDialog) != 0)
-                    {
-                        defaultVoiceTypes.Add(voiceType.EditorID);
+                        _factionNPCs
+                            .GetOrAdd(faction.FormKey)
+                            .Add(uniqueActor);
                     }
                 }
             }
         }
 
+        foreach (var leveledNpc in _formLinkCache.WinningOverrides<ILeveledNpcGetter>())
+        {
+            if (leveledNpc.Entries is null) continue;
+
+            var voiceTypes = leveledNpc.Entries
+                .Select(x => x.Data?.Reference)
+                .WhereNotNull()
+                .SelectMany(GetVoiceTypes)
+                .ToHashSet();
+
+            _speakerVoices
+                .GetOrAdd(leveledNpc.FormKey)
+                .Add(voiceTypes);
+        }
+
+        foreach (var npc in _formLinkCache.WinningOverrides<INpcGetter>())
+        {
+            _speakerVoices.GetOrAdd(npc.FormKey, () => GetVoiceTypes(npc).ToHashSet());
+
+            foreach (var factionKey in GetFactions(npc))
+            {
+                _factionNPCs
+                    .GetOrAdd(factionKey.FormKey)
+                    .Add(npc.FormKey);
+            }
+
+            foreach (var classKey in GetClasses(npc))
+            {
+                _classNPCs
+                    .GetOrAdd(classKey.FormKey)
+                    .Add(npc.FormKey);
+            }
+
+            foreach (var gender in GetGenders(npc))
+            {
+                _genderNPCs
+                    .GetOrAdd(gender)
+                    .Add(npc.FormKey);
+            }
+
+            foreach (var raceKey in GetRaces(npc))
+            {
+                _raceNPCs
+                    .GetOrAdd(raceKey.FormKey)
+                    .Add(npc.FormKey);
+            }
+        }
+
+        foreach (var response in _formLinkCache.WinningOverrides<IDialogResponsesGetter>())
+        {
+            if (!response.ResponseData.IsNull)
+            {
+                _sharedInfoUsages
+                    .GetOrAdd(response.ResponseData.FormKey)
+                    .Add(response.FormKey);
+            }
+        }
+
+        foreach (var talkingActivator in _formLinkCache.WinningOverrides<ITalkingActivatorGetter>())
+        {
+            if (!_speakerVoices.ContainsKey(talkingActivator.FormKey))
+            {
+                var voice = GetVoiceType(talkingActivator);
+                if (voice != null)
+                    _speakerVoices.Add(talkingActivator.FormKey, [voice]);
+            }
+        }
+
+        foreach (var scene in _formLinkCache.WinningOverrides<ISceneGetter>())
+        {
+            foreach (var action in scene.Actions)
+            {
+                if (action.Type == SceneAction.TypeEnum.Dialog && !action.Topic.IsNull && action.ActorID != null && !_dialogueSceneAliasIndex.ContainsKey(action.Topic.FormKey))
+                {
+                    _dialogueSceneAliasIndex.Add(action.Topic.FormKey, action.ActorID.Value);
+                }
+            }
+        }
+
         //Build child cache
-        _childNPCs = childRaces
+        _childNPCs = _formLinkCache.WinningOverrides<IRaceGetter>()
+            .Where(r => r.Flags.HasFlag(Race.Flag.Child))
+            .Select(r => r.FormKey)
             .SelectWhere(r => _raceNPCs.TryGetValue(r, out var raceNpcFormKeys) ? TryGet<HashSet<FormKey>>.Succeed(raceNpcFormKeys) : TryGet<HashSet<FormKey>>.Failure)
             .SelectMany(x => x)
             .ToHashSet();
 
-        //Add master voice types
+
+        // Build default voice type lookup, including those defined in masters
+        foreach (var mod in _formLinkCache.PriorityOrder)
+        {
+            //var defaultVoiceTypes = new HashSet<string>();
+
+            var defaultVoiceTypes = mod.EnumerateMajorRecords<IVoiceTypeGetter>()
+                .Where(v => v.Flags.HasFlag(Skyrim.VoiceType.Flag.AllowDefaultDialog))
+                .Select(v => v.EditorID)
+                .WhereNotNull()
+                .ToHashSet();
+            _defaultVoiceTypes.Add(mod.ModKey, defaultVoiceTypes);
+        }
+
         var defaultVoicesCopy = new Dictionary<ModKey, HashSet<string>>(_defaultVoiceTypes);
         foreach (var mod in _formLinkCache.PriorityOrder)
         {

--- a/Mutagen.Bethesda.Skyrim/Records/Assets/VoiceType/VoiceTypeAssetLookup.cs
+++ b/Mutagen.Bethesda.Skyrim/Records/Assets/VoiceType/VoiceTypeAssetLookup.cs
@@ -70,19 +70,19 @@ public class VoiceTypeAssetLookup : IAssetCacheComponent
 
             foreach (var npc in mod.EnumerateMajorRecords<INpcGetter>())
             {
-                _speakerVoices.GetOrAdd(npc.FormKey, () => GetVoiceTypes(npc));
+                _speakerVoices.GetOrAdd(npc.FormKey, () => GetVoiceTypes(npc).ToHashSet());
 
                 foreach (var factionKey in GetFactions(npc))
                 {
                     _factionNPCs
-                        .GetOrAdd(factionKey)
+                        .GetOrAdd(factionKey.FormKey)
                         .Add(npc.FormKey);
                 }
 
                 foreach (var classKey in GetClasses(npc))
                 {
                     _classNPCs
-                        .GetOrAdd(classKey)
+                        .GetOrAdd(classKey.FormKey)
                         .Add(npc.FormKey);
                 }
 
@@ -96,7 +96,7 @@ public class VoiceTypeAssetLookup : IAssetCacheComponent
                 foreach (var raceKey in GetRaces(npc))
                 {
                     _raceNPCs
-                        .GetOrAdd(raceKey)
+                        .GetOrAdd(raceKey.FormKey)
                         .Add(npc.FormKey);
                 }
             }
@@ -115,7 +115,9 @@ public class VoiceTypeAssetLookup : IAssetCacheComponent
             {
                 if (!_speakerVoices.ContainsKey(talkingActivator.FormKey))
                 {
-                    _speakerVoices.Add(talkingActivator.FormKey, GetVoiceTypes(talkingActivator));
+                    var voice = GetVoiceType(talkingActivator);
+                    if (voice != null)
+                        _speakerVoices.Add(talkingActivator.FormKey, [voice]);
                 }
             }
 
@@ -807,156 +809,123 @@ public class VoiceTypeAssetLookup : IAssetCacheComponent
     }
 
     #region Voice Parser
-    private HashSet<string> GetVoiceTypes(INpcGetter npc)
+    private IEnumerable<string> GetVoiceTypes(INpcGetter npc)
     {
         if (_speakerVoices.TryGetValue(npc.FormKey, out var speakerVoiceTypes)) return speakerVoiceTypes;
 
+        if (!npc.Template.IsNull && npc.Configuration.TemplateFlags.HasFlag(NpcConfiguration.TemplateFlag.Traits))
+            return GetVoiceTypes(npc.Template);
+
         //Check voice type
-        if (!npc.Voice.IsNull)
+        if (npc.Voice.TryResolve(_formLinkCache, out var voiceType) && voiceType.EditorID != null)
         {
-            var voiceType = npc.Voice.TryResolve(_formLinkCache);
-            if (voiceType is { EditorID: {} })
-            {
-                return new HashSet<string> { voiceType.EditorID };
-            }
+            return [voiceType.EditorID];
         }
 
-        //Check template
-        if (!npc.Template.IsNull && (npc.Configuration.TemplateFlags & NpcConfiguration.TemplateFlag.Traits) != 0)
-        {
-            return GetVoiceTypes(npc.Template).ToHashSet();
-        }
-
-        return new HashSet<string>();
+        return [];
     }
 
-    private HashSet<string> GetVoiceTypes(IFormLinkGetter<INpcSpawnGetter> npcSpawn)
+    private IEnumerable<string> GetVoiceTypes(IFormLinkGetter<INpcSpawnGetter> npcSpawn)
     {
-        if (npcSpawn.IsNull) return new HashSet<string>();
-
         //NPC
-        var npc = npcSpawn.TryResolve<INpcGetter>(_formLinkCache);
-        if (npc != null)
-        {
+        if (npcSpawn.TryResolve<INpcGetter>(_formLinkCache, out var npc))
             return GetVoiceTypes(npc);
-        }
 
         //Levelled NPC
-        var leveledNpc = npcSpawn.TryResolve<ILeveledNpcGetter>(_formLinkCache);
-        if (leveledNpc is { Entries: {} })
+        if (npcSpawn.TryResolve<ILeveledNpcGetter>(_formLinkCache, out var leveledNpc) && leveledNpc.Entries != null)
         {
             return leveledNpc.Entries
                 .Select(entry => entry.Data?.Reference).NotNull()
                 .SelectMany(GetVoiceTypes).ToHashSet();
         }
 
-        return new HashSet<string>();
+        return [];
     }
 
-    private HashSet<string> GetVoiceTypes(ITalkingActivatorGetter talkingActivator)
+    private string? GetVoiceType(ITalkingActivatorGetter talkingActivator)
     {
-        if (_speakerVoices.TryGetValue(talkingActivator.FormKey, out var speakerVoiceTypes)) return speakerVoiceTypes;
-
-        if (!talkingActivator.Voice.IsNull)
+        if (talkingActivator.Voice.TryResolve(_formLinkCache, out var voiceType) && voiceType.EditorID != null)
         {
-            var voiceTypeGetter = talkingActivator.Voice.TryResolve(_formLinkCache);
-            if (voiceTypeGetter is { EditorID: not null })
-            {
-                return new HashSet<string> { voiceTypeGetter.EditorID };
-            }
+            return voiceType.EditorID;
         }
 
-        return new HashSet<string>();
+        return null;
     }
     #endregion
 
     #region Faction Parser
-    private HashSet<FormKey> GetFactions(INpcGetter npc)
+    private IEnumerable<IFormLinkGetter<IFactionGetter>> GetFactions(INpcGetter npc)
     {
-        if ((npc.Configuration.TemplateFlags & NpcConfiguration.TemplateFlag.Factions) == 0)
-        {
-            return npc.Factions.Where(f => !f.Faction.IsNull).Select(f => f.Faction.FormKey).ToHashSet();
-        }
+        if (!npc.Template.IsNull && npc.Configuration.TemplateFlags.HasFlag(NpcConfiguration.TemplateFlag.Factions))
+            return GetFactions(npc.Template);
 
-        return npc.Template.IsNull ? new HashSet<FormKey>() : GetFactions(npc.Template);
+        return npc.Factions.Select(f => f.Faction).Where(f => !f.IsNull);
 
     }
 
-    private HashSet<FormKey> GetFactions(IFormLinkGetter<INpcSpawnGetter> npcTemplate)
+    private IEnumerable<IFormLinkGetter<IFactionGetter>> GetFactions(IFormLinkGetter<INpcSpawnGetter> npcTemplate)
     {
-        if (npcTemplate.IsNull) return new HashSet<FormKey>();
-
         //NPC
-        var npc = npcTemplate.TryResolve<INpcGetter>(_formLinkCache);
-        if (npc != null) return GetFactions(npc);
+        if (npcTemplate.TryResolve<INpcGetter>(_formLinkCache, out var npc)) return GetFactions(npc);
 
         //Levelled NPC
-        var leveledNpc = npcTemplate.TryResolve<ILeveledNpcGetter>(_formLinkCache);
-        if (leveledNpc is { Entries: {} })
+        if (npcTemplate.TryResolve<ILeveledNpcGetter>(_formLinkCache, out var leveledNpc) && leveledNpc.Entries != null)
         {
             return leveledNpc.Entries
                 .Select(entry => entry.Data?.Reference).NotNull()
                 .SelectMany(GetFactions).ToHashSet();
         }
 
-        return new HashSet<FormKey>();
+        return [];
     }
     #endregion
 
     #region Class Parser
-    private HashSet<FormKey> GetClasses(INpcGetter npc)
+    private IEnumerable<IFormLinkGetter<IClassGetter>> GetClasses(INpcGetter npc)
     {
-        if ((npc.Configuration.TemplateFlags & NpcConfiguration.TemplateFlag.Stats) == 0 && !npc.Class.IsNull)
-        {
-            return new HashSet<FormKey> { npc.Class.FormKey };
-        }
+        if (!npc.Template.IsNull && npc.Configuration.TemplateFlags.HasFlag(NpcConfiguration.TemplateFlag.Stats))
+            return GetClasses(npc.Template);
 
-        return npc.Template.IsNull ? new HashSet<FormKey>() : GetClasses(npc.Template);
+        return [npc.Class];
 
     }
 
-    private HashSet<FormKey> GetClasses(IFormLinkGetter<INpcSpawnGetter> npcTemplate)
+    private IEnumerable<IFormLinkGetter<IClassGetter>> GetClasses(IFormLinkGetter<INpcSpawnGetter> npcTemplate)
     {
-        if (npcTemplate.IsNull) return new HashSet<FormKey>();
-
         //NPC
-        var npc = npcTemplate.TryResolve<INpcGetter>(_formLinkCache);
-        if (npc != null) return GetClasses(npc);
+        if (npcTemplate.TryResolve<INpcGetter>(_formLinkCache, out var npc)) return GetClasses(npc);
 
         //Levelled NPC
-        var leveledNpc = npcTemplate.TryResolve<ILeveledNpcGetter>(_formLinkCache);
-        if (leveledNpc is { Entries: {} })
+        if (npcTemplate.TryResolve<ILeveledNpcGetter>(_formLinkCache, out var leveledNpc) && leveledNpc.Entries != null)
         {
             return leveledNpc.Entries
                 .Select(entry => entry.Data?.Reference).NotNull()
                 .SelectMany(GetClasses).ToHashSet();
         }
 
-        return new HashSet<FormKey>();
+        return [];
     }
     #endregion
 
     #region Gender Parser
-    private HashSet<MaleFemaleGender> GetGenders(INpcGetter npc)
+    private IEnumerable<MaleFemaleGender> GetGenders(INpcGetter npc)
     {
-        if ((npc.Configuration.TemplateFlags & NpcConfiguration.TemplateFlag.Traits) == 0)
-        {
-            return [(npc.Configuration.Flags & NpcConfiguration.Flag.Female) != 0 ? MaleFemaleGender.Female : MaleFemaleGender.Male];
-        }
+        // TODO: Account for templates
+        if (!npc.Template.IsNull && npc.Configuration.TemplateFlags.HasFlag(NpcConfiguration.TemplateFlag.Traits))
+            return [];
 
-        return [];
+        return [(npc.Configuration.Flags & NpcConfiguration.Flag.Female) != 0 ? MaleFemaleGender.Female : MaleFemaleGender.Male];
     }
     #endregion
 
     #region Race Parser
-    private HashSet<FormKey> GetRaces(INpcGetter npc)
+    private IEnumerable<IFormLinkGetter<IRaceGetter>> GetRaces(INpcGetter npc)
     {
-        if ((npc.Configuration.TemplateFlags & NpcConfiguration.TemplateFlag.Traits) == 0 && !npc.Race.IsNull)
-        {
-            return new HashSet<FormKey> { npc.Race.FormKey };
-        }
+        // TODO: Account for templates
+        if (!npc.Template.IsNull && npc.Configuration.TemplateFlags.HasFlag(NpcConfiguration.TemplateFlag.Traits))
+            return [];
 
-        return [];
+        return [npc.Race];
     }
     #endregion
 }

--- a/Mutagen.Bethesda.Skyrim/Records/Assets/VoiceType/VoiceTypeAssetLookup.cs
+++ b/Mutagen.Bethesda.Skyrim/Records/Assets/VoiceType/VoiceTypeAssetLookup.cs
@@ -12,7 +12,10 @@ public class VoiceTypeAssetLookup : IAssetCacheComponent
 
     //Databases
     private readonly Dictionary<ModKey, HashSet<string>> _defaultVoiceTypes = new();
+    // NPC -> Voice types
     private readonly Dictionary<FormKey, HashSet<string>> _speakerVoices = new();
+    // Voice type -> NPCs. Kept as a List<FormLink> as we always return the full value as form links
+    private readonly Dictionary<string, List<IFormLinkGetter<IHasVoiceTypeGetter>>> _voiceSpeakers = [];
     private readonly Dictionary<FormKey, HashSet<FormKey>> _factionNPCs = new();
     private readonly Dictionary<FormKey, HashSet<FormKey>> _classNPCs = new();
     private readonly Dictionary<FormKey, HashSet<FormKey>> _raceNPCs = new();
@@ -137,6 +140,13 @@ public class VoiceTypeAssetLookup : IAssetCacheComponent
             .SelectMany(x => x)
             .ToHashSet();
 
+        foreach (var (speaker, voices) in _speakerVoices)
+        {
+            foreach (var voice in voices)
+            {
+                _voiceSpeakers.GetOrAdd(voice).Add(speaker);
+            }
+        }
 
         // Build default voice type lookup, including those defined in masters
         foreach (var mod in _formLinkCache.PriorityOrder)
@@ -259,17 +269,23 @@ public class VoiceTypeAssetLookup : IAssetCacheComponent
             voiceContainer = GetAllDefaultVoices();
         }
 
-        foreach (var formKey in voiceContainer.Voices.SelectMany(x =>
-                 {
-                     if (x.Value.Count > 0) return x.Value;
-
-                     // Get speakers with voice type when the whole voice type is used (there are no speakers)
-                     return _speakerVoices
-                         .Where(y => y.Value.Contains(x.Key))
-                         .Select(y => y.Key);
-                 }))
+        foreach (var voice in voiceContainer.Voices)
         {
-            yield return new FormLink<IHasVoiceTypeGetter>(formKey);
+            // Filtered from voice type
+            if (voice.Value.Count > 0)
+            {
+                foreach (var speaker in voice.Value)
+                    yield return new FormLink<IHasVoiceTypeGetter>(speaker);
+            }
+            // All NPCs of voice
+            else
+            {
+                if (_voiceSpeakers.TryGetValue(voice.Key, out var speakers))
+                {
+                    foreach (var speaker in speakers)
+                        yield return speaker;
+                }
+            }
         }
     }
 

--- a/Mutagen.Bethesda.Skyrim/Records/Assets/VoiceType/VoiceTypeAssetLookup.cs
+++ b/Mutagen.Bethesda.Skyrim/Records/Assets/VoiceType/VoiceTypeAssetLookup.cs
@@ -13,6 +13,7 @@ public class VoiceTypeAssetLookup : IAssetCacheComponent
     //Databases
     private readonly Dictionary<ModKey, HashSet<string>> _defaultVoiceTypes = new();
     // NPC -> Voice types
+    // TODO: Most NPCs only have one voice type, but using an enumerable here is slower. Check if unions work better once updated to C# 15
     private readonly Dictionary<FormKey, HashSet<string>> _speakerVoices = new();
     // Voice type -> NPCs. Kept as a List<FormLink> as we always return the full value as form links
     private readonly Dictionary<string, List<IFormLinkGetter<IHasVoiceTypeGetter>>> _voiceSpeakers = [];
@@ -20,9 +21,10 @@ public class VoiceTypeAssetLookup : IAssetCacheComponent
     private readonly Dictionary<FormKey, HashSet<FormKey>> _classNPCs = new();
     private readonly Dictionary<FormKey, HashSet<FormKey>> _raceNPCs = new();
     private readonly Dictionary<MaleFemaleGender, HashSet<FormKey>> _genderNPCs = new();
-    private HashSet<FormKey> _childNPCs = null!;
-    private readonly Dictionary<FormKey, int> _dialogueSceneAliasIndex = new();
-    private readonly Dictionary<FormKey, HashSet<FormKey>> _sharedInfoUsages = new();
+    // Child NPCs -> voice types. Used for IsChild condition. VoiceContainer is not reused as these are mutable
+    private Lazy<Dictionary<FormKey, IEnumerable<string>>> _childVoices = null!;
+    private Lazy<Dictionary<FormKey, int>> _dialogueSceneAliasIndex = null!;
+    private Lazy<Dictionary<FormKey, HashSet<FormKey>>> _sharedInfoUsages = null!;
 
     //Caches
     private readonly object _defaultSpeakerVoicesLock = new();
@@ -101,15 +103,11 @@ public class VoiceTypeAssetLookup : IAssetCacheComponent
             }
         }
 
-        foreach (var response in _formLinkCache.WinningOverrides<IDialogResponsesGetter>())
-        {
-            if (!response.ResponseData.IsNull)
-            {
-                _sharedInfoUsages
-                    .GetOrAdd(response.ResponseData.FormKey)
-                    .Add(response.FormKey);
-            }
-        }
+        // TODO: This could use a usage cache (breaking change)
+        _sharedInfoUsages = new(() => _formLinkCache.WinningOverrides<IDialogResponsesGetter>()
+            .Where(r => !r.ResponseData.IsNull)
+            .GroupBy(r => r.ResponseData.FormKey)
+            .ToDictionary(g => g.Key, g => g.Select(r => r.FormKey).ToHashSet()));
 
         foreach (var talkingActivator in _formLinkCache.WinningOverrides<ITalkingActivatorGetter>())
         {
@@ -121,24 +119,30 @@ public class VoiceTypeAssetLookup : IAssetCacheComponent
             }
         }
 
-        foreach (var scene in _formLinkCache.WinningOverrides<ISceneGetter>())
-        {
-            foreach (var action in scene.Actions)
+        // TODO: This could use a usage cache (breaking change)
+        _dialogueSceneAliasIndex = new(() => {
+            var index = new Dictionary<FormKey, int>();
+            foreach (var scene in _formLinkCache.WinningOverrides<ISceneGetter>())
             {
-                if (action.Type == SceneAction.TypeEnum.Dialog && !action.Topic.IsNull && action.ActorID != null && !_dialogueSceneAliasIndex.ContainsKey(action.Topic.FormKey))
+                foreach (var action in scene.Actions)
                 {
-                    _dialogueSceneAliasIndex.Add(action.Topic.FormKey, action.ActorID.Value);
+                    if (action.Type == SceneAction.TypeEnum.Dialog && !action.Topic.IsNull && action.ActorID != null && !index.ContainsKey(action.Topic.FormKey))
+                    {
+                        index.Add(action.Topic.FormKey, action.ActorID.Value);
+                    }
                 }
             }
-        }
+            return index;
+        });
+
 
         //Build child cache
-        _childNPCs = _formLinkCache.WinningOverrides<IRaceGetter>()
+        _childVoices = new(() => _formLinkCache.WinningOverrides<IRaceGetter>()
             .Where(r => r.Flags.HasFlag(Race.Flag.Child))
             .Select(r => r.FormKey)
             .SelectWhere(r => _raceNPCs.TryGetValue(r, out var raceNpcFormKeys) ? TryGet<HashSet<FormKey>>.Succeed(raceNpcFormKeys) : TryGet<HashSet<FormKey>>.Failure)
             .SelectMany(x => x)
-            .ToHashSet();
+            .ToDictionary(npc => npc, GetVoiceTypes));
 
         foreach (var (speaker, voices) in _speakerVoices)
         {
@@ -151,8 +155,6 @@ public class VoiceTypeAssetLookup : IAssetCacheComponent
         // Build default voice type lookup, including those defined in masters
         foreach (var mod in _formLinkCache.PriorityOrder)
         {
-            //var defaultVoiceTypes = new HashSet<string>();
-
             var defaultVoiceTypes = mod.EnumerateMajorRecords<IVoiceTypeGetter>()
                 .Where(v => v.Flags.HasFlag(Skyrim.VoiceType.Flag.AllowDefaultDialog))
                 .Select(v => v.EditorID)
@@ -194,7 +196,7 @@ public class VoiceTypeAssetLookup : IAssetCacheComponent
         if (response.Responses.All(r => !r.Sound.IsNull)) return new VoiceContainer();
 
         //If this is a shared info and it's not used, return no voices
-        if (topic.Subtype == DialogTopic.SubtypeEnum.SharedInfo && !_sharedInfoUsages.ContainsKey(response.FormKey)) return new VoiceContainer();
+        if (topic.Subtype == DialogTopic.SubtypeEnum.SharedInfo && !_sharedInfoUsages.Value.ContainsKey(response.FormKey)) return new VoiceContainer();
 
         //Get quest voices
         var questVoices = GetQuestVoices(topic, quest);
@@ -343,7 +345,7 @@ public class VoiceTypeAssetLookup : IAssetCacheComponent
     }
 
     private void LimitVoicesToSharedInfoUsages(VoiceContainer voices, IDialogTopicGetter topic, IDialogResponsesGetter responses) {
-        if (topic.Subtype == DialogTopic.SubtypeEnum.SharedInfo && _sharedInfoUsages.TryGetValue(responses.FormKey, out var responseFormKeys))
+        if (topic.Subtype == DialogTopic.SubtypeEnum.SharedInfo && _sharedInfoUsages.Value.TryGetValue(responses.FormKey, out var responseFormKeys))
         {
             var userConditions = responseFormKeys
                 .Select(responseKey =>
@@ -413,7 +415,7 @@ public class VoiceTypeAssetLookup : IAssetCacheComponent
         if (!response.Speaker.IsNull) return GetVoices(response.Speaker.FormKey);
 
         //Check scene
-        if (topic.Category == DialogTopic.CategoryEnum.Scene && _dialogueSceneAliasIndex.TryGetValue(topic.FormKey, out var aliasIndex))
+        if (topic.Category == DialogTopic.CategoryEnum.Scene && _dialogueSceneAliasIndex.Value.TryGetValue(topic.FormKey, out var aliasIndex))
         {
             voices.IntersectWith(GetVoices(quest, aliasIndex, topic.FormKey.ModKey));
         }
@@ -557,8 +559,7 @@ public class VoiceTypeAssetLookup : IAssetCacheComponent
 
                 break;
             case IIsChildConditionDataGetter isChild:
-                voices = new VoiceContainer(_childNPCs.ToDictionary(npc => npc, GetVoiceTypes));
-
+                voices = new VoiceContainer(_childVoices.Value);
                 break;
             default:
                 voices = new VoiceContainer(true);

--- a/Mutagen.Bethesda.Skyrim/Records/Assets/VoiceType/VoiceTypeAssetLookup.cs
+++ b/Mutagen.Bethesda.Skyrim/Records/Assets/VoiceType/VoiceTypeAssetLookup.cs
@@ -13,8 +13,7 @@ public class VoiceTypeAssetLookup : IAssetCacheComponent
     //Databases
     private readonly Dictionary<ModKey, HashSet<string>> _defaultVoiceTypes = new();
     // NPC -> Voice types
-    // TODO: Most NPCs only have one voice type, but using an enumerable here is slower. Check if unions work better once updated to C# 15
-    private readonly Dictionary<FormKey, HashSet<string>> _speakerVoices = new();
+    private readonly Dictionary<FormKey, IEnumerable<string>> _speakerVoices = new();
     private readonly Dictionary<FormKey, HashSet<FormKey>> _factionNPCs = new();
     private readonly Dictionary<FormKey, HashSet<FormKey>> _classNPCs = new();
     private readonly Dictionary<FormKey, HashSet<FormKey>> _raceNPCs = new();
@@ -65,14 +64,12 @@ public class VoiceTypeAssetLookup : IAssetCacheComponent
                 .SelectMany(GetVoiceTypes)
                 .ToHashSet();
 
-            _speakerVoices
-                .GetOrAdd(leveledNpc.FormKey)
-                .Add(voiceTypes);
+            _speakerVoices.Add(leveledNpc.FormKey, voiceTypes);
         }
 
         foreach (var npc in _formLinkCache.WinningOverrides<INpcGetter>())
         {
-            _speakerVoices.GetOrAdd(npc.FormKey, () => GetVoiceTypes(npc).ToHashSet());
+            _speakerVoices.Add(npc.FormKey, GetVoiceTypes(npc));
 
             foreach (var factionKey in GetFactions(npc))
             {
@@ -111,12 +108,9 @@ public class VoiceTypeAssetLookup : IAssetCacheComponent
 
         foreach (var talkingActivator in _formLinkCache.WinningOverrides<ITalkingActivatorGetter>())
         {
-            if (!_speakerVoices.ContainsKey(talkingActivator.FormKey))
-            {
-                var voice = GetVoiceType(talkingActivator);
-                if (voice != null)
-                    _speakerVoices.Add(talkingActivator.FormKey, [voice]);
-            }
+            var voice = GetVoiceType(talkingActivator);
+            if (voice != null)
+                _speakerVoices.Add(talkingActivator.FormKey, [voice]);
         }
 
         // TODO: This could use a usage cache (breaking change)

--- a/Mutagen.Bethesda.Skyrim/Records/Assets/VoiceType/VoiceTypeAssetLookup.cs
+++ b/Mutagen.Bethesda.Skyrim/Records/Assets/VoiceType/VoiceTypeAssetLookup.cs
@@ -15,8 +15,6 @@ public class VoiceTypeAssetLookup : IAssetCacheComponent
     // NPC -> Voice types
     // TODO: Most NPCs only have one voice type, but using an enumerable here is slower. Check if unions work better once updated to C# 15
     private readonly Dictionary<FormKey, HashSet<string>> _speakerVoices = new();
-    // Voice type -> NPCs. Kept as a List<FormLink> as we always return the full value as form links
-    private readonly Dictionary<string, List<IFormLinkGetter<IHasVoiceTypeGetter>>> _voiceSpeakers = [];
     private readonly Dictionary<FormKey, HashSet<FormKey>> _factionNPCs = new();
     private readonly Dictionary<FormKey, HashSet<FormKey>> _classNPCs = new();
     private readonly Dictionary<FormKey, HashSet<FormKey>> _raceNPCs = new();
@@ -25,6 +23,8 @@ public class VoiceTypeAssetLookup : IAssetCacheComponent
     private Lazy<Dictionary<FormKey, IEnumerable<string>>> _childVoices = null!;
     private Lazy<Dictionary<FormKey, int>> _dialogueSceneAliasIndex = null!;
     private Lazy<Dictionary<FormKey, HashSet<FormKey>>> _sharedInfoUsages = null!;
+    // Voice type -> NPCs. Kept as a List<FormLink> as we always return the full value as form links
+    private Lazy<Dictionary<string, List<IFormLinkGetter<IHasVoiceTypeGetter>>>> _voiceSpeakers = null!;
 
     //Caches
     private readonly object _defaultSpeakerVoicesLock = new();
@@ -144,13 +144,18 @@ public class VoiceTypeAssetLookup : IAssetCacheComponent
             .SelectMany(x => x)
             .ToDictionary(npc => npc, GetVoiceTypes));
 
-        foreach (var (speaker, voices) in _speakerVoices)
+        _voiceSpeakers = new(() =>
         {
-            foreach (var voice in voices)
+            var lookup = new Dictionary<string, List<IFormLinkGetter<IHasVoiceTypeGetter>>>();
+            foreach (var (speaker, voices) in _speakerVoices)
             {
-                _voiceSpeakers.GetOrAdd(voice).Add(speaker);
+                foreach (var voice in voices)
+                {
+                    lookup.GetOrAdd(voice).Add(speaker);
+                }
             }
-        }
+            return lookup;
+        });
 
         // Build default voice type lookup, including those defined in masters
         foreach (var mod in _formLinkCache.PriorityOrder)
@@ -282,7 +287,7 @@ public class VoiceTypeAssetLookup : IAssetCacheComponent
             // All NPCs of voice
             else
             {
-                if (_voiceSpeakers.TryGetValue(voice.Key, out var speakers))
+                if (_voiceSpeakers.Value.TryGetValue(voice.Key, out var speakers))
                 {
                     foreach (var speaker in speakers)
                         yield return speaker;

--- a/Mutagen.Bethesda.Tests/Benchmarks/VoiceTypeAssetLookupBenchmark.cs
+++ b/Mutagen.Bethesda.Tests/Benchmarks/VoiceTypeAssetLookupBenchmark.cs
@@ -1,0 +1,68 @@
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Engines;
+using Mutagen.Bethesda.Environments;
+using Mutagen.Bethesda.Plugins;
+using Mutagen.Bethesda.Plugins.Assets;
+using Mutagen.Bethesda.Plugins.Cache;
+using Mutagen.Bethesda.Skyrim;
+using Mutagen.Bethesda.Skyrim.Records.Assets.VoiceType;
+
+namespace Mutagen.Bethesda.Tests.Benchmarks;
+
+[MemoryDiagnoser, InProcess]
+public class VoiceTypeAssetLookupBenchmark
+{
+    public static ILinkCache LinkCache;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        var env = GameEnvironment.Typical.Builder<ISkyrimMod, ISkyrimModGetter>(GameRelease.SkyrimSE)
+            .Build();
+        LinkCache = env.LinkCache;
+    }
+
+    [Benchmark]
+    public void PrepareWithDefaultMasters()
+    {
+        var lookup = new VoiceTypeAssetLookup();
+        var assetCache = LinkCache.CreateImmutableAssetLinkCache();
+        lookup.Prep(assetCache);
+    }
+}
+
+[MemoryDiagnoser, InProcess]
+public class VoiceTypeAssetLookupRuntimeBenchmark
+{
+    public static ILinkCache LinkCache;
+    public static VoiceTypeAssetLookup Lookup;
+
+    public static IDialogResponsesGetter ResponsesSpecific = null!;
+    public static IDialogResponsesGetter ResponsesGeneric = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        var env = GameEnvironment.Typical.Builder<ISkyrimMod, ISkyrimModGetter>(GameRelease.SkyrimSE)
+            .Build();
+        LinkCache = env.LinkCache;
+        Lookup = new();
+        var assetCache = LinkCache.CreateImmutableAssetLinkCache();
+        Lookup.Prep(assetCache);
+
+        ResponsesSpecific = LinkCache.Resolve<IDialogResponsesGetter>(FormKey.Factory("0D5533:Skyrim.esm"));
+        ResponsesGeneric = LinkCache.Resolve<IDialogResponsesGetter>(FormKey.Factory("0DBA2A:Skyrim.esm"));
+    }
+
+    [Benchmark]
+    public IFormLinkGetter<IHasVoiceTypeGetter>[] LookupVoicesSpecificSpeaker()
+    {
+        return Lookup.GetSpeakers(ResponsesSpecific).ToArray();
+    }
+
+    [Benchmark]
+    public IFormLinkGetter<IHasVoiceTypeGetter>[] LookupVoicesGenericSpeaker()
+    {
+        return Lookup.GetSpeakers(ResponsesGeneric).ToArray();
+    }
+}


### PR DESCRIPTION
Optimizations and refactoring of VoiceTypeAssetLookup

- Reduce usage of HashSet during prepare
- Build lookups from winning overrides
- Cache voice type -> speakers for cases where the whole voice type is used
- Use Lazy for child NPCs, scene aliases, and shared info usages
- Use enumerable for SpeakerVoices value as most NPCs only have one voice type.

Scene aliases and shared info usages may benefit further from a usage cache, this is not implemented here as it would be a breaking change.

Overall, this gives a 1.8x speedup and reduction in allocations when preparing the lookup against the vanilla masters and a
45x speedup with 5x reduction in allocations when processing GetIsVoiceType conditions.

---
Before:
| Method                      | Mean         | Error      | StdDev     | Gen0    | Gen1 | Gen2  | Allocated |
|---------------------------- | ------------:|-----------:|-----------:|--------:|-------:|-:|----------:|
| PrepareWithDefaultMasters | 261.9 ms | 5.21 ms |  4.87 ms | 17000.0000 | 5000.0000 | 1000.0000 | 282.92 MB |
| LookupVoicesSpecificSpeaker |     2.384 us |  0.0473 us |  0.0790 us |  0.4158 |      - | - |    6.8 KB |
| LookupVoicesGenericSpeaker  | 5,460.695 us | 49.8194 us | 41.6015 us | 15.6250 | 7.8125 | - | 379.58 KB |

After:
| Method                      | Mean       | Error     | StdDev    | Gen0   | Gen1 | Gen2  | Allocated |
|------------------------ |-----------:|----------:|----------:|-------:|-------:|-:|----------:|
| PrepareWithDefaultMasters | 144.8 ms | 2.53 ms | 3.19 ms | 9000.0000 | 2000.0000 |        - | 157.56 MB |
| LookupVoicesSpecificSpeaker |   2.178 us | 0.0197 us | 0.0175 us | 0.4005 |      - | - |   6.59 KB |
| LookupVoicesGenericSpeaker | 119.337 us | 0.6232 us | 0.5204 us | 4.0283 | 0.7324 | - |  67.18 KB |
