### PR TITLE
Exclude nested records from usage cache

### DIFF
--- a/Mutagen.Bethesda.Core/Plugins/Cache/Internals/Implementations/ImmutableLoadOrderLinkUsageCache.cs
+++ b/Mutagen.Bethesda.Core/Plugins/Cache/Internals/Implementations/ImmutableLoadOrderLinkUsageCache.cs
@@ -75,7 +75,7 @@ public sealed class ImmutableLoadOrderLinkUsageCache : ILinkUsageCache
             },
             record =>
             {
-                var recordLinks = record.EnumerateFormLinks()
+                var recordLinks = record.EnumerateFormLinks(iterateNestedRecords: false)
                     .Where(link => !link.IsNull)
                     .ToArray();
                 if (recordLinks.Length == 0) return;

--- a/Mutagen.Bethesda.UnitTests/Plugins/Cache/ReferencedBy/ImmutableLoadOrderLinkUsageCacheTests.cs
+++ b/Mutagen.Bethesda.UnitTests/Plugins/Cache/ReferencedBy/ImmutableLoadOrderLinkUsageCacheTests.cs
@@ -1,4 +1,4 @@
-﻿using Mutagen.Bethesda.Plugins;
+using Mutagen.Bethesda.Plugins;
 using Mutagen.Bethesda.Plugins.Cache;
 using Mutagen.Bethesda.Plugins.Cache.Internals.Implementations;
 using Mutagen.Bethesda.Plugins.Records;
@@ -270,5 +270,25 @@ public class ImmutableLoadOrderLinkUsageCacheTests
         TestUntypedResult(c => c.GetUsagesOf(r.ToStandardizedIdentifier()));
         TestTypedResult(c => c.GetUsagesOf<INpcGetter>(r.ToLinkGetter()));
         TestTypedResult(c => c.GetUsagesOf<INpcGetter>(r.ToLink()));
+    }
+
+    [Theory, MutagenModAutoData]
+    public void NestedRecord(
+        SkyrimMod mod,
+        Cell cell,
+        PlacedObject placed,
+        Static stat)
+    {
+        cell.Flags |= Cell.Flag.IsInteriorCell;
+        mod.Cells.AddInteriorCell(cell);
+        cell.Persistent.Add(placed);
+
+        placed.Base.SetTo(stat);
+
+        var linkCache = mod.ToImmutableLinkCache();
+        var usageCache = new ImmutableLoadOrderLinkUsageCache(linkCache);
+
+        usageCache.GetUsagesOf<ICellGetter>(stat).UsageLinks.ShouldBeEmpty();
+        usageCache.GetUsagesOf<IPlacedGetter>(stat).UsageLinks.ShouldEqualEnumerable([placed.ToLink()]);
     }
 }


### PR DESCRIPTION
Do not include references via nested records in usage caches.

Enumerating nested records excludes prior overrides, and does not clearly match the description of "fields that point to a specific record"