### PR TITLE
Extend Test Cases for VoiceTypeAssetLookup and fix differences from runtime behaviour

### DIFF
--- a/Mutagen.Bethesda.Skyrim/Records/Assets/VoiceType/VoiceContainer.cs
+++ b/Mutagen.Bethesda.Skyrim/Records/Assets/VoiceType/VoiceContainer.cs
@@ -1,4 +1,4 @@
-﻿using System.Text;
+using System.Text;
 using Mutagen.Bethesda.Plugins;
 using Noggog;
 namespace Mutagen.Bethesda.Skyrim.Records.Assets.VoiceType;
@@ -213,9 +213,9 @@ public class VoiceContainer : ICloneable, IEquatable<VoiceContainer>
     }
     #endregion
 
-    public HashSet<string> GetVoiceTypes(HashSet<string> defaultVoiceTypes)
+    public IEnumerable<string> GetVoiceTypes(HashSet<string> allVoices)
     {
-        return IsDefault ? defaultVoiceTypes : _voices.Keys.ToHashSet();
+        return IsDefault ? allVoices : _voices.Keys;
     }
 
     public bool IsEmpty()

--- a/Mutagen.Bethesda.Skyrim/Records/Assets/VoiceType/VoiceContainer.cs
+++ b/Mutagen.Bethesda.Skyrim/Records/Assets/VoiceType/VoiceContainer.cs
@@ -8,8 +8,8 @@ public class VoiceContainer : ICloneable, IEquatable<VoiceContainer>
     /// <summary>
     /// Voice type names mapped to form keys of npcs or talking activators using that voice type 
     /// </summary>
-    private readonly Dictionary<string, HashSet<FormKey>> _voices = new();
-    public IReadOnlyDictionary<string, HashSet<FormKey>> Voices => _voices;
+    private readonly Dictionary<FormKey, HashSet<FormKey>> _voices = new();
+    public IReadOnlyDictionary<FormKey, HashSet<FormKey>> Voices => _voices;
     public bool IsDefault { get; private set; }
 
     #region Constructors
@@ -18,7 +18,7 @@ public class VoiceContainer : ICloneable, IEquatable<VoiceContainer>
         IsDefault = isDefault;
     }
 
-    public VoiceContainer(FormKey npc, IEnumerable<string> voiceTypes)
+    public VoiceContainer(FormKey npc, IEnumerable<FormKey> voiceTypes)
     {
         foreach (var voiceType in voiceTypes)
         {
@@ -26,7 +26,7 @@ public class VoiceContainer : ICloneable, IEquatable<VoiceContainer>
         }
     }
 
-    public VoiceContainer(Dictionary<FormKey, IEnumerable<string>> npcVoices)
+    public VoiceContainer(Dictionary<FormKey, IEnumerable<FormKey>> npcVoices)
     {
         foreach (var (npc, voiceTypes) in npcVoices)
         {
@@ -39,7 +39,7 @@ public class VoiceContainer : ICloneable, IEquatable<VoiceContainer>
         }
     }
 
-    public VoiceContainer(Dictionary<FormKey, HashSet<string>> npcVoices)
+    public VoiceContainer(Dictionary<FormKey, HashSet<FormKey>> npcVoices)
     {
         foreach (var (npc, voiceTypes) in npcVoices)
         {
@@ -53,12 +53,12 @@ public class VoiceContainer : ICloneable, IEquatable<VoiceContainer>
         }
     }
 
-    public VoiceContainer(string voiceType)
+    public VoiceContainer(FormKey voiceType)
     {
         _voices.Add(voiceType, []);
     }
 
-    public VoiceContainer(IEnumerable<string> voiceTypes)
+    public VoiceContainer(IEnumerable<FormKey> voiceTypes)
     {
         foreach (var voiceType in voiceTypes)
         {
@@ -68,9 +68,9 @@ public class VoiceContainer : ICloneable, IEquatable<VoiceContainer>
     #endregion
 
     #region ExplicitOperators
-    public void InvertVoiceTypes(HashSet<string> voiceTypesToKeep)
+    public void InvertVoiceTypes(HashSet<FormKey> voiceTypesToKeep)
     {
-        var voiceTypes = new List<string>(_voices.Keys);
+        var voiceTypes = new List<FormKey>(_voices.Keys);
 
         foreach (var voiceType in voiceTypes.Where(voiceType => !voiceTypesToKeep.Contains(voiceType)))
         {
@@ -98,7 +98,7 @@ public class VoiceContainer : ICloneable, IEquatable<VoiceContainer>
         }
 
         // If both are non-default, we need to intersect the voice types and their NPCs
-        var removeVoiceTypes = new HashSet<string>();
+        var removeVoiceTypes = new HashSet<FormKey>();
 
         foreach (var (voiceType, npcs) in _voices)
         {
@@ -177,7 +177,7 @@ public class VoiceContainer : ICloneable, IEquatable<VoiceContainer>
     {
         if (other.IsEmpty()) return;
 
-        var removeVoiceTypes = new HashSet<string>();
+        var removeVoiceTypes = new HashSet<FormKey>();
 
         foreach (var (voiceType, npcs) in _voices)
         {
@@ -213,7 +213,7 @@ public class VoiceContainer : ICloneable, IEquatable<VoiceContainer>
     }
     #endregion
 
-    public IEnumerable<string> GetVoiceTypes(HashSet<string> allVoices)
+    public IEnumerable<FormKey> GetVoiceTypes(HashSet<FormKey> allVoices)
     {
         return IsDefault ? allVoices : _voices.Keys;
     }

--- a/Mutagen.Bethesda.Skyrim/Records/Assets/VoiceType/VoiceTypeAssetLookup.cs
+++ b/Mutagen.Bethesda.Skyrim/Records/Assets/VoiceType/VoiceTypeAssetLookup.cs
@@ -11,7 +11,7 @@ public class VoiceTypeAssetLookup : IAssetCacheComponent
     private ILinkCache _formLinkCache = null!;
 
     //Databases
-    private readonly Dictionary<ModKey, HashSet<string>> _defaultVoiceTypes = new();
+    private HashSet<string> _allVoiceTypes = null!;
     private readonly Dictionary<FormKey, HashSet<string>> _speakerVoices = new();
     private readonly Dictionary<FormKey, HashSet<FormKey>> _factionNPCs = new();
     private readonly Dictionary<FormKey, HashSet<FormKey>> _classNPCs = new();
@@ -22,8 +22,6 @@ public class VoiceTypeAssetLookup : IAssetCacheComponent
     private readonly Dictionary<FormKey, HashSet<FormKey>> _sharedInfoUsages = new();
 
     //Caches
-    private readonly object _defaultSpeakerVoicesLock = new();
-    private readonly Dictionary<ModKey, VoiceContainer> _defaultSpeakerVoices = new();
     private readonly object _questCacheLock = new();
     private readonly Dictionary<FormKey, VoiceContainer> _questCache = new();
 
@@ -137,19 +135,6 @@ public class VoiceTypeAssetLookup : IAssetCacheComponent
                     }
                 }
             }
-
-            var defaultVoiceTypes = new HashSet<string>();
-            _defaultVoiceTypes.Add(mod.ModKey, defaultVoiceTypes);
-            foreach (var voiceType in mod.EnumerateMajorRecords<IVoiceTypeGetter>())
-            {
-                if (voiceType.EditorID != null)
-                {
-                    if ((voiceType.Flags & Skyrim.VoiceType.Flag.AllowDefaultDialog) != 0)
-                    {
-                        defaultVoiceTypes.Add(voiceType.EditorID);
-                    }
-                }
-            }
         }
 
         //Build child cache
@@ -158,20 +143,10 @@ public class VoiceTypeAssetLookup : IAssetCacheComponent
             .SelectMany(x => x)
             .ToHashSet();
 
-        //Add master voice types
-        var defaultVoicesCopy = new Dictionary<ModKey, HashSet<string>>(_defaultVoiceTypes);
-        foreach (var mod in _formLinkCache.PriorityOrder)
-        {
-            foreach (var master in mod.MasterReferences)
-            {
-                if (!defaultVoicesCopy.TryGetValue(master.Master, out var defaultVoiceTypes)) continue;
-
-                foreach (var voiceType in defaultVoiceTypes)
-                {
-                    _defaultVoiceTypes[mod.ModKey].Add(voiceType);
-                }
-            }
-        }
+        _allVoiceTypes = _formLinkCache.WinningOverrides<IVoiceTypeGetter>()
+            .Select(v => v.EditorID)
+            .WhereNotNull()
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
     }
 
     /// <summary>
@@ -264,7 +239,7 @@ public class VoiceTypeAssetLookup : IAssetCacheComponent
 
         if (voiceContainer.IsDefault)
         {
-            voiceContainer = GetAllDefaultVoices();
+            voiceContainer = new(_allVoiceTypes);
         }
 
         foreach (var formKey in voiceContainer.Voices.SelectMany(x =>
@@ -299,13 +274,13 @@ public class VoiceTypeAssetLookup : IAssetCacheComponent
             if (!response.Sound.IsNull) continue;
 
             var responseNumber = response.ResponseNumber;
-            foreach (var voiceType in voices.GetVoiceTypes(_defaultVoiceTypes[topic.FormKey.ModKey]))
+            foreach (var voiceType in voices.GetVoiceTypes(_allVoiceTypes))
             {
                 yield return Path.Combine
                 (
                     "Sound",
                     "Voice",
-                    topic.FormKey.ModKey.FileName,
+                    responses.FormKey.ModKey.FileName,
                     voiceType,
                     $"{questString}_{topicString}_{responseFormID}_{responseNumber}.fuz"
                 );
@@ -347,7 +322,7 @@ public class VoiceTypeAssetLookup : IAssetCacheComponent
                     var currentQuest = currentTopic.Quest.TryResolve(_formLinkCache);
                     if (currentQuest == null) return null;
 
-                    return GetVoices(responseContext.Record.Conditions, currentQuest, topic.FormKey.ModKey);
+                    return GetVoices(responseContext.Record.Conditions, currentQuest);
                 })
                 .WhereNotNull()
                 .MergeInsert(true);
@@ -362,7 +337,7 @@ public class VoiceTypeAssetLookup : IAssetCacheComponent
         {
             if (!_questCache.TryGetValue(quest.FormKey, out var questVoices))
             {
-                questVoices = GetVoices(quest, topic.FormKey.ModKey);
+                questVoices = GetVoices(quest);
                 _questCache.TryAdd(quest.FormKey, questVoices);
             }
 
@@ -407,19 +382,19 @@ public class VoiceTypeAssetLookup : IAssetCacheComponent
         //Check scene
         if (topic.Category == DialogTopic.CategoryEnum.Scene && _dialogueSceneAliasIndex.TryGetValue(topic.FormKey, out var aliasIndex))
         {
-            voices.IntersectWith(GetVoices(quest, aliasIndex, topic.FormKey.ModKey));
+            voices.IntersectWith(GetVoices(quest, aliasIndex));
         }
 
         //Search conditions
         if (response.Conditions.Any())
         {
-            voices.IntersectWith(GetVoices(response.Conditions, quest, topic.FormKey.ModKey));
+            voices.IntersectWith(GetVoices(response.Conditions, quest));
         }
 
         return voices;
     }
 
-    private VoiceContainer GetVoices(IEnumerable<IConditionGetter> conditions, IQuestGetter quest, ModKey currentMod)
+    private VoiceContainer GetVoices(IEnumerable<IConditionGetter> conditions, IQuestGetter quest)
     {
         var voiceTypesOrBlock = new List<VoiceContainer>();
         var currentConditions = new List<IConditionGetter>();
@@ -434,7 +409,7 @@ public class VoiceTypeAssetLookup : IAssetCacheComponent
             //At every new AND or at the end of the conditions, finish the current block
             if ((condition.Flags & Condition.Flag.OR) == 0 || i == conditionsList.Count - 1)
             {
-                var voices = GetVoiceTypesOrBlock(currentConditions, quest, currentMod);
+                var voices = GetVoiceTypesOrBlock(currentConditions, quest);
                 if (!voices.IsDefault) voiceTypesOrBlock.Add(voices);
 
                 currentConditions.Clear();
@@ -445,12 +420,12 @@ public class VoiceTypeAssetLookup : IAssetCacheComponent
         return voiceTypesOrBlock.Any() ? voiceTypesOrBlock.MergeIntersect() : new VoiceContainer(true);
     }
 
-    private VoiceContainer GetVoiceTypesOrBlock(IEnumerable<IConditionGetter> conditions, IQuestGetter quest, ModKey currentMod)
+    private VoiceContainer GetVoiceTypesOrBlock(IEnumerable<IConditionGetter> conditions, IQuestGetter quest)
     {
         return conditions
             .Select(condition =>
             {
-                var conditionVoices = GetVoices(condition, quest, currentMod);
+                var conditionVoices = GetVoices(condition, quest);
                 if (conditionVoices.IsDefault) return null;
 
                 return conditionVoices;
@@ -459,7 +434,7 @@ public class VoiceTypeAssetLookup : IAssetCacheComponent
             .MergeInsert(true);
     }
 
-    private VoiceContainer GetVoices(IConditionGetter condition, IQuestGetter quest, ModKey currentMod)
+    private VoiceContainer GetVoices(IConditionGetter condition, IQuestGetter quest)
     {
         var voices = new VoiceContainer();
 
@@ -500,7 +475,7 @@ public class VoiceTypeAssetLookup : IAssetCacheComponent
 
                 break;
             case IGetIsAliasRefConditionDataGetter aliasRef:
-                voices = GetVoices(quest, aliasRef.ReferenceAliasIndex, currentMod);
+                voices = GetVoices(quest, aliasRef.ReferenceAliasIndex);
 
                 break;
             case IGetInFactionConditionDataGetter getInFaction:
@@ -565,7 +540,7 @@ public class VoiceTypeAssetLookup : IAssetCacheComponent
                 return new VoiceContainer(true);
             }
 
-            voices = Invert(voices, data.Function == Condition.Function.GetIsVoiceType, currentMod);
+            voices = Invert(voices);
         }
 
         return voices;
@@ -616,13 +591,13 @@ public class VoiceTypeAssetLookup : IAssetCacheComponent
         }
     }
 
-    private VoiceContainer GetVoices(IQuestGetter quest, int aliasIndex, ModKey currentMod)
+    private VoiceContainer GetVoices(IQuestGetter quest, int aliasIndex)
     {
         var alias = quest.Aliases.FirstOrDefault(a => a.ID == aliasIndex);
-        return alias == null ? new VoiceContainer(true) : GetVoices(alias, quest, currentMod);
+        return alias == null ? new VoiceContainer(true) : GetVoices(alias, quest);
     }
 
-    private VoiceContainer GetVoices(IQuestAliasGetter alias, IQuestGetter quest, ModKey currentMod)
+    private VoiceContainer GetVoices(IQuestAliasGetter alias, IQuestGetter quest)
     {
         //External Alias
         if (alias.External != null)
@@ -631,7 +606,7 @@ public class VoiceTypeAssetLookup : IAssetCacheComponent
             var aliasIndex = alias.External.AliasID;
             if (externalQuest != null && aliasIndex != null)
             {
-                return GetVoices(externalQuest, aliasIndex.Value, currentMod);
+                return GetVoices(externalQuest, aliasIndex.Value);
             }
         }
 
@@ -682,7 +657,7 @@ public class VoiceTypeAssetLookup : IAssetCacheComponent
         //Conditions
         if (alias.Conditions.Any())
         {
-            var voices = GetVoices(alias.Conditions, quest, currentMod);
+            var voices = GetVoices(alias.Conditions, quest);
             if (additionalVoices != null) voices.Insert(additionalVoices);
             return voices;
         }
@@ -758,45 +733,11 @@ public class VoiceTypeAssetLookup : IAssetCacheComponent
         return voices.MergeInsert(false);
     }
 
-    private VoiceContainer GetVoices(IQuestGetter quest, ModKey currentMod) => GetVoices(quest.DialogConditions, quest, currentMod);
+    private VoiceContainer GetVoices(IQuestGetter quest) => GetVoices(quest.DialogConditions, quest);
 
-    private VoiceContainer GetAllDefaultVoices()
+    private VoiceContainer Invert(VoiceContainer voiceContainer)
     {
-        var allDefaultVoices = new VoiceContainer();
-
-        foreach (var modKey in _formLinkCache.PriorityOrder.Select(x => x.ModKey))
-        {
-            allDefaultVoices.Insert(GetDefaultVoices(modKey));
-        }
-
-        return allDefaultVoices;
-    }
-
-    private VoiceContainer GetDefaultVoices(ModKey mod)
-    {
-        lock (_defaultSpeakerVoicesLock)
-        {
-            if (_defaultSpeakerVoices.TryGetValue(mod, out var defaultVoiceTypes)) return defaultVoiceTypes;
-
-            var vc = new VoiceContainer(_speakerVoices);
-            vc.InvertVoiceTypes(_defaultVoiceTypes[mod]);
-            _defaultSpeakerVoices.TryAdd(mod, vc);
-            return vc;
-        }
-    }
-
-    private VoiceContainer Invert(VoiceContainer voiceContainer, bool invertDefaultVoices, ModKey currentMod)
-    {
-        VoiceContainer baseVoices;
-        if (invertDefaultVoices)
-        {
-            baseVoices = (VoiceContainer)GetDefaultVoices(currentMod).Clone();
-        }
-        else
-        {
-            baseVoices = new VoiceContainer(_speakerVoices);
-        }
-
+        VoiceContainer baseVoices = new(_speakerVoices);
         baseVoices.Remove(voiceContainer);
         return baseVoices;
     }

--- a/Mutagen.Bethesda.Skyrim/Records/Assets/VoiceType/VoiceTypeAssetLookup.cs
+++ b/Mutagen.Bethesda.Skyrim/Records/Assets/VoiceType/VoiceTypeAssetLookup.cs
@@ -651,7 +651,7 @@ public class VoiceTypeAssetLookup : IAssetCacheComponent
             return additionalVoices;
         }
 
-        //Location alias
+        //Location alias. Currently only SpecificLocation is supported
         if (alias.Location is { AliasID: {} })
         {
             var locationAlias = quest.Aliases.FirstOrDefault(a => a.ID == alias.Location.AliasID.Value);

--- a/Mutagen.Bethesda.Skyrim/Records/Assets/VoiceType/VoiceTypeAssetLookup.cs
+++ b/Mutagen.Bethesda.Skyrim/Records/Assets/VoiceType/VoiceTypeAssetLookup.cs
@@ -116,10 +116,7 @@ public class VoiceTypeAssetLookup : IAssetCacheComponent
 
         foreach (var talkingActivator in _formLinkCache.WinningOverrides<ITalkingActivatorGetter>())
         {
-            if (!_speakerVoices.ContainsKey(talkingActivator.FormKey))
-            {
-                _speakerVoices.Add(talkingActivator.FormKey, GetVoiceTypes(talkingActivator));
-            }
+            _speakerVoices.Add(talkingActivator.FormKey, GetVoiceTypes(talkingActivator));
         }
 
         // TODO: Use usage cache for this

--- a/Mutagen.Bethesda.Skyrim/Records/Assets/VoiceType/VoiceTypeAssetLookup.cs
+++ b/Mutagen.Bethesda.Skyrim/Records/Assets/VoiceType/VoiceTypeAssetLookup.cs
@@ -212,12 +212,7 @@ public class VoiceTypeAssetLookup : IAssetCacheComponent
         }
     }
 
-    /// <summary>
-    /// Get all NPCs for a given dialog that can speak it based on the conditions of the dialog.
-    /// </summary>
-    /// <param name="responses">Dialog responses to get speakers for</param>
-    /// <returns>List of NPC speakers, including npcs or talking activators</returns>
-    public IEnumerable<IFormLinkGetter<IHasVoiceTypeGetter>> GetSpeakers(IDialogResponsesGetter responses)
+    private VoiceContainer GetVoiceContainer(IDialogResponsesGetter responses)
     {
         var responsesContext = _formLinkCache.ResolveSimpleContext<IDialogResponsesGetter>(responses.FormKey);
         if (!responsesContext.TryGetParent<IDialogTopicGetter>(out var topic)) return [];
@@ -236,8 +231,28 @@ public class VoiceTypeAssetLookup : IAssetCacheComponent
         {
             voiceContainer = new(_allVoiceTypes);
         }
+        return voiceContainer;
+    }
 
-        return voiceContainer.Voices.SelectMany(x =>
+    /// <summary>
+    /// Get all voice types for a given dialog that can speak it based on the conditions of the dialog.
+    /// </summary>
+    /// <param name="responses">Dialog responses to get speakers for</param>
+    /// <returns>List of voice types</returns>
+    public IEnumerable<IFormLinkGetter<IVoiceTypeGetter>> GetVoices(IDialogResponsesGetter responses)
+    {
+        return GetVoiceContainer(responses).Voices.Keys
+            .Select(v => v.ToLink<IVoiceTypeGetter>());
+    }
+
+    /// <summary>
+    /// Get all NPCs for a given dialog that can speak it based on the conditions of the dialog.
+    /// </summary>
+    /// <param name="responses">Dialog responses to get speakers for</param>
+    /// <returns>List of NPC speakers, including npcs or talking activators</returns>
+    public IEnumerable<IFormLinkGetter<IHasVoiceTypeGetter>> GetSpeakers(IDialogResponsesGetter responses)
+    {
+        return GetVoiceContainer(responses).Voices.SelectMany(x =>
         {
             // A subset of speakers is used
             if (x.Value.Count > 0) return x.Value;

--- a/Mutagen.Bethesda.Skyrim/Records/Assets/VoiceType/VoiceTypeAssetLookup.cs
+++ b/Mutagen.Bethesda.Skyrim/Records/Assets/VoiceType/VoiceTypeAssetLookup.cs
@@ -59,21 +59,6 @@ public class VoiceTypeAssetLookup : IAssetCacheComponent
             }
         }
 
-        foreach (var leveledNpc in _formLinkCache.WinningOverrides<ILeveledNpcGetter>())
-        {
-            if (leveledNpc.Entries is null) continue;
-
-            var voiceTypes = leveledNpc.Entries
-                .Select(x => x.Data?.Reference)
-                .WhereNotNull()
-                .SelectMany(GetVoiceTypes)
-                .ToHashSet();
-
-            _speakerVoices
-                .GetOrAdd(leveledNpc.FormKey)
-                .Add(voiceTypes);
-        }
-
         foreach (var npc in _formLinkCache.WinningOverrides<INpcGetter>())
         {
             _speakerVoices.Add(npc.FormKey, GetVoiceTypes(npc));

--- a/Mutagen.Bethesda.Skyrim/Records/Assets/VoiceType/VoiceTypeAssetLookup.cs
+++ b/Mutagen.Bethesda.Skyrim/Records/Assets/VoiceType/VoiceTypeAssetLookup.cs
@@ -6,6 +6,13 @@ using Mutagen.Bethesda.Plugins.Records;
 using Noggog;
 namespace Mutagen.Bethesda.Skyrim.Records.Assets.VoiceType;
 
+/// <summary>
+/// Lookup for potential speakers and voice types of dialogue. Attempts to determine potential speakers at runtime to the extent that it can be statically determined.
+/// Considers winning overrides only.
+/// 
+/// Intentionally differs from CK behaviour in that it ignores the `AllowDefaultDialog` flag of voice types, which has no effect at runtime but removes a response with
+/// no explicit inclusion condition from voice export consideration in the CK.
+/// </summary>
 public class VoiceTypeAssetLookup : IAssetCacheComponent
 {
     private ILinkCache _formLinkCache = null!;
@@ -29,118 +36,107 @@ public class VoiceTypeAssetLookup : IAssetCacheComponent
     {
         _formLinkCache = linkCache.FormLinkCache;
 
-        var childRaces = new HashSet<FormKey>();
-        foreach (var mod in _formLinkCache.PriorityOrder)
+        foreach (var quest in _formLinkCache.WinningOverrides<IQuestGetter>())
         {
-            foreach (var quest in mod.EnumerateMajorRecords<IQuestGetter>())
+            foreach (var alias in quest.Aliases)
             {
-                foreach (var alias in quest.Aliases)
-                {
-                    var uniqueActor = alias.UniqueActor.FormKey;
-                    if (uniqueActor.IsNull) continue;
+                var uniqueActor = alias.UniqueActor.FormKey;
+                if (uniqueActor.IsNull) continue;
 
-                    foreach (var faction in alias.Factions)
+                foreach (var faction in alias.Factions)
+                {
+                    if (!faction.IsNull)
                     {
-                        if (!faction.IsNull)
-                        {
-                            _factionNPCs
-                                .GetOrAdd(faction.FormKey)
-                                .Add(uniqueActor);
-                        }
-                    }
-                }
-            }
-
-            foreach (var leveledNpc in mod.EnumerateMajorRecords<ILeveledNpcGetter>())
-            {
-                if (leveledNpc.Entries is null) continue;
-
-                var voiceTypes = leveledNpc.Entries
-                    .Select(x => x.Data?.Reference)
-                    .WhereNotNull()
-                    .SelectMany(GetVoiceTypes)
-                    .ToHashSet();
-
-                _speakerVoices
-                    .GetOrAdd(leveledNpc.FormKey)
-                    .Add(voiceTypes);
-            }
-
-            foreach (var npc in mod.EnumerateMajorRecords<INpcGetter>())
-            {
-                _speakerVoices.GetOrAdd(npc.FormKey, () => GetVoiceTypes(npc));
-
-                foreach (var factionKey in GetFactions(npc))
-                {
-                    _factionNPCs
-                        .GetOrAdd(factionKey)
-                        .Add(npc.FormKey);
-                }
-
-                foreach (var classKey in GetClasses(npc))
-                {
-                    _classNPCs
-                        .GetOrAdd(classKey)
-                        .Add(npc.FormKey);
-                }
-
-                foreach (var gender in GetGenders(npc))
-                {
-                    _genderNPCs
-                        .GetOrAdd(gender)
-                        .Add(npc.FormKey);
-                }
-
-                foreach (var raceKey in GetRaces(npc))
-                {
-                    _raceNPCs
-                        .GetOrAdd(raceKey)
-                        .Add(npc.FormKey);
-                }
-            }
-
-            foreach (var response in mod.EnumerateMajorRecords<IDialogResponsesGetter>())
-            {
-                if (!response.ResponseData.IsNull)
-                {
-                    _sharedInfoUsages
-                        .GetOrAdd(response.ResponseData.FormKey)
-                        .Add(response.FormKey);
-                }
-            }
-
-            foreach (var talkingActivator in mod.EnumerateMajorRecords<ITalkingActivatorGetter>())
-            {
-                if (!_speakerVoices.ContainsKey(talkingActivator.FormKey))
-                {
-                    _speakerVoices.Add(talkingActivator.FormKey, GetVoiceTypes(talkingActivator));
-                }
-            }
-
-            foreach (var race in mod.EnumerateMajorRecords<IRaceGetter>())
-            {
-                if ((race.Flags & Race.Flag.Child) != 0)
-                {
-                    childRaces.Add(race.FormKey);
-                }
-            }
-
-            foreach (var scene in mod.EnumerateMajorRecords<ISceneGetter>())
-            {
-                foreach (var action in scene.Actions)
-                {
-                    if (action.Type == SceneAction.TypeEnum.Dialog && !action.Topic.IsNull && action.ActorID != null && !_dialogueSceneAliasIndex.ContainsKey(action.Topic.FormKey))
-                    {
-                        _dialogueSceneAliasIndex.Add(action.Topic.FormKey, action.ActorID.Value);
+                        _factionNPCs
+                            .GetOrAdd(faction.FormKey)
+                            .Add(uniqueActor);
                     }
                 }
             }
         }
 
-        //Build child cache
-        _childNPCs = childRaces
-            .SelectWhere(r => _raceNPCs.TryGetValue(r, out var raceNpcFormKeys) ? TryGet<HashSet<FormKey>>.Succeed(raceNpcFormKeys) : TryGet<HashSet<FormKey>>.Failure)
-            .SelectMany(x => x)
+        foreach (var leveledNpc in _formLinkCache.WinningOverrides<ILeveledNpcGetter>())
+        {
+            if (leveledNpc.Entries is null) continue;
+
+            var voiceTypes = leveledNpc.Entries
+                .Select(x => x.Data?.Reference)
+                .WhereNotNull()
+                .SelectMany(GetVoiceTypes)
+                .ToHashSet();
+
+            _speakerVoices
+                .GetOrAdd(leveledNpc.FormKey)
+                .Add(voiceTypes);
+        }
+
+        foreach (var npc in _formLinkCache.WinningOverrides<INpcGetter>())
+        {
+            _speakerVoices.GetOrAdd(npc.FormKey, () => GetVoiceTypes(npc));
+
+            foreach (var factionKey in GetFactions(npc))
+            {
+                _factionNPCs
+                    .GetOrAdd(factionKey)
+                    .Add(npc.FormKey);
+            }
+
+            foreach (var classKey in GetClasses(npc))
+            {
+                _classNPCs
+                    .GetOrAdd(classKey)
+                    .Add(npc.FormKey);
+            }
+
+            foreach (var gender in GetGenders(npc))
+            {
+                _genderNPCs
+                    .GetOrAdd(gender)
+                    .Add(npc.FormKey);
+            }
+
+            foreach (var raceKey in GetRaces(npc))
+            {
+                _raceNPCs
+                    .GetOrAdd(raceKey)
+                    .Add(npc.FormKey);
+            }
+        }
+
+        // TODO: Use usage cache for this
+        foreach (var response in _formLinkCache.WinningOverrides<IDialogResponsesGetter>())
+        {
+            if (!response.ResponseData.IsNull)
+            {
+                _sharedInfoUsages
+                    .GetOrAdd(response.ResponseData.FormKey)
+                    .Add(response.FormKey);
+            }
+        }
+
+        foreach (var talkingActivator in _formLinkCache.WinningOverrides<ITalkingActivatorGetter>())
+        {
+            if (!_speakerVoices.ContainsKey(talkingActivator.FormKey))
+            {
+                _speakerVoices.Add(talkingActivator.FormKey, GetVoiceTypes(talkingActivator));
+            }
+        }
+
+        // TODO: Use usage cache for this
+        foreach (var scene in _formLinkCache.WinningOverrides<ISceneGetter>())
+        {
+            foreach (var action in scene.Actions)
+            {
+                if (action.Type == SceneAction.TypeEnum.Dialog && !action.Topic.IsNull && action.ActorID != null && !_dialogueSceneAliasIndex.ContainsKey(action.Topic.FormKey))
+                {
+                    _dialogueSceneAliasIndex.Add(action.Topic.FormKey, action.ActorID.Value);
+                }
+            }
+        }
+
+        // Build caches
+        _childNPCs = _raceNPCs.Where(raceNpcs => _formLinkCache.Resolve<IRaceGetter>(raceNpcs.Key).Flags.HasFlag(Race.Flag.Child))
+            .SelectMany(raceNpcs => raceNpcs.Value)
             .ToHashSet();
 
         _allVoiceTypes = _formLinkCache.WinningOverrides<IVoiceTypeGetter>()

--- a/Mutagen.Bethesda.Skyrim/Records/Assets/VoiceType/VoiceTypeAssetLookup.cs
+++ b/Mutagen.Bethesda.Skyrim/Records/Assets/VoiceType/VoiceTypeAssetLookup.cs
@@ -218,10 +218,10 @@ public class VoiceTypeAssetLookup : IAssetCacheComponent
     public IEnumerable<IFormLinkGetter<IHasVoiceTypeGetter>> GetSpeakers(IDialogResponsesGetter responses)
     {
         var responsesContext = _formLinkCache.ResolveSimpleContext<IDialogResponsesGetter>(responses.FormKey);
-        if (!responsesContext.TryGetParent<IDialogTopicGetter>(out var topic)) yield break;
+        if (!responsesContext.TryGetParent<IDialogTopicGetter>(out var topic)) return [];
 
         var quest = topic.Quest.TryResolve(_formLinkCache);
-        if (quest == null) yield break;
+        if (quest == null) return [];
 
         //Get quest voices
         var questVoices = GetQuestVoices(topic, quest);
@@ -235,18 +235,17 @@ public class VoiceTypeAssetLookup : IAssetCacheComponent
             voiceContainer = new(_allVoiceTypes);
         }
 
-        foreach (var formKey in voiceContainer.Voices.SelectMany(x =>
-                 {
-                     if (x.Value.Count > 0) return x.Value;
-
-                     // Get speakers with voice type when the whole voice type is used (there are no speakers)
-                     return _speakerVoices
-                         .Where(y => y.Value.Contains(x.Key))
-                         .Select(y => y.Key);
-                 }))
+        return voiceContainer.Voices.SelectMany(x =>
         {
-            yield return new FormLink<IHasVoiceTypeGetter>(formKey);
-        }
+            // A subset of speakers is used
+            if (x.Value.Count > 0) return x.Value;
+
+            // The whole voice type is used
+            // TODO: This would benefit from a reverse lookup
+            return _speakerVoices
+                .Where(y => y.Value.Contains(x.Key))
+                .Select(y => y.Key);
+        }).Distinct().Select(speaker => new FormLink<IHasVoiceTypeGetter>(speaker));
     }
 
     private IEnumerable<DataRelativePath> GetVoiceLineFilePaths(

--- a/Mutagen.Bethesda.Skyrim/Records/Assets/VoiceType/VoiceTypeAssetLookup.cs
+++ b/Mutagen.Bethesda.Skyrim/Records/Assets/VoiceType/VoiceTypeAssetLookup.cs
@@ -20,10 +20,10 @@ public class VoiceTypeAssetLookup : IAssetCacheComponent
     private ILinkCache _formLinkCache = null!;
 
     //Databases
-    private HashSet<string> _allVoiceTypes = null!;
+    private HashSet<FormKey> _allVoiceTypes = null!;
     // TODO: This is probably unnecessary. Leave optimisation for its own PR.
     // Kept as enumerable as most unique NPCs have only one voice
-    private readonly Dictionary<FormKey, IEnumerable<string>> _speakerVoices = new();
+    private readonly Dictionary<FormKey, IEnumerable<FormKey>> _speakerVoices = new();
     private readonly Dictionary<FormKey, HashSet<FormKey>> _factionNPCs = new();
     private readonly Dictionary<FormKey, HashSet<FormKey>> _classNPCs = new();
     private readonly Dictionary<FormKey, HashSet<FormKey>> _raceNPCs = new();
@@ -118,9 +118,8 @@ public class VoiceTypeAssetLookup : IAssetCacheComponent
 
         foreach (var talkingActivator in _formLinkCache.WinningOverrides<ITalkingActivatorGetter>())
         {
-            var voice = GetVoiceType(talkingActivator);
-            if (voice != null)
-                _speakerVoices.Add(talkingActivator.FormKey, [voice]);
+            if (!talkingActivator.Voice.IsNull)
+                _speakerVoices.Add(talkingActivator.FormKey, [talkingActivator.Voice.FormKey]);
         }
 
         // TODO: Use usage cache for this
@@ -141,9 +140,8 @@ public class VoiceTypeAssetLookup : IAssetCacheComponent
             .ToHashSet();
 
         _allVoiceTypes = _formLinkCache.WinningOverrides<IVoiceTypeGetter>()
-            .Select(v => v.EditorID)
-            .WhereNotNull()
-            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+            .Select(v => v.FormKey)
+            .ToHashSet();
     }
 
     /// <summary>
@@ -272,12 +270,13 @@ public class VoiceTypeAssetLookup : IAssetCacheComponent
             var responseNumber = response.ResponseNumber;
             foreach (var voiceType in voices.GetVoiceTypes(_allVoiceTypes))
             {
+                if (!_formLinkCache.TryResolve<IVoiceTypeGetter>(voiceType, out var voice) || voice.EditorID == null) continue;
                 yield return Path.Combine
                 (
                     "Sound",
                     "Voice",
                     responses.FormKey.ModKey.FileName,
-                    voiceType,
+                    voice.EditorID,
                     $"{questString}_{topicString}_{responseFormID}_{responseNumber}.fuz"
                 );
             }
@@ -456,15 +455,14 @@ public class VoiceTypeAssetLookup : IAssetCacheComponent
                 {
                     switch (voiceTypeRecord)
                     {
-                        case IVoiceTypeGetter voiceType when voiceType.EditorID != null:
-                            voices = new VoiceContainer(voiceType.EditorID);
+                        case IVoiceTypeGetter voiceType:
+                            voices = new VoiceContainer(voiceType.FormKey);
                             break;
                         case IFormListGetter formList:
-                            voices = new VoiceContainer(formList.Items.SelectWhere(link =>
-                            {
-                                _formLinkCache.TryResolveIdentifier<IVoiceTypeGetter>(link.FormKey, out var linkVoiceTypeEditorId);
-                                return linkVoiceTypeEditorId == null ? TryGet<string>.Failure : TryGet<string>.Succeed(linkVoiceTypeEditorId);
-                            }).ToHashSet());
+                            voices = new VoiceContainer(formList.Items
+                                .Where(link => _formLinkCache.TryResolveIdentifier(link, out var _))
+                                .Select(voice => voice.FormKey)
+                                .ToHashSet());
                             break;
                     }
                 }
@@ -705,10 +703,10 @@ public class VoiceTypeAssetLookup : IAssetCacheComponent
 
         foreach (var item in formList.Items)
         {
-            if (_formLinkCache.TryResolveIdentifier<IVoiceTypeGetter>(item.FormKey, out var voiceTypeEditorId))
+            if (_formLinkCache.TryResolveIdentifier<IVoiceTypeGetter>(item.FormKey, out var _))
             {
                 //FormList entry is VoiceType
-                voices.Add(new VoiceContainer(voiceTypeEditorId!));
+                voices.Add(new VoiceContainer(item.FormKey));
             }
             else if (_speakerVoices.ContainsKey(item.FormKey))
             {
@@ -729,7 +727,7 @@ public class VoiceTypeAssetLookup : IAssetCacheComponent
         return baseVoices;
     }
 
-    private IEnumerable<string> GetVoiceTypes(FormKey speaker)
+    private IEnumerable<FormKey> GetVoiceTypes(FormKey speaker)
     {
         return _speakerVoices.TryGetValue(speaker, out var speakerVoiceTypes) ? speakerVoiceTypes : [];
     }
@@ -754,28 +752,26 @@ public class VoiceTypeAssetLookup : IAssetCacheComponent
         }
     }
 
-    private string? GetDefaultVoice(IFormLinkGetter<IRaceGetter> raceLink, bool female)
+    private FormKey GetDefaultVoice(IFormLinkGetter<IRaceGetter> raceLink, bool female)
     {
         if (!raceLink.TryResolve(_formLinkCache, out var race))
-            return null;
+            return FormKey.Null;
         var link = female ? race.Voices.Female : race.Voices.Male;
-        return link.TryResolve(_formLinkCache)?.EditorID;
+        return link.FormKey;
     }
 
-    private HashSet<string> GetVoiceTypes(INpcGetter npc)
+    private HashSet<FormKey> GetVoiceTypes(INpcGetter npc)
     {
-        return GetInheritedData<string?>(npc, NpcConfiguration.TemplateFlag.Traits, entry => {
-            if (entry.Voice.TryResolve(_formLinkCache, out var voice))
-                return [voice.EditorID];
+        return GetInheritedData<FormKey>(npc, NpcConfiguration.TemplateFlag.Traits, entry => {
+            if (!entry.Voice.IsNull)
+                return [entry.Voice.FormKey];
             else
-                return [GetDefaultVoice(npc.Race, npc.Configuration.Flags.HasFlag(NpcConfiguration.Flag.Female))];
+            {
+                var defaultVoice = GetDefaultVoice(npc.Race, npc.Configuration.Flags.HasFlag(NpcConfiguration.Flag.Female));
+                return defaultVoice.IsNull ? [] : [defaultVoice];
+            }
             // TODO: Could this avoid hash set for single-voice NPCs?
-        }).WhereNotNull().ToHashSet();
-    }
-
-    private string? GetVoiceType(ITalkingActivatorGetter talkingActivator)
-    {
-        return talkingActivator.Voice.TryResolve(_formLinkCache)?.EditorID;
+        }).ToHashSet();
     }
 
     private HashSet<IFormLinkGetter<IFactionGetter>> GetFactions(INpcSpawnGetter npc)

--- a/Mutagen.Bethesda.Skyrim/Records/Assets/VoiceType/VoiceTypeAssetLookup.cs
+++ b/Mutagen.Bethesda.Skyrim/Records/Assets/VoiceType/VoiceTypeAssetLookup.cs
@@ -66,14 +66,14 @@ public class VoiceTypeAssetLookup : IAssetCacheComponent
             foreach (var factionKey in GetFactions(npc))
             {
                 _factionNPCs
-                    .GetOrAdd(factionKey)
+                    .GetOrAdd(factionKey.FormKey)
                     .Add(npc.FormKey);
             }
 
             foreach (var classKey in GetClasses(npc))
             {
                 _classNPCs
-                    .GetOrAdd(classKey)
+                    .GetOrAdd(classKey.FormKey)
                     .Add(npc.FormKey);
             }
 
@@ -743,7 +743,7 @@ public class VoiceTypeAssetLookup : IAssetCacheComponent
         return link.TryResolve(_formLinkCache)?.EditorID;
     }
 
-    private IEnumerable<string> GetVoiceTypes(INpcGetter npc)
+    private HashSet<string> GetVoiceTypes(INpcGetter npc)
     {
         return GetInheritedData<string?>(npc, NpcConfiguration.TemplateFlag.Traits, entry => {
             if (entry.Voice.TryResolve(_formLinkCache, out var voice))
@@ -759,66 +759,16 @@ public class VoiceTypeAssetLookup : IAssetCacheComponent
         return talkingActivator.Voice.TryResolve(_formLinkCache)?.EditorID;
     }
 
-    private HashSet<FormKey> GetFactions(INpcGetter npc)
+    private HashSet<IFormLinkGetter<IFactionGetter>> GetFactions(INpcSpawnGetter npc)
     {
-        if ((npc.Configuration.TemplateFlags & NpcConfiguration.TemplateFlag.Factions) == 0)
-        {
-            return npc.Factions.Where(f => !f.Faction.IsNull).Select(f => f.Faction.FormKey).ToHashSet();
-        }
-
-        return npc.Template.IsNull ? new HashSet<FormKey>() : GetFactions(npc.Template);
-
+        return GetInheritedData(npc, NpcConfiguration.TemplateFlag.Factions, entry => entry.Factions.Select(f => f.Faction)).ToHashSet();
     }
 
-    private HashSet<FormKey> GetFactions(IFormLinkGetter<INpcSpawnGetter> npcTemplate)
+    private HashSet<IFormLinkGetter<IClassGetter>> GetClasses(INpcGetter npc)
     {
-        if (npcTemplate.IsNull) return new HashSet<FormKey>();
-
-        //NPC
-        var npc = npcTemplate.TryResolve<INpcGetter>(_formLinkCache);
-        if (npc != null) return GetFactions(npc);
-
-        //Levelled NPC
-        var leveledNpc = npcTemplate.TryResolve<ILeveledNpcGetter>(_formLinkCache);
-        if (leveledNpc is { Entries: {} })
-        {
-            return leveledNpc.Entries
-                .Select(entry => entry.Data?.Reference).NotNull()
-                .SelectMany(GetFactions).ToHashSet();
-        }
-
-        return new HashSet<FormKey>();
-    }
-
-    private HashSet<FormKey> GetClasses(INpcGetter npc)
-    {
-        if ((npc.Configuration.TemplateFlags & NpcConfiguration.TemplateFlag.Stats) == 0 && !npc.Class.IsNull)
-        {
-            return new HashSet<FormKey> { npc.Class.FormKey };
-        }
-
-        return npc.Template.IsNull ? new HashSet<FormKey>() : GetClasses(npc.Template);
-
-    }
-
-    private HashSet<FormKey> GetClasses(IFormLinkGetter<INpcSpawnGetter> npcTemplate)
-    {
-        if (npcTemplate.IsNull) return new HashSet<FormKey>();
-
-        //NPC
-        var npc = npcTemplate.TryResolve<INpcGetter>(_formLinkCache);
-        if (npc != null) return GetClasses(npc);
-
-        //Levelled NPC
-        var leveledNpc = npcTemplate.TryResolve<ILeveledNpcGetter>(_formLinkCache);
-        if (leveledNpc is { Entries: {} })
-        {
-            return leveledNpc.Entries
-                .Select(entry => entry.Data?.Reference).NotNull()
-                .SelectMany(GetClasses).ToHashSet();
-        }
-
-        return new HashSet<FormKey>();
+        return GetInheritedData<IFormLinkGetter<IClassGetter>>(npc, NpcConfiguration.TemplateFlag.Stats, entry => [entry.Class])
+            .Where(c => !c.IsNull)
+            .ToHashSet();
     }
 
     private IEnumerable<MaleFemaleGender> GetGenders(INpcGetter npc)
@@ -831,6 +781,8 @@ public class VoiceTypeAssetLookup : IAssetCacheComponent
 
     private IEnumerable<IFormLinkGetter<IRaceGetter>> GetRaces(INpcGetter npc)
     {
-        return GetInheritedData<IFormLinkGetter<IRaceGetter>>(npc, NpcConfiguration.TemplateFlag.Traits, entry => entry.Race.IsNull ? [] : [entry.Race]).ToHashSet();
+        return GetInheritedData<IFormLinkGetter<IRaceGetter>>(npc, NpcConfiguration.TemplateFlag.Traits, entry => [entry.Race])
+            .Where(r => !r.IsNull)
+            .ToHashSet();
     }
 }

--- a/Mutagen.Bethesda.Skyrim/Records/Assets/VoiceType/VoiceTypeAssetLookup.cs
+++ b/Mutagen.Bethesda.Skyrim/Records/Assets/VoiceType/VoiceTypeAssetLookup.cs
@@ -12,6 +12,8 @@ namespace Mutagen.Bethesda.Skyrim.Records.Assets.VoiceType;
 /// 
 /// Intentionally differs from CK behaviour in that it ignores the `AllowDefaultDialog` flag of voice types, which has no effect at runtime but removes a response with
 /// no explicit inclusion condition from voice export consideration in the CK.
+/// 
+/// Behaviour is undefined if a filter condition is compared against something other than a boolean, or using operators other than == or !=
 /// </summary>
 public class VoiceTypeAssetLookup : IAssetCacheComponent
 {
@@ -528,7 +530,7 @@ public class VoiceTypeAssetLookup : IAssetCacheComponent
                 break;
         }
 
-        if (!voices.IsDefault && !IsConditionValid(condition))
+        if (!voices.IsDefault && IsConditionInverted(condition))
         {
             //Can't invert alias according to CK calculation
             if (data.Function == Condition.Function.GetIsAliasRef)
@@ -542,42 +544,27 @@ public class VoiceTypeAssetLookup : IAssetCacheComponent
         return voices;
     }
 
-    private bool IsConditionValid(IConditionGetter condition)
+    private bool IsConditionInverted(IConditionGetter condition)
     {
-        const double floatTolerance = 0.001;
-
-        bool FloatEquals(float value, int expected) => Math.Abs(value - expected) < floatTolerance;
-
-        bool GlobalEquals(ILink<IGlobalGetter> global, int expected)
+        var compareValue = condition switch
         {
-            var globalValue = global.TryResolve(_formLinkCache);
-            if (globalValue == null) return false;
-
-            return globalValue switch
+            IConditionFloatGetter conditionFloat => conditionFloat.ComparisonValue,
+            IConditionGlobalGetter conditionGlobal => conditionGlobal.ComparisonValue.TryResolve(_formLinkCache) switch
             {
-                IGlobalFloatGetter globalFloat => globalFloat.Data != null && Math.Abs(globalFloat.Data.Value - expected) < floatTolerance,
-                IGlobalIntGetter globalInt => globalInt.Data != null && globalInt.Data.Value == expected,
-                IGlobalShortGetter globalShort => globalShort.Data != null && globalShort.Data.Value == expected,
-                _ => false
-            };
-        }
+                IGlobalFloat globalFloat => globalFloat.Data,
+                IGlobalInt globalInt => globalInt.Data,
+                IGlobalShortGetter globalShort => globalShort.Data,
+                _ => 0,
+            },
+            _ => 0
+        } ?? 0;
 
         switch (condition.CompareOperator)
         {
             case CompareOperator.EqualTo:
-                return condition switch
-                {
-                    IConditionFloatGetter floatCondition => FloatEquals(floatCondition.ComparisonValue, 1),
-                    IConditionGlobalGetter globalCondition => GlobalEquals(globalCondition.ComparisonValue, 1),
-                    _ => false
-                };
+                return compareValue == 0;
             case CompareOperator.NotEqualTo:
-                return condition switch
-                {
-                    IConditionFloatGetter floatCondition => FloatEquals(floatCondition.ComparisonValue, 0),
-                    IConditionGlobalGetter globalCondition => GlobalEquals(globalCondition.ComparisonValue, 0),
-                    _ => false
-                };
+                return compareValue == 1;
             case CompareOperator.GreaterThan:
             case CompareOperator.GreaterThanOrEqualTo:
             case CompareOperator.LessThan:

--- a/Mutagen.Bethesda.Skyrim/Records/Assets/VoiceType/VoiceTypeAssetLookup.cs
+++ b/Mutagen.Bethesda.Skyrim/Records/Assets/VoiceType/VoiceTypeAssetLookup.cs
@@ -27,6 +27,7 @@ public class VoiceTypeAssetLookup : IAssetCacheComponent
     private readonly Dictionary<FormKey, HashSet<FormKey>> _factionNPCs = new();
     private readonly Dictionary<FormKey, HashSet<FormKey>> _classNPCs = new();
     private readonly Dictionary<FormKey, HashSet<FormKey>> _raceNPCs = new();
+    private readonly Dictionary<FormKey, HashSet<FormKey>> _keywordNPCs = new();
     private readonly Dictionary<MaleFemaleGender, HashSet<FormKey>> _genderNPCs = new();
     private HashSet<FormKey> _childNPCs = null!;
     private readonly Dictionary<FormKey, int> _dialogueSceneAliasIndex = new();
@@ -54,6 +55,13 @@ public class VoiceTypeAssetLookup : IAssetCacheComponent
                         _factionNPCs
                             .GetOrAdd(faction.FormKey)
                             .Add(uniqueActor);
+                    }
+                }
+                if (alias.Keywords != null)
+                {
+                    foreach (var keyword in alias.Keywords)
+                    {
+                        _keywordNPCs.GetOrAdd(keyword.FormKey).Add(uniqueActor);
                     }
                 }
             }
@@ -89,6 +97,11 @@ public class VoiceTypeAssetLookup : IAssetCacheComponent
                 _raceNPCs
                     .GetOrAdd(raceKey.FormKey)
                     .Add(npc.FormKey);
+            }
+
+            foreach (var keyword in GetKeywords(npc))
+            {
+                _keywordNPCs.GetOrAdd(keyword.FormKey).Add(npc.FormKey);
             }
         }
 
@@ -483,6 +496,12 @@ public class VoiceTypeAssetLookup : IAssetCacheComponent
                 }
 
                 break;
+            case IHasKeywordConditionDataGetter hasKeyword:
+                if (_keywordNPCs.TryGetValue(hasKeyword.Keyword.Link.FormKey, out var keywordNpcs))
+                {
+                    voices = new VoiceContainer(keywordNpcs.ToDictionary(npc => npc, GetVoiceTypes));
+                }
+                break;
             case IGetIsRaceConditionDataGetter getIsRace:
                 if (getIsRace.Race.UsesLink() && _raceNPCs.TryGetValue(getIsRace.Race.Link.FormKey, out var raceNpcFormKeys))
                 {
@@ -764,14 +783,14 @@ public class VoiceTypeAssetLookup : IAssetCacheComponent
         return GetInheritedData(npc, NpcConfiguration.TemplateFlag.Factions, entry => entry.Factions.Select(f => f.Faction)).ToHashSet();
     }
 
-    private HashSet<IFormLinkGetter<IClassGetter>> GetClasses(INpcGetter npc)
+    private HashSet<IFormLinkGetter<IClassGetter>> GetClasses(INpcSpawnGetter npc)
     {
         return GetInheritedData<IFormLinkGetter<IClassGetter>>(npc, NpcConfiguration.TemplateFlag.Stats, entry => [entry.Class])
             .Where(c => !c.IsNull)
             .ToHashSet();
     }
 
-    private IEnumerable<MaleFemaleGender> GetGenders(INpcGetter npc)
+    private HashSet<MaleFemaleGender> GetGenders(INpcSpawnGetter npc)
     {
         return GetInheritedData<MaleFemaleGender>(npc, NpcConfiguration.TemplateFlag.Traits, entry => [entry.Configuration.Flags.HasFlag(NpcConfiguration.Flag.Female) ? MaleFemaleGender.Female : MaleFemaleGender.Male])
             // TODO: HashSet is overkill
@@ -779,10 +798,17 @@ public class VoiceTypeAssetLookup : IAssetCacheComponent
 
     }
 
-    private IEnumerable<IFormLinkGetter<IRaceGetter>> GetRaces(INpcGetter npc)
+    private HashSet<IFormLinkGetter<IRaceGetter>> GetRaces(INpcSpawnGetter npc)
     {
         return GetInheritedData<IFormLinkGetter<IRaceGetter>>(npc, NpcConfiguration.TemplateFlag.Traits, entry => [entry.Race])
             .Where(r => !r.IsNull)
             .ToHashSet();
+    }
+
+    private HashSet<IFormLinkGetter<IKeywordGetter>> GetKeywords(INpcSpawnGetter npc)
+    {
+        var direct = GetInheritedData(npc, NpcConfiguration.TemplateFlag.Keywords, entry => entry.Keywords ?? []);
+        var race = GetInheritedData(npc, NpcConfiguration.TemplateFlag.Traits, entry => entry.Race.TryResolve(_formLinkCache)?.Keywords ?? []);
+        return direct.And(race).ToHashSet();
     }
 }

--- a/Mutagen.Bethesda.Skyrim/Records/Assets/VoiceType/VoiceTypeAssetLookup.cs
+++ b/Mutagen.Bethesda.Skyrim/Records/Assets/VoiceType/VoiceTypeAssetLookup.cs
@@ -136,7 +136,7 @@ public class VoiceTypeAssetLookup : IAssetCacheComponent
         }
 
         // Build caches
-        _childNPCs = _raceNPCs.Where(raceNpcs => _formLinkCache.Resolve<IRaceGetter>(raceNpcs.Key).Flags.HasFlag(Race.Flag.Child))
+        _childNPCs = _raceNPCs.Where(raceNpcs => _formLinkCache.TryResolve<IRaceGetter>(raceNpcs.Key, out var race) && race.Flags.HasFlag(Race.Flag.Child))
             .SelectMany(raceNpcs => raceNpcs.Value)
             .ToHashSet();
 
@@ -859,6 +859,6 @@ public class VoiceTypeAssetLookup : IAssetCacheComponent
 
     private IEnumerable<IFormLinkGetter<IRaceGetter>> GetRaces(INpcGetter npc)
     {
-        return GetInheritedData<IFormLinkGetter<IRaceGetter>>(npc, NpcConfiguration.TemplateFlag.Traits, entry => [entry.Race]).ToHashSet();
+        return GetInheritedData<IFormLinkGetter<IRaceGetter>>(npc, NpcConfiguration.TemplateFlag.Traits, entry => entry.Race.IsNull ? [] : [entry.Race]).ToHashSet();
     }
 }

--- a/Mutagen.Bethesda.Skyrim/Records/Assets/VoiceType/VoiceTypeAssetLookup.cs
+++ b/Mutagen.Bethesda.Skyrim/Records/Assets/VoiceType/VoiceTypeAssetLookup.cs
@@ -214,11 +214,12 @@ public class VoiceTypeAssetLookup : IAssetCacheComponent
 
     private VoiceContainer GetVoiceContainer(IDialogResponsesGetter responses)
     {
-        var responsesContext = _formLinkCache.ResolveSimpleContext<IDialogResponsesGetter>(responses.FormKey);
-        if (!responsesContext.TryGetParent<IDialogTopicGetter>(out var topic)) return [];
-
-        var quest = topic.Quest.TryResolve(_formLinkCache);
-        if (quest == null) return [];
+        if (!_formLinkCache.TryResolveSimpleContext(responses, out var context))
+            return new();
+        if (!context.TryGetParent<IDialogTopicGetter>(out var topic))
+            return new();
+        if (!topic.Quest.TryResolve(_formLinkCache, out var quest))
+            return new();
 
         //Get quest voices
         var questVoices = GetQuestVoices(topic, quest);
@@ -239,7 +240,7 @@ public class VoiceTypeAssetLookup : IAssetCacheComponent
     /// </summary>
     /// <param name="responses">Dialog responses to get speakers for</param>
     /// <returns>List of voice types</returns>
-    public IEnumerable<IFormLinkGetter<IVoiceTypeGetter>> GetVoices(IDialogResponsesGetter responses)
+    public IEnumerable<IFormLinkGetter<IVoiceTypeGetter>> GetVoiceTypes(IDialogResponsesGetter responses)
     {
         return GetVoiceContainer(responses).Voices.Keys
             .Select(v => v.ToLink<IVoiceTypeGetter>());
@@ -262,7 +263,7 @@ public class VoiceTypeAssetLookup : IAssetCacheComponent
             return _speakerVoices
                 .Where(y => y.Value.Contains(x.Key))
                 .Select(y => y.Key);
-        }).Distinct().Select(speaker => new FormLink<IHasVoiceTypeGetter>(speaker));
+        }).Distinct().Select(speaker => speaker.ToLink<IHasVoiceTypeGetter>());
     }
 
     private IEnumerable<DataRelativePath> GetVoiceLineFilePaths(

--- a/Mutagen.Bethesda.Skyrim/Records/Assets/VoiceType/VoiceTypeAssetLookup.cs
+++ b/Mutagen.Bethesda.Skyrim/Records/Assets/VoiceType/VoiceTypeAssetLookup.cs
@@ -19,7 +19,9 @@ public class VoiceTypeAssetLookup : IAssetCacheComponent
 
     //Databases
     private HashSet<string> _allVoiceTypes = null!;
-    private readonly Dictionary<FormKey, HashSet<string>> _speakerVoices = new();
+    // TODO: This is probably unnecessary. Leave optimisation for its own PR.
+    // Kept as enumerable as most unique NPCs have only one voice
+    private readonly Dictionary<FormKey, IEnumerable<string>> _speakerVoices = new();
     private readonly Dictionary<FormKey, HashSet<FormKey>> _factionNPCs = new();
     private readonly Dictionary<FormKey, HashSet<FormKey>> _classNPCs = new();
     private readonly Dictionary<FormKey, HashSet<FormKey>> _raceNPCs = new();
@@ -72,7 +74,7 @@ public class VoiceTypeAssetLookup : IAssetCacheComponent
 
         foreach (var npc in _formLinkCache.WinningOverrides<INpcGetter>())
         {
-            _speakerVoices.GetOrAdd(npc.FormKey, () => GetVoiceTypes(npc));
+            _speakerVoices.Add(npc.FormKey, GetVoiceTypes(npc));
 
             foreach (var factionKey in GetFactions(npc))
             {
@@ -98,7 +100,7 @@ public class VoiceTypeAssetLookup : IAssetCacheComponent
             foreach (var raceKey in GetRaces(npc))
             {
                 _raceNPCs
-                    .GetOrAdd(raceKey)
+                    .GetOrAdd(raceKey.FormKey)
                     .Add(npc.FormKey);
             }
         }
@@ -116,7 +118,9 @@ public class VoiceTypeAssetLookup : IAssetCacheComponent
 
         foreach (var talkingActivator in _formLinkCache.WinningOverrides<ITalkingActivatorGetter>())
         {
-            _speakerVoices.Add(talkingActivator.FormKey, GetVoiceTypes(talkingActivator));
+            var voice = GetVoiceType(talkingActivator);
+            if (voice != null)
+                _speakerVoices.Add(talkingActivator.FormKey, [voice]);
         }
 
         // TODO: Use usage cache for this
@@ -739,71 +743,50 @@ public class VoiceTypeAssetLookup : IAssetCacheComponent
         return _speakerVoices.TryGetValue(speaker, out var speakerVoiceTypes) ? speakerVoiceTypes : [];
     }
 
-    #region Voice Parser
-    private HashSet<string> GetVoiceTypes(INpcGetter npc)
+    private IEnumerable<T> GetInheritedData<T>(INpcSpawnGetter spawn, NpcConfiguration.TemplateFlag inheritFlag, Func<INpcGetter, IEnumerable<T>> getter)
     {
-        if (_speakerVoices.TryGetValue(npc.FormKey, out var speakerVoiceTypes)) return speakerVoiceTypes;
-
-        //Check voice type
-        if (!npc.Voice.IsNull)
+        switch (spawn)
         {
-            var voiceType = npc.Voice.TryResolve(_formLinkCache);
-            if (voiceType is { EditorID: {} })
-            {
-                return new HashSet<string> { voiceType.EditorID };
-            }
-        }
+            case INpcGetter npc:
+                if (npc.Configuration.TemplateFlags.HasFlag(inheritFlag) && npc.Template.TryResolve(_formLinkCache, out var template))
+                    return GetInheritedData(template, inheritFlag, getter);
+                else
+                    return getter(npc);
+            case ILeveledNpcGetter leveledNpc:
+                if (leveledNpc.Entries == null) return [];
 
-        //Check template
-        if (!npc.Template.IsNull && (npc.Configuration.TemplateFlags & NpcConfiguration.TemplateFlag.Traits) != 0)
-        {
-            return GetVoiceTypes(npc.Template).ToHashSet();
+                return leveledNpc.Entries
+                    .Select(e => e.Data?.Reference?.TryResolve(_formLinkCache))
+                    .WhereNotNull()
+                    .SelectMany(e => GetInheritedData(e, inheritFlag, getter));
+            default: return [];
         }
-
-        return new HashSet<string>();
     }
 
-    private HashSet<string> GetVoiceTypes(IFormLinkGetter<INpcSpawnGetter> npcSpawn)
+    private string? GetDefaultVoice(IFormLinkGetter<IRaceGetter> raceLink, bool female)
     {
-        if (npcSpawn.IsNull) return new HashSet<string>();
-
-        //NPC
-        var npc = npcSpawn.TryResolve<INpcGetter>(_formLinkCache);
-        if (npc != null)
-        {
-            return GetVoiceTypes(npc);
-        }
-
-        //Levelled NPC
-        var leveledNpc = npcSpawn.TryResolve<ILeveledNpcGetter>(_formLinkCache);
-        if (leveledNpc is { Entries: {} })
-        {
-            return leveledNpc.Entries
-                .Select(entry => entry.Data?.Reference).NotNull()
-                .SelectMany(GetVoiceTypes).ToHashSet();
-        }
-
-        return new HashSet<string>();
+        if (!raceLink.TryResolve(_formLinkCache, out var race))
+            return null;
+        var link = female ? race.Voices.Female : race.Voices.Male;
+        return link.TryResolve(_formLinkCache)?.EditorID;
     }
 
-    private HashSet<string> GetVoiceTypes(ITalkingActivatorGetter talkingActivator)
+    private IEnumerable<string> GetVoiceTypes(INpcGetter npc)
     {
-        if (_speakerVoices.TryGetValue(talkingActivator.FormKey, out var speakerVoiceTypes)) return speakerVoiceTypes;
-
-        if (!talkingActivator.Voice.IsNull)
-        {
-            var voiceTypeGetter = talkingActivator.Voice.TryResolve(_formLinkCache);
-            if (voiceTypeGetter is { EditorID: not null })
-            {
-                return new HashSet<string> { voiceTypeGetter.EditorID };
-            }
-        }
-
-        return new HashSet<string>();
+        return GetInheritedData<string?>(npc, NpcConfiguration.TemplateFlag.Traits, entry => {
+            if (entry.Voice.TryResolve(_formLinkCache, out var voice))
+                return [voice.EditorID];
+            else
+                return [GetDefaultVoice(npc.Race, npc.Configuration.Flags.HasFlag(NpcConfiguration.Flag.Female))];
+            // TODO: Could this avoid hash set for single-voice NPCs?
+        }).WhereNotNull().ToHashSet();
     }
-    #endregion
 
-    #region Faction Parser
+    private string? GetVoiceType(ITalkingActivatorGetter talkingActivator)
+    {
+        return talkingActivator.Voice.TryResolve(_formLinkCache)?.EditorID;
+    }
+
     private HashSet<FormKey> GetFactions(INpcGetter npc)
     {
         if ((npc.Configuration.TemplateFlags & NpcConfiguration.TemplateFlag.Factions) == 0)
@@ -834,9 +817,7 @@ public class VoiceTypeAssetLookup : IAssetCacheComponent
 
         return new HashSet<FormKey>();
     }
-    #endregion
 
-    #region Class Parser
     private HashSet<FormKey> GetClasses(INpcGetter npc)
     {
         if ((npc.Configuration.TemplateFlags & NpcConfiguration.TemplateFlag.Stats) == 0 && !npc.Class.IsNull)
@@ -867,29 +848,17 @@ public class VoiceTypeAssetLookup : IAssetCacheComponent
 
         return new HashSet<FormKey>();
     }
-    #endregion
 
-    #region Gender Parser
-    private HashSet<MaleFemaleGender> GetGenders(INpcGetter npc)
+    private IEnumerable<MaleFemaleGender> GetGenders(INpcGetter npc)
     {
-        if ((npc.Configuration.TemplateFlags & NpcConfiguration.TemplateFlag.Traits) == 0)
-        {
-            return [(npc.Configuration.Flags & NpcConfiguration.Flag.Female) != 0 ? MaleFemaleGender.Female : MaleFemaleGender.Male];
-        }
+        return GetInheritedData<MaleFemaleGender>(npc, NpcConfiguration.TemplateFlag.Traits, entry => [entry.Configuration.Flags.HasFlag(NpcConfiguration.Flag.Female) ? MaleFemaleGender.Female : MaleFemaleGender.Male])
+            // TODO: HashSet is overkill
+            .ToHashSet();
 
-        return [];
     }
-    #endregion
 
-    #region Race Parser
-    private HashSet<FormKey> GetRaces(INpcGetter npc)
+    private IEnumerable<IFormLinkGetter<IRaceGetter>> GetRaces(INpcGetter npc)
     {
-        if ((npc.Configuration.TemplateFlags & NpcConfiguration.TemplateFlag.Traits) == 0 && !npc.Race.IsNull)
-        {
-            return new HashSet<FormKey> { npc.Race.FormKey };
-        }
-
-        return [];
+        return GetInheritedData<IFormLinkGetter<IRaceGetter>>(npc, NpcConfiguration.TemplateFlag.Traits, entry => [entry.Race]).ToHashSet();
     }
-    #endregion
 }

--- a/Mutagen.Bethesda.UnitTests/Plugins/Records/Skyrim/Assets/VoiceTypeAssetLookupTestSkyrim.cs
+++ b/Mutagen.Bethesda.UnitTests/Plugins/Records/Skyrim/Assets/VoiceTypeAssetLookupTestSkyrim.cs
@@ -144,7 +144,7 @@ public class VoiceTypeAssetLookupTestSkyrim
             return data;
         }
 
-        public static ConditionData GetIsClass(IClassGetter npcClass)
+        public static ConditionData GetIsClass(IFormLinkGetter<IClassGetter> npcClass)
         {
             var data = new GetIsClassConditionData();
             data.Class.Link.SetTo(npcClass);
@@ -315,9 +315,18 @@ public class VoiceTypeAssetLookupTestSkyrim
         member.Factions.Add(new() { Faction = faction.ToLink() });
         var nonmember = fixture.CreateSpeaker("nonmember");
 
+        // Factions may be applied via aliases
+        var questmember = fixture.CreateSpeaker("questmember");
+        fixture.Quest.Aliases.Add(new()
+        {
+            UniqueActor = questmember.ToNullableLink(),
+            Factions = [faction.ToLink()],
+        });
+
         fixture.AssertSpeakersEqual(
             [ConditionFactory.Create(ConditionFactory.GetInFaction(faction), 1)],
-            [member]);
+            [member, questmember]);
+
     }
 
     [Theory, MutagenModAutoData]
@@ -330,7 +339,7 @@ public class VoiceTypeAssetLookupTestSkyrim
         fixture.CreateSpeaker("dummy");
 
         fixture.AssertSpeakersEqual(
-            [ConditionFactory.Create(ConditionFactory.GetIsClass(npcClass), 1)],
+            [ConditionFactory.Create(ConditionFactory.GetIsClass(npcClass.ToLink()), 1)],
             [npc1]);
     }
 
@@ -565,6 +574,10 @@ public class VoiceTypeAssetLookupTestSkyrim
         var derived = fixture.CreateSpeaker("derived");
         derived.Race.SetTo(dummyRace);
         derived.Template.SetTo(leveledNpc);
+
+        fixture.AssertSpeakersEqual(
+            [ConditionFactory.Create(ConditionFactory.GetIsVoice(base1.Voice), 1)],
+            [base1]);
         derived.Configuration.TemplateFlags |= NpcConfiguration.TemplateFlag.Traits;
 
         fixture.AssertSpeakersEqual(
@@ -595,21 +608,121 @@ public class VoiceTypeAssetLookupTestSkyrim
     }
 
     [Theory, MutagenModAutoData]
-    public void TestInheritedStats(VoiceTypeAssetLookupTestFixture fixture)
+    public void TestInheritedStats(
+        VoiceTypeAssetLookupTestFixture fixture,
+        LeveledNpc leveledNpc,
+        Class class1,
+        Class class2,
+        Class dummyClass)
     {
-        false.ShouldBe(true); // TODO: Class
+        var base1 = fixture.CreateSpeaker("base1");
+        base1.Class.SetTo(class1);
+        var base2 = fixture.CreateSpeaker("base2");
+        base2.Class.SetTo(class2);
+        leveledNpc.Entries =
+        [
+            new() {Data = new() {Reference = base1.ToLink() } },
+            new() {Data = new() {Reference = base2.ToLink() } },
+        ];
+        var derived = fixture.CreateSpeaker("derived");
+        derived.Template.SetTo(leveledNpc);
+
+        fixture.AssertSpeakersEqual(
+            [ConditionFactory.Create(ConditionFactory.GetIsClass(base1.Class), 1)],
+            [base1]);
+        derived.Configuration.TemplateFlags |= NpcConfiguration.TemplateFlag.Stats;
+
+        fixture.AssertSpeakersEqual(
+            [ConditionFactory.Create(ConditionFactory.GetIsClass(base1.Class), 1)],
+            [base1, derived]);
+
+        // Derived data should be disregarded if a template is used
+        derived.Class.SetTo(dummyClass);
+        fixture.AssertSpeakersEqual(
+            [ConditionFactory.Create(ConditionFactory.GetIsClass(dummyClass.ToLink()), 1)],
+            []);
+
+        // Template flags should be ignored if template is null
+        derived.Template.SetToNull();
+        fixture.AssertSpeakersEqual(
+            [ConditionFactory.Create(ConditionFactory.GetIsClass(dummyClass.ToLink()), 1)],
+            [derived]);
     }
 
     [Theory, MutagenModAutoData]
-    public void TestInheritedFactions(VoiceTypeAssetLookupTestFixture fixture)
+    public void TestInheritedFactions(
+        VoiceTypeAssetLookupTestFixture fixture,
+        LeveledNpc leveledNpc,
+        Faction faction1,
+        Faction faction2)
     {
-        false.ShouldBe(true); // TODO: Factions                                                                             
+        var base1 = fixture.CreateSpeaker("base1");
+        base1.Factions.Add(new() { Faction = faction1.ToLink() });
+        var base2 = fixture.CreateSpeaker("base2");
+        base1.Factions.Add(new() { Faction = faction2.ToLink() });
+        leveledNpc.Entries =
+        [
+            new() {Data = new() {Reference = base1.ToLink() } },
+            new() {Data = new() {Reference = base2.ToLink() } },
+        ];
+        var derived = fixture.CreateSpeaker("derived");
+        derived.Template.SetTo(leveledNpc);
+
+        fixture.AssertSpeakersEqual(
+            [ConditionFactory.Create(ConditionFactory.GetInFaction(faction1), 1)],
+            [base1]);
+        derived.Configuration.TemplateFlags |= NpcConfiguration.TemplateFlag.Stats;
+
+        fixture.AssertSpeakersEqual(
+            [ConditionFactory.Create(ConditionFactory.GetInFaction(faction1), 1)],
+            [base1, derived]);
     }
 
     [Theory, MutagenModAutoData]
-    public void TestInheritedKeywords(VoiceTypeAssetLookupTestFixture fixture)
+    public void TestInheritedKeywords(
+        VoiceTypeAssetLookupTestFixture fixture,
+        LeveledNpc leveledNpc,
+        Keyword keyword1,
+        Keyword keyword2,
+        Race race,
+        Keyword raceKeyword)
     {
-        false.ShouldBeTrue();
+        var base1 = fixture.CreateSpeaker("base1");
+        base1.Keywords = [keyword2.ToLink()];
+        var base2 = fixture.CreateSpeaker("base2");
+        base2.Keywords = [keyword2.ToLink()];
+        var raceBase = fixture.CreateSpeaker("raceBase");
+        raceBase.Race.SetTo(race);
+        race.Keywords = [raceKeyword.ToLink()];
+        leveledNpc.Entries =
+        [
+            new() {Data = new() {Reference = base1.ToLink() } },
+            new() {Data = new() {Reference = base2.ToLink() } },
+            new() {Data = new() {Reference = raceBase.ToLink() } },
+        ];
+        var derived = fixture.CreateSpeaker("derived");
+        derived.Template.SetTo(leveledNpc);
+
+        fixture.AssertSpeakersEqual(
+            [ConditionFactory.Create(ConditionFactory.HasKeyword(keyword1), 1)],
+            [base1]);
+        fixture.AssertSpeakersEqual(
+            [ConditionFactory.Create(ConditionFactory.HasKeyword(raceKeyword), 1)],
+            [raceBase]);
+
+
+        // Keywords are inherited via the UseKeywords flag
+        derived.Configuration.TemplateFlags |= NpcConfiguration.TemplateFlag.Keywords;
+        fixture.AssertSpeakersEqual(
+            [ConditionFactory.Create(ConditionFactory.HasKeyword(keyword1), 1)],
+            [base1]);
+
+        // They can also be inheited via the race, this time with UseStats
+        derived.Configuration.TemplateFlags &= ~NpcConfiguration.TemplateFlag.Keywords;
+        derived.Configuration.TemplateFlags |= NpcConfiguration.TemplateFlag.Stats;
+        fixture.AssertSpeakersEqual(
+            [ConditionFactory.Create(ConditionFactory.HasKeyword(raceKeyword), 1)],
+            [raceBase]);
     }
 
     [Theory, MutagenModAutoData]

--- a/Mutagen.Bethesda.UnitTests/Plugins/Records/Skyrim/Assets/VoiceTypeAssetLookupTestSkyrim.cs
+++ b/Mutagen.Bethesda.UnitTests/Plugins/Records/Skyrim/Assets/VoiceTypeAssetLookupTestSkyrim.cs
@@ -377,7 +377,7 @@ public class VoiceTypeAssetLookupTestSkyrim
     }
 
     [Theory, MutagenModAutoData]
-    public void TestCompareOperators(VoiceTypeAssetLookupTestFixture fixture)
+    public void TestCompareOperators(VoiceTypeAssetLookupTestFixture fixture, GlobalFloat global)
     {
         var npc1 = fixture.CreateSpeaker("npc1");
         var npc2 = fixture.CreateSpeaker("npc2");
@@ -391,16 +391,15 @@ public class VoiceTypeAssetLookupTestSkyrim
             [ConditionFactory.Create(data, 1, CompareOperator.NotEqualTo)],
             [npc2]);
 
-        // Runtime does not use an epsilon when comparing floats
-        fixture.AssertSpeakersEqual(
-            [ConditionFactory.Create(data, 1.001f, CompareOperator.EqualTo)],
-            []);
-
-        // TODO: Should we handle edge cases of comparing a bool with something other than 0 or 1 and == or !=
-        // or leave it as undefined behavior?
-        // Either way, should have an analyser to check this
-
-        false.ShouldBeTrue(); // TODO: Test for globals
+        var conditionGlobal = new ConditionGlobal()
+        {
+            Data = data,
+            ComparisonValue = global.ToLink()
+        };
+        global.Data = 1;
+        fixture.AssertSpeakersEqual([conditionGlobal], [npc1]);
+        global.Data = 0;
+        fixture.AssertSpeakersEqual([conditionGlobal], [npc2]);
     }
 
     [Theory, MutagenModAutoData]

--- a/Mutagen.Bethesda.UnitTests/Plugins/Records/Skyrim/Assets/VoiceTypeAssetLookupTestSkyrim.cs
+++ b/Mutagen.Bethesda.UnitTests/Plugins/Records/Skyrim/Assets/VoiceTypeAssetLookupTestSkyrim.cs
@@ -221,7 +221,7 @@ public class VoiceTypeAssetLookupTestSkyrim
     }
 
     [Theory, MutagenModAutoData]
-    public void TestGetPaths(VoiceTypeAssetLookupTestFixture fixture)
+    public void TestGetPaths(VoiceTypeAssetLookupTestFixture fixture, FormKey sharedInfo)
     {
         // Smoke test based on response in DialogueGeneric
         fixture.Quest.EditorID = "DialogueGeneric";
@@ -238,6 +238,10 @@ public class VoiceTypeAssetLookupTestSkyrim
         // Should also work for unfiltered response
         response.Conditions.Clear();
         fixture.GetLookup().GetVoiceLineFilePaths(response).ShouldBe([new DataRelativePath("Sound/Voice/Skyrim.esm/MaleEvenToned/DialogueGe_DialogueGeneric_000142C2_1.fuz")]);
+
+        // A shared info should have no associated paths
+        response.ResponseData.SetTo(sharedInfo);
+        fixture.GetLookup().GetVoiceLineFilePaths(response).ShouldBeEmpty();
     }
 
     private readonly ILinkCache _linkCache;

--- a/Mutagen.Bethesda.UnitTests/Plugins/Records/Skyrim/Assets/VoiceTypeAssetLookupTestSkyrim.cs
+++ b/Mutagen.Bethesda.UnitTests/Plugins/Records/Skyrim/Assets/VoiceTypeAssetLookupTestSkyrim.cs
@@ -382,6 +382,7 @@ public class VoiceTypeAssetLookupTestSkyrim
         actorKey.Keywords = [actorKeyword.ToLink()];
         
         var raceKey = fixture.CreateSpeaker("raceKey");
+        raceKey.Race.SetTo(race);
         race.Keywords = [raceKeyword.ToLink()];
 
         var questKey = fixture.CreateSpeaker("questKey");
@@ -691,7 +692,7 @@ public class VoiceTypeAssetLookupTestSkyrim
         Keyword raceKeyword)
     {
         var base1 = fixture.CreateSpeaker("base1");
-        base1.Keywords = [keyword2.ToLink()];
+        base1.Keywords = [keyword1.ToLink()];
         var base2 = fixture.CreateSpeaker("base2");
         base2.Keywords = [keyword2.ToLink()];
         var raceBase = fixture.CreateSpeaker("raceBase");
@@ -718,14 +719,14 @@ public class VoiceTypeAssetLookupTestSkyrim
         derived.Configuration.TemplateFlags |= NpcConfiguration.TemplateFlag.Keywords;
         fixture.AssertSpeakersEqual(
             [ConditionFactory.Create(ConditionFactory.HasKeyword(keyword1), 1)],
-            [base1]);
+            [base1, derived]);
 
         // They can also be inheited via the race, this time with UseTraits
         derived.Configuration.TemplateFlags &= ~NpcConfiguration.TemplateFlag.Keywords;
         derived.Configuration.TemplateFlags |= NpcConfiguration.TemplateFlag.Traits;
         fixture.AssertSpeakersEqual(
             [ConditionFactory.Create(ConditionFactory.HasKeyword(raceKeyword), 1)],
-            [raceBase]);
+            [raceBase, derived]);
     }
 
     [Theory, MutagenModAutoData]

--- a/Mutagen.Bethesda.UnitTests/Plugins/Records/Skyrim/Assets/VoiceTypeAssetLookupTestSkyrim.cs
+++ b/Mutagen.Bethesda.UnitTests/Plugins/Records/Skyrim/Assets/VoiceTypeAssetLookupTestSkyrim.cs
@@ -255,6 +255,9 @@ public class VoiceTypeAssetLookupTestSkyrim
 
         CheckAlias(new() { UniqueActor = npc1.ToNullableLink() });
 
+        // Created
+        CheckAlias(new() { CreateReferenceToObject = new() { Object =  npc1.ToLink() }  });
+
         // Forced ref
         cell.Flags |= Cell.Flag.IsInteriorCell;
         fixture.Mod.Cells.AddInteriorCell(cell);
@@ -671,7 +674,7 @@ public class VoiceTypeAssetLookupTestSkyrim
         fixture.AssertSpeakersEqual(
             [ConditionFactory.Create(ConditionFactory.GetInFaction(faction1), 1)],
             [base1]);
-        derived.Configuration.TemplateFlags |= NpcConfiguration.TemplateFlag.Stats;
+        derived.Configuration.TemplateFlags |= NpcConfiguration.TemplateFlag.Factions;
 
         fixture.AssertSpeakersEqual(
             [ConditionFactory.Create(ConditionFactory.GetInFaction(faction1), 1)],
@@ -717,9 +720,9 @@ public class VoiceTypeAssetLookupTestSkyrim
             [ConditionFactory.Create(ConditionFactory.HasKeyword(keyword1), 1)],
             [base1]);
 
-        // They can also be inheited via the race, this time with UseStats
+        // They can also be inheited via the race, this time with UseTraits
         derived.Configuration.TemplateFlags &= ~NpcConfiguration.TemplateFlag.Keywords;
-        derived.Configuration.TemplateFlags |= NpcConfiguration.TemplateFlag.Stats;
+        derived.Configuration.TemplateFlags |= NpcConfiguration.TemplateFlag.Traits;
         fixture.AssertSpeakersEqual(
             [ConditionFactory.Create(ConditionFactory.HasKeyword(raceKeyword), 1)],
             [raceBase]);

--- a/Mutagen.Bethesda.UnitTests/Plugins/Records/Skyrim/Assets/VoiceTypeAssetLookupTestSkyrim.cs
+++ b/Mutagen.Bethesda.UnitTests/Plugins/Records/Skyrim/Assets/VoiceTypeAssetLookupTestSkyrim.cs
@@ -124,6 +124,20 @@ public class VoiceTypeAssetLookupTestSkyrim
             data.VoiceTypeOrList.Link.SetTo(voice);
             return data;
         }
+
+        public static ConditionData GetIsRace(IRaceGetter race)
+        {
+            var data = new GetIsRaceConditionData();
+            data.Race.Link.SetTo(race);
+            return data;
+        }
+
+        public static ConditionData HasKeyword(IKeywordGetter keyword)
+        {
+            var data = new HasKeywordConditionData();
+            data.Keyword.Link.SetTo(keyword);
+            return data;
+        }
     }
 
     [Theory, MutagenModAutoData]
@@ -150,6 +164,7 @@ public class VoiceTypeAssetLookupTestSkyrim
             [ConditionFactory.Create(ConditionFactory.GetIsVoice(npc1.Voice), 1)],
             [npc1]);
 
+        // A form list can be used to check for any voice in a list
         list.Items.AddRange(npc1.Voice, npc2.Voice);
         fixture.AssertSpeakersEqual(
             [ConditionFactory.Create(ConditionFactory.GetIsVoice(list.ToLink()), 1)],
@@ -159,6 +174,36 @@ public class VoiceTypeAssetLookupTestSkyrim
         fixture.AssertSpeakersEqual(
             [ConditionFactory.Create(ConditionFactory.GetIsVoice(list.ToLink()), 1), ConditionFactory.Create(ConditionFactory.GetIsVoice(npc2.Voice), 0)],
             [npc1]);
+    }
+
+    [Theory, MutagenModAutoData]
+    public void TestRaceDefaultVoice(
+        VoiceTypeAssetLookupTestFixture fixture,
+        Race race,
+        VoiceType maleVoice,
+        string maleEdid,
+        VoiceType femaleVoice,
+        string femaleEdid)
+    {
+        var male = fixture.CreateSpeaker("male");
+        var female = fixture.CreateSpeaker("female");
+        female.Configuration.Flags |= NpcConfiguration.Flag.Female;
+
+        maleVoice.EditorID = maleEdid;
+        femaleVoice.EditorID = femaleEdid;
+        race.Voices = new GenderedItem<IFormLinkGetter<IVoiceTypeGetter>>(maleVoice.ToLink(), femaleVoice.ToLink());
+
+        // Race voices should only be used as a fallback
+        male.Voice.ShouldNotBeNull();
+        female.Voice.ShouldNotBeNull();
+        fixture.AssertSpeakersEqual([ConditionFactory.Create(ConditionFactory.GetIsVoice(maleVoice.ToLink()), 1)], []);
+        fixture.AssertSpeakersEqual([ConditionFactory.Create(ConditionFactory.GetIsVoice(femaleVoice.ToLink()), 1)], []);
+
+        // If no explicit voice is provided, fall back to the race's default for the NPCs gender
+        male.Voice.SetToNull();
+        female.Voice.SetToNull();
+        fixture.AssertSpeakersEqual([ConditionFactory.Create(ConditionFactory.GetIsVoice(maleVoice.ToLink()), 1)], [male]);
+        fixture.AssertSpeakersEqual([ConditionFactory.Create(ConditionFactory.GetIsVoice(femaleVoice.ToLink()), 1)], [female]);
     }
 
     [Theory, MutagenModAutoData]
@@ -186,9 +231,54 @@ public class VoiceTypeAssetLookupTestSkyrim
     }
 
     [Theory, MutagenModAutoData]
-    public void TestGetIsRace(VoiceTypeAssetLookupTestFixture fixture)
+    public void TestHasKeyword(
+        VoiceTypeAssetLookupTestFixture fixture,
+        Keyword actorKeyword,
+        Keyword raceKeyword,
+        Keyword questKeyword,
+        Race race,
+        Quest quest)
     {
-        false.ShouldBe(true); // TODO
+        var actorKey = fixture.CreateSpeaker("actorKey");
+        actorKey.Keywords = [actorKeyword.ToLink()];
+        
+        var raceKey = fixture.CreateSpeaker("raceKey");
+        race.Keywords = [raceKeyword.ToLink()];
+
+        var questKey = fixture.CreateSpeaker("questKey");
+        quest.Aliases.Add(new()
+        {
+            UniqueActor = questKey.ToNullableLink(),
+            Keywords = [questKeyword.ToLink()],
+        });
+
+        fixture.AssertSpeakersEqual(
+            [ConditionFactory.Create(ConditionFactory.HasKeyword(actorKeyword), 1)],
+            [actorKey]);
+
+        fixture.AssertSpeakersEqual(
+            [ConditionFactory.Create(ConditionFactory.HasKeyword(raceKeyword), 1)],
+            [raceKey]);
+
+        fixture.AssertSpeakersEqual(
+            [ConditionFactory.Create(ConditionFactory.HasKeyword(questKeyword), 1)],
+            [questKey]);
+    }
+
+    [Theory, MutagenModAutoData]
+    public void TestGetIsRace(
+        VoiceTypeAssetLookupTestFixture fixture,
+        Race race1,
+        Race race2)
+    {
+        var npc1 = fixture.CreateSpeaker("npc1");
+        npc1.Race.SetTo(race1);
+        var npc2 = fixture.CreateSpeaker("npc2");
+        npc2.Race.SetTo(race2);
+
+        fixture.AssertSpeakersEqual(
+            [ConditionFactory.Create(ConditionFactory.GetIsRace(race1), 1)],
+            [npc1]);
     }
 
     [Theory, MutagenModAutoData]
@@ -308,21 +398,56 @@ public class VoiceTypeAssetLookupTestSkyrim
 
     [Theory, MutagenModAutoData]
     public void TestInheritedTraits(
-        VoiceTypeAssetLookupTestFixture fixture)
+        VoiceTypeAssetLookupTestFixture fixture,
+        LeveledNpc leveledNpc,
+        Race race1,
+        Race race2,
+        Race dummyRace)
     {
+        var base1 = fixture.CreateSpeaker("base1");
+        base1.Race.SetTo(race1);
+        base1.Configuration.Flags &= ~NpcConfiguration.Flag.Female;
+        var base2 = fixture.CreateSpeaker("base2");
+        base2.Race.SetTo(race2);
+        base2.Configuration.Flags |= NpcConfiguration.Flag.Female;
+        leveledNpc.Entries =
+        [
+            new() {Data = new() {Reference = base1.ToLink() } },
+            new() {Data = new() {Reference = base2.ToLink() } },
+        ];
+
+        var derived = fixture.CreateSpeaker("derived");
+        derived.Template.SetTo(leveledNpc);
+
+        fixture.AssertSpeakersEqual(
+            [ConditionFactory.Create(ConditionFactory.GetIsVoice(base1.Voice), 1)],
+            [base1, derived]);
+
+        // Derived data should be disregarded if a template is used
+
+        // TODO: Race
+        // TODO: Voice
+        // TODO: Gender
+
         false.ShouldBe(true); // TODO
     }
 
     [Theory, MutagenModAutoData]
     public void TestInheritedStats(VoiceTypeAssetLookupTestFixture fixture)
     {
-        false.ShouldBe(true); // TODO
+        false.ShouldBe(true); // TODO: Class
     }
 
     [Theory, MutagenModAutoData]
     public void TestInheritedFactions(VoiceTypeAssetLookupTestFixture fixture)
     {
-        false.ShouldBe(true); // TODO
+        false.ShouldBe(true); // TODO: Factions                                                                             
+    }
+
+    [Theory, MutagenModAutoData]
+    public void TestInheritedKeywords(VoiceTypeAssetLookupTestFixture fixture)
+    {
+        false.ShouldBeTrue();
     }
 
     [Theory, MutagenModAutoData]

--- a/Mutagen.Bethesda.UnitTests/Plugins/Records/Skyrim/Assets/VoiceTypeAssetLookupTestSkyrim.cs
+++ b/Mutagen.Bethesda.UnitTests/Plugins/Records/Skyrim/Assets/VoiceTypeAssetLookupTestSkyrim.cs
@@ -1,16 +1,160 @@
-﻿using Mutagen.Bethesda.Plugins;
+using AutoFixture;
+using Mutagen.Bethesda.Plugins;
 using Mutagen.Bethesda.Plugins.Assets;
 using Mutagen.Bethesda.Plugins.Cache;
 using Mutagen.Bethesda.Skyrim;
 using Mutagen.Bethesda.Skyrim.Records.Assets.VoiceType;
 using Mutagen.Bethesda.Testing;
 using Mutagen.Bethesda.Testing.AutoData;
-using Xunit;
+using Shouldly;
 
 namespace Mutagen.Bethesda.UnitTests.Plugins.Records.Skyrim.Assets;
 
+public class VoiceTypeAssetLookupTestFixture
+{
+    private readonly IFixture _fixture;
+    public readonly ILinkCache LinkCache;
+    public readonly SkyrimMod Mod;
+    public readonly Quest Quest;
+    public readonly DialogTopic Topic;
+
+    public VoiceTypeAssetLookupTestFixture(
+        IFixture fixture,
+        SkyrimMod mod,
+        DialogTopic topic,
+        Quest quest)
+    {
+        _fixture = fixture;
+        LinkCache = mod.ToMutableLinkCache();
+        Mod = mod;
+        Quest = quest;
+        Topic = topic;
+        topic.Quest.SetTo(quest);
+    }
+
+    /// <summary>
+    /// Create and configure an NPC with a unique voice type
+    /// </summary>
+    public Npc CreateSpeaker(string name)
+    {
+        var npc = _fixture.Create<Npc>();
+        var voice = _fixture.Create<VoiceType>();
+        // Name is included here to provide additional context in errors
+        npc.EditorID = name;
+        voice.EditorID = name;
+        npc.Voice.SetTo(voice);
+        return npc;
+    }
+
+    public void AssertSceneSpeakersEqual(uint aliasId, IEnumerable<Condition> conditions, IEnumerable<Npc> expectedSpeakers)
+    {
+        var scene = _fixture.Create<Scene>();
+        scene.Actors.Add(new() { ID = aliasId });
+        scene.Actions.Add(new() { ActorID = (int)aliasId, Topic = Topic.ToNullableLink() });
+
+        var response = _fixture.Create<DialogResponses>();
+        Topic.Responses.Add(response);
+        response.Conditions.AddRange(conditions);
+
+        AssertSpeakersEqualImpl(response, expectedSpeakers);
+    }
+
+    public void AssertSpeakersEqual(IEnumerable<Condition> conditions, IEnumerable<Npc> expectedSpeakers)
+    {
+        var response = _fixture.Create<DialogResponses>();
+        Topic.Responses.Add(response);
+        response.Conditions.AddRange(conditions);
+
+        AssertSpeakersEqualImpl(response, expectedSpeakers);
+    }
+
+    void AssertSpeakersEqualImpl(DialogResponses response, IEnumerable<Npc> expectedSpeakers)
+    {
+        var assetCache = LinkCache.CreateImmutableAssetLinkCache();
+        var lookup = new VoiceTypeAssetLookup();
+        lookup.Prep(assetCache);
+
+        // We compare against a resolved list to provide more context in errors
+        var actual = lookup.GetSpeakers(response).Select(s => s.Resolve(LinkCache));
+        actual.ShouldBe(expectedSpeakers, ignoreOrder: true);
+    }
+}
+
 public class VoiceTypeAssetLookupTestSkyrim
 {
+    public static class ConditionFactory
+    {
+        public static ConditionFloat Create(ConditionData data, float compareValue, Condition.Flag flags = 0)
+        {
+            return new ConditionFloat
+            {
+                Data = data,
+                ComparisonValue = compareValue,
+                Flags = flags
+            };
+        }
+
+        public static ConditionData GetIsId(IReferenceableObjectGetter target)
+        {
+            var data = new GetIsIDConditionData();
+            data.Object.Link.SetTo(target);
+            return data;
+        }
+
+        public static ConditionData GetIsVoice(IFormLinkGetter<IVoiceTypeOrListGetter> voice)
+        {
+            var data = new GetIsVoiceTypeConditionData();
+            data.VoiceTypeOrList.Link.SetTo(voice);
+            return data;
+        }
+    }
+
+    [Theory, MutagenModAutoData]
+    public void TestGetIsId(VoiceTypeAssetLookupTestFixture fixture)
+    {
+        var npc1 = fixture.CreateSpeaker("npc1");
+        var npc2 = fixture.CreateSpeaker("npc2");
+
+        fixture.AssertSpeakersEqual(
+            [ConditionFactory.Create(ConditionFactory.GetIsId(npc1), 1)],
+            [npc1]);
+        fixture.AssertSpeakersEqual(
+            [ConditionFactory.Create(ConditionFactory.GetIsId(npc1), 0)],
+            [npc2]);
+    }
+
+    [Theory, MutagenModAutoData]
+    public void TestSceneSpeaker(VoiceTypeAssetLookupTestFixture fixture, uint aliasId)
+    {
+        var npc1 = fixture.CreateSpeaker("npc1");
+        var npc2 = fixture.CreateSpeaker("npc2");
+        fixture.Quest.Aliases.Add(new() { ID = aliasId, UniqueActor = npc1.ToNullableLink() });
+
+        fixture.AssertSceneSpeakersEqual(aliasId, [], [npc1]);
+        fixture.AssertSceneSpeakersEqual(aliasId, [ConditionFactory.Create(ConditionFactory.GetIsId(npc2), 1)], [npc1]);
+    }
+
+    [Theory, MutagenModAutoData]
+    public void TestGetIsVoice(VoiceTypeAssetLookupTestFixture fixture, FormList list)
+    {
+        var npc1 = fixture.CreateSpeaker("npc1");
+        var npc2 = fixture.CreateSpeaker("npc2");
+
+        fixture.AssertSpeakersEqual(
+            [ConditionFactory.Create(ConditionFactory.GetIsVoice(npc1.Voice), 1)],
+            [npc1]);
+
+        list.Items.AddRange(npc1.Voice, npc2.Voice);
+        fixture.AssertSpeakersEqual(
+            [ConditionFactory.Create(ConditionFactory.GetIsVoice(list.ToLink()), 1)],
+            [npc1, npc2]);
+
+        // (Voice1 || Voice2) && !Voice1
+        fixture.AssertSpeakersEqual(
+            [ConditionFactory.Create(ConditionFactory.GetIsVoice(list.ToLink()), 1), ConditionFactory.Create(ConditionFactory.GetIsVoice(npc2.Voice), 0)],
+            [npc1]);
+    }
+
     private readonly ILinkCache _linkCache;
     private readonly VoiceTypeAssetLookup _searcher = new();
 

--- a/Mutagen.Bethesda.UnitTests/Plugins/Records/Skyrim/Assets/VoiceTypeAssetLookupTestSkyrim.cs
+++ b/Mutagen.Bethesda.UnitTests/Plugins/Records/Skyrim/Assets/VoiceTypeAssetLookupTestSkyrim.cs
@@ -138,6 +138,13 @@ public class VoiceTypeAssetLookupTestSkyrim
             data.Keyword.Link.SetTo(keyword);
             return data;
         }
+
+        public static ConditionData GetIsClass(IClassGetter npcClass)
+        {
+            var data = new GetIsClassConditionData();
+            data.Class.Link.SetTo(npcClass);
+            return data;
+        }
     }
 
     [Theory, MutagenModAutoData]
@@ -207,7 +214,15 @@ public class VoiceTypeAssetLookupTestSkyrim
     }
 
     [Theory, MutagenModAutoData]
-    public void TestGetIsAliasRef(VoiceTypeAssetLookupTestFixture fixture)
+    public void TestGetIsAliasRef(
+        VoiceTypeAssetLookupTestFixture fixture,
+        Quest quest,
+        Quest externalQuest,
+        FormList additionalVoices,
+        Cell cell,
+        PlacedNpc placedNpc,
+        Location location,
+        LocationReferenceType refType)
     {
         false.ShouldBe(true); // TODO. Include each way alias can be filled
     }
@@ -225,9 +240,17 @@ public class VoiceTypeAssetLookupTestSkyrim
     }
 
     [Theory, MutagenModAutoData]
-    public void TestGetIsClass(VoiceTypeAssetLookupTestFixture fixture)
+    public void TestGetIsClass(
+        VoiceTypeAssetLookupTestFixture fixture,
+        Class npcClass)
     {
-        false.ShouldBe(true); // TODO
+        var npc1 = fixture.CreateSpeaker("npc1");
+        npc1.Class.SetTo(npcClass);
+        fixture.CreateSpeaker("dummy");
+
+        fixture.AssertSpeakersEqual(
+            [ConditionFactory.Create(ConditionFactory.GetIsClass(npcClass), 1)],
+            [npc1]);
     }
 
     [Theory, MutagenModAutoData]
@@ -346,6 +369,12 @@ public class VoiceTypeAssetLookupTestSkyrim
     }
 
     [Theory, MutagenModAutoData]
+    public void TestSpecificSpeaker(VoiceTypeAssetLookupTestFixture fixture)
+    {
+        false.ShouldBeTrue();
+    }
+
+    [Theory, MutagenModAutoData]
     public void TestCompareOperators(VoiceTypeAssetLookupTestFixture fixture)
     {
         var npc1 = fixture.CreateSpeaker("npc1");
@@ -417,19 +446,35 @@ public class VoiceTypeAssetLookupTestSkyrim
         ];
 
         var derived = fixture.CreateSpeaker("derived");
+        derived.Race.SetTo(dummyRace);
         derived.Template.SetTo(leveledNpc);
+        derived.Configuration.TemplateFlags |= NpcConfiguration.TemplateFlag.Traits;
 
         fixture.AssertSpeakersEqual(
             [ConditionFactory.Create(ConditionFactory.GetIsVoice(base1.Voice), 1)],
             [base1, derived]);
+        fixture.AssertSpeakersEqual(
+            [ConditionFactory.Create(ConditionFactory.GetIsRace(race2), 1)],
+            [base2, derived]);
+        fixture.AssertSpeakersEqual(
+            [ConditionFactory.Create(new GetIsSexConditionData() { MaleFemaleGender = MaleFemaleGender.Male }, 1)],
+            [base1, derived]);
 
         // Derived data should be disregarded if a template is used
+        derived.Race.SetTo(dummyRace);
+        fixture.AssertSpeakersEqual(
+            [ConditionFactory.Create(ConditionFactory.GetIsRace(dummyRace), 1)],
+            []);
+        derived.Voice.ShouldNotBeNull();
+        fixture.AssertSpeakersEqual(
+            [ConditionFactory.Create(ConditionFactory.GetIsVoice(derived.Voice), 1)],
+            []);
 
-        // TODO: Race
-        // TODO: Voice
-        // TODO: Gender
-
-        false.ShouldBe(true); // TODO
+        // Template flags should be ignored if template is null
+        derived.Template.SetToNull();
+        fixture.AssertSpeakersEqual(
+            [ConditionFactory.Create(ConditionFactory.GetIsRace(dummyRace), 1)],
+            [derived]);
     }
 
     [Theory, MutagenModAutoData]

--- a/Mutagen.Bethesda.UnitTests/Plugins/Records/Skyrim/Assets/VoiceTypeAssetLookupTestSkyrim.cs
+++ b/Mutagen.Bethesda.UnitTests/Plugins/Records/Skyrim/Assets/VoiceTypeAssetLookupTestSkyrim.cs
@@ -9,7 +9,6 @@ using Mutagen.Bethesda.Skyrim;
 using Mutagen.Bethesda.Skyrim.Records.Assets.VoiceType;
 using Mutagen.Bethesda.Testing;
 using Mutagen.Bethesda.Testing.AutoData;
-using Noggog.Testing.Extensions;
 using Shouldly;
 
 namespace Mutagen.Bethesda.UnitTests.Plugins.Records.Skyrim.Assets;
@@ -58,14 +57,20 @@ public class VoiceTypeAssetLookupTestFixture
         return npc;
     }
 
+    public DialogResponses CreateResponses()
+    {
+        var response = _fixture.Create<DialogResponses>();
+        Topic.Responses.Add(response);
+        return response;
+    }
+
     public void AssertSceneSpeakersEqual(uint aliasId, IEnumerable<Condition> conditions, IEnumerable<Npc> expectedSpeakers)
     {
         var scene = _fixture.Create<Scene>();
         scene.Actors.Add(new() { ID = aliasId });
         scene.Actions.Add(new() { ActorID = (int)aliasId, Topic = Topic.ToNullableLink() });
 
-        var response = _fixture.Create<DialogResponses>();
-        Topic.Responses.Add(response);
+        var response = CreateResponses();
         Topic.Category = DialogTopic.CategoryEnum.Scene;
         response.Conditions.AddRange(conditions);
 
@@ -74,8 +79,7 @@ public class VoiceTypeAssetLookupTestFixture
 
     public void AssertSpeakersEqual(IEnumerable<Condition> conditions, IEnumerable<Npc> expectedSpeakers)
     {
-        var response = _fixture.Create<DialogResponses>();
-        Topic.Responses.Add(response);
+        var response = CreateResponses();
         response.Conditions.AddRange(conditions);
 
         AssertSpeakersEqualImpl(response, expectedSpeakers);
@@ -373,7 +377,15 @@ public class VoiceTypeAssetLookupTestSkyrim
     [Theory, MutagenModAutoData]
     public void TestSpecificSpeaker(VoiceTypeAssetLookupTestFixture fixture)
     {
-        false.ShouldBeTrue();
+        var npc = fixture.CreateSpeaker("npc");
+        var speaker = fixture.CreateSpeaker("speaker");
+
+        var responses = fixture.CreateResponses();
+        responses.Conditions.Add(ConditionFactory.Create(ConditionFactory.GetIsId(npc), 1));
+        fixture.GetLookup().GetSpeakers(responses).ShouldBe([npc.ToLink()]);
+
+        responses.Speaker.SetTo(speaker);
+        fixture.GetLookup().GetSpeakers(responses).ShouldBe([speaker.ToLink()]);
     }
 
     [Theory, MutagenModAutoData]

--- a/Mutagen.Bethesda.UnitTests/Plugins/Records/Skyrim/Assets/VoiceTypeAssetLookupTestSkyrim.cs
+++ b/Mutagen.Bethesda.UnitTests/Plugins/Records/Skyrim/Assets/VoiceTypeAssetLookupTestSkyrim.cs
@@ -186,7 +186,11 @@ public class VoiceTypeAssetLookupTestSkyrim
         response.Responses.Add(new() { ResponseNumber = 1 });
         fixture.Topic.Responses.Add(response);
         response.Conditions.Add(ConditionFactory.Create(ConditionFactory.GetIsVoice(npc.Voice), 1));
-        fixture.Mod.ModKey.ShouldNotBe(fixture.Topic.FormKey.ModKey, "Voice paths depend on the ID of the response, and must be different for this test to cover that edge case");
+        response.FormKey.ModKey.ShouldNotBe(fixture.Topic.FormKey.ModKey, "Voice paths depend on the ID of the response, and must be different for this test to cover that edge case");
+        fixture.GetLookup().GetVoiceLineFilePaths(response).ShouldBe([new DataRelativePath("Sound/Voice/Skyrim.esm/MaleEvenToned/DialogueGe_DialogueGeneric_000142C2_1.fuz")]);
+
+        // Should also work for unfiltered response
+        response.Conditions.Clear();
         fixture.GetLookup().GetVoiceLineFilePaths(response).ShouldBe([new DataRelativePath("Sound/Voice/Skyrim.esm/MaleEvenToned/DialogueGe_DialogueGeneric_000142C2_1.fuz")]);
     }
 
@@ -386,6 +390,7 @@ public class VoiceTypeAssetLookupTestSkyrim
         Assert.Equal(
             new VoiceContainer(new HashSet<string>
             {
+                "CYRaaaPLACEHOLDERVoicetype",
                 "CYRMaleArgonian",
                 "CYRMaleArgonianAccented",
                 "CYRFemaleDeepToned",

--- a/Mutagen.Bethesda.UnitTests/Plugins/Records/Skyrim/Assets/VoiceTypeAssetLookupTestSkyrim.cs
+++ b/Mutagen.Bethesda.UnitTests/Plugins/Records/Skyrim/Assets/VoiceTypeAssetLookupTestSkyrim.cs
@@ -767,6 +767,28 @@ public class VoiceTypeAssetLookupTestSkyrim
         lookup.GetSpeakers(response).ShouldBeEmpty();
     }
 
+    [Theory, MutagenModAutoData]
+    public void EditorIdEqual(
+        VoiceTypeAssetLookupTestFixture fixture,
+        VoiceType voice1,
+        Npc npc1,
+        VoiceType voice2,
+        Npc npc2,
+        string edid)
+    {
+        voice1.EditorID = edid;
+        npc1.Voice.SetTo(voice1);
+        voice2.EditorID = edid;
+        npc2.Voice.SetTo(voice2);
+
+        // Voice types with the same editor ID should be considered as separate.
+        // Conditions care about form IDs, duplicated editor IDs are rare, but valid
+        // such as in patchless integration of follower mods
+        fixture.AssertSpeakersEqual(
+            [ConditionFactory.Create(ConditionFactory.GetIsVoice(voice1.ToLink()), 1)],
+            [npc1]);
+    }
+
     private readonly ILinkCache _linkCache;
     private readonly VoiceTypeAssetLookup _searcher = new();
 
@@ -827,15 +849,16 @@ public class VoiceTypeAssetLookupTestSkyrim
         var linkCache = mod.ToImmutableLinkCache();
         var sut = new VoiceTypeAssetLookup();
         sut.Prep(linkCache.CreateImmutableAssetLinkCache());
-        
+
         Assert.Equal(
-            new VoiceContainer(new HashSet<string>
-            {
-                edid1,
-                edid2
-            }),
+            new VoiceContainer([voiceType.FormKey, voiceType2.FormKey]),
             sut.GetVoicesWithQuest(topic, dialogResponses)
         );
+    }
+
+    VoiceContainer CreateVoiceIdContainer(IEnumerable<string> editorIds)
+    {
+        return new VoiceContainer(editorIds.Select(e => _linkCache.Resolve<IVoiceTypeGetter>(e).FormKey));
     }
 
     [Fact]
@@ -845,10 +868,7 @@ public class VoiceTypeAssetLookupTestSkyrim
         Assert.True(_linkCache.TryResolve<IDialogTopicGetter>(FormKey.Factory("155352:VoiceTypeTestPlugin.esm"), out var topic), "Topic not resolved");
 
         Assert.Equal(
-            new VoiceContainer(new HashSet<string>
-            {
-                "CYRaaaPLACEHOLDERVoicetype"
-            }),
+            CreateVoiceIdContainer(["CYRaaaPLACEHOLDERVoicetype"]),
             _searcher.GetVoicesWithQuest(topic!, responses!)
         );
     }
@@ -860,16 +880,13 @@ public class VoiceTypeAssetLookupTestSkyrim
         Assert.True(_linkCache.TryResolve<IDialogTopicGetter>(FormKey.Factory("0CE39F:VoiceTypeTestPlugin.esm"), out var topic), "Topic not resolved");
 
         Assert.Equal(
-            new VoiceContainer(new HashSet<string>
-            {
-                "CYRMaleEvenToned",
+            CreateVoiceIdContainer(["CYRMaleEvenToned",
                 "CYRMaleStandard",
                 "CYRMaleHonorable",
                 "CYRFemaleRich",
                 "CYRFemaleSultry",
                 "CYRFemaleEnergetic",
-                "CYRaaaPLACEHOLDERVoicetype"
-            }),
+                "CYRaaaPLACEHOLDERVoicetype"]),
             _searcher.GetVoicesWithQuest(topic!, responses!)
         );
     }
@@ -881,9 +898,7 @@ public class VoiceTypeAssetLookupTestSkyrim
         Assert.True(_linkCache.TryResolve<IDialogTopicGetter>(FormKey.Factory("0724D7:VoiceTypeTestPlugin.esm"), out var topic), "Topic not resolved");
 
         Assert.Equal(
-            new VoiceContainer(new HashSet<string>
-            {
-                "CYRMaleArgonian",
+            CreateVoiceIdContainer(["CYRMaleArgonian",
                 "CYRMaleArgonianAccented",
                 "CYRFemaleDeepToned",
                 "CYRFemaleKhajiit",
@@ -904,8 +919,7 @@ public class VoiceTypeAssetLookupTestSkyrim
                 "CYRMaleKhajiitMercurial",
                 "CYRFemaleEnergetic",
                 "CYRMaleEnglishRich",
-                "CYRMaleOrcAlexC"
-            }),
+                "CYRMaleOrcAlexC"]),
             _searcher.GetVoicesWithQuest(topic!, responses!)
         );
     }
@@ -917,10 +931,7 @@ public class VoiceTypeAssetLookupTestSkyrim
         Assert.True(_linkCache.TryResolve<IDialogTopicGetter>(FormKey.Factory("0AF395:VoiceTypeTestPlugin.esm"), out var topic), "Topic not resolved");
 
         Assert.Equal(
-            new VoiceContainer(new HashSet<string>
-            {
-                "CYRMaleSemiUniqueTES4MaleImperialVoiceMatch"
-            }),
+            CreateVoiceIdContainer(["CYRMaleSemiUniqueTES4MaleImperialVoiceMatch"]),
             _searcher.GetVoicesWithQuest(topic!, responses!)
         );
     }
@@ -932,12 +943,10 @@ public class VoiceTypeAssetLookupTestSkyrim
         Assert.True(_linkCache.TryResolve<IDialogTopicGetter>(FormKey.Factory("07EFDC:VoiceTypeTestPlugin.esm"), out var topic), "Topic not resolved");
 
         Assert.Equal(
-            new VoiceContainer(new HashSet<string>
-            {
-                "CYRFemaleEnergetic",
+            CreateVoiceIdContainer(["CYRFemaleEnergetic",
                 "CYRMaleHonorable",
                 "CYRMaleStandard"
-            }),
+            ]),
             _searcher.GetVoicesWithQuest(topic!, responses!)
         );
     }
@@ -949,7 +958,7 @@ public class VoiceTypeAssetLookupTestSkyrim
         Assert.True(_linkCache.TryResolve<IDialogTopicGetter>(FormKey.Factory("16EAE2:VoiceTypeTestPlugin.esm"), out var topic), "Topic not resolved");
 
         Assert.Equal(
-            new VoiceContainer(new HashSet<string>()),
+            new VoiceContainer(new HashSet<FormKey>()),
             _searcher.GetVoicesWithQuest(topic!, responses!)
         );
     }
@@ -961,8 +970,7 @@ public class VoiceTypeAssetLookupTestSkyrim
         Assert.True(_linkCache.TryResolve<IDialogTopicGetter>(FormKey.Factory("063B3F:VoiceTypeTestPlugin.esm"), out var topic), "Topic not resolved");
 
         Assert.Equal(
-            new VoiceContainer(new HashSet<string>
-            {
+            CreateVoiceIdContainer([
                 "CYRaaaPLACEHOLDERVoicetype",
                 "CYRMaleArgonian",
                 "CYRMaleArgonianAccented",
@@ -988,7 +996,7 @@ public class VoiceTypeAssetLookupTestSkyrim
                 "CYRFemaleEnergetic",
                 "CYRMaleEnglishRich",
                 "CYRMaleOrcAlexC"
-            }),
+            ]),
             _searcher.GetVoicesWithQuest(topic!, responses!)
         );
     }

--- a/Mutagen.Bethesda.UnitTests/Plugins/Records/Skyrim/Assets/VoiceTypeAssetLookupTestSkyrim.cs
+++ b/Mutagen.Bethesda.UnitTests/Plugins/Records/Skyrim/Assets/VoiceTypeAssetLookupTestSkyrim.cs
@@ -4,6 +4,7 @@ using Mutagen.Bethesda.Plugins;
 using Mutagen.Bethesda.Plugins.Assets;
 using Mutagen.Bethesda.Plugins.Cache;
 using Mutagen.Bethesda.Plugins.Order;
+using Mutagen.Bethesda.Plugins.Records;
 using Mutagen.Bethesda.Skyrim;
 using Mutagen.Bethesda.Skyrim.Records.Assets.VoiceType;
 using Mutagen.Bethesda.Testing;
@@ -92,13 +93,14 @@ public class VoiceTypeAssetLookupTestSkyrim
 {
     public static class ConditionFactory
     {
-        public static ConditionFloat Create(ConditionData data, float compareValue, Condition.Flag flags = 0)
+        // TODO: Test for combining with OR and AND
+        public static ConditionFloat Create(ConditionData data, float compareValue, CompareOperator op = CompareOperator.EqualTo)
         {
             return new ConditionFloat
             {
                 Data = data,
                 ComparisonValue = compareValue,
-                Flags = flags
+                CompareOperator = op,
             };
         }
 
@@ -125,10 +127,209 @@ public class VoiceTypeAssetLookupTestSkyrim
     }
 
     [Theory, MutagenModAutoData]
+    public void TestGetIsId(VoiceTypeAssetLookupTestFixture fixture)
+    {
+        var npc1 = fixture.CreateSpeaker("npc1");
+        var npc2 = fixture.CreateSpeaker("npc2");
+
+        fixture.AssertSpeakersEqual(
+            [ConditionFactory.Create(ConditionFactory.GetIsId(npc1), 1)],
+            [npc1]);
+        fixture.AssertSpeakersEqual(
+            [ConditionFactory.Create(ConditionFactory.GetIsId(npc1), 0)],
+            [npc2]);
+    }
+
+    [Theory, MutagenModAutoData]
+    public void TestGetIsVoice(VoiceTypeAssetLookupTestFixture fixture, FormList list)
+    {
+        var npc1 = fixture.CreateSpeaker("npc1");
+        var npc2 = fixture.CreateSpeaker("npc2");
+
+        fixture.AssertSpeakersEqual(
+            [ConditionFactory.Create(ConditionFactory.GetIsVoice(npc1.Voice), 1)],
+            [npc1]);
+
+        list.Items.AddRange(npc1.Voice, npc2.Voice);
+        fixture.AssertSpeakersEqual(
+            [ConditionFactory.Create(ConditionFactory.GetIsVoice(list.ToLink()), 1)],
+            [npc1, npc2]);
+
+        // (Voice1 || Voice2) && !Voice1
+        fixture.AssertSpeakersEqual(
+            [ConditionFactory.Create(ConditionFactory.GetIsVoice(list.ToLink()), 1), ConditionFactory.Create(ConditionFactory.GetIsVoice(npc2.Voice), 0)],
+            [npc1]);
+    }
+
+    [Theory, MutagenModAutoData]
+    public void TestGetIsAliasRef(VoiceTypeAssetLookupTestFixture fixture)
+    {
+        false.ShouldBe(true); // TODO. Include each way alias can be filled
+    }
+
+    [Theory, MutagenModAutoData]
+    public void TestGetInFaction(VoiceTypeAssetLookupTestFixture fixture, Faction faction)
+    {
+        var member = fixture.CreateSpeaker("member");
+        member.Factions.Add(new() { Faction = faction.ToLink() });
+        var nonmember = fixture.CreateSpeaker("nonmember");
+
+        fixture.AssertSpeakersEqual(
+            [ConditionFactory.Create(ConditionFactory.GetInFaction(faction), 1)],
+            [member]);
+    }
+
+    [Theory, MutagenModAutoData]
+    public void TestGetIsClass(VoiceTypeAssetLookupTestFixture fixture)
+    {
+        false.ShouldBe(true); // TODO
+    }
+
+    [Theory, MutagenModAutoData]
+    public void TestGetIsRace(VoiceTypeAssetLookupTestFixture fixture)
+    {
+        false.ShouldBe(true); // TODO
+    }
+
+    [Theory, MutagenModAutoData]
+    public void TestGetIsSex(VoiceTypeAssetLookupTestFixture fixture)
+    {
+        var male = fixture.CreateSpeaker("male");
+        male.Configuration.Flags &= ~NpcConfiguration.Flag.Female;
+        var female = fixture.CreateSpeaker("female");
+        female.Configuration.Flags |= NpcConfiguration.Flag.Female;
+
+        fixture.AssertSpeakersEqual(
+            [ConditionFactory.Create(new GetIsSexConditionData() { MaleFemaleGender = MaleFemaleGender.Male }, 1)],
+            [male]);
+        fixture.AssertSpeakersEqual(
+            [ConditionFactory.Create(new GetIsSexConditionData() { MaleFemaleGender = MaleFemaleGender.Female }, 1)],
+            [female]);
+    }
+
+    [Theory, MutagenModAutoData]
+    public void TestIsInList(VoiceTypeAssetLookupTestFixture fixture)
+    {
+        false.ShouldBe(true); // TODO
+    }
+
+    [Theory, MutagenModAutoData]
+    public void TestIsChild(
+        VoiceTypeAssetLookupTestFixture fixture,
+        Race child,
+        Race adult)
+    {
+        child.Flags |= Race.Flag.Child;
+        var childNpc = fixture.CreateSpeaker("child");
+        childNpc.Race.SetTo(child);
+
+
+        adult.Flags &= ~Race.Flag.Child;
+        var adultNpc = fixture.CreateSpeaker("adult");
+        adultNpc.Race.SetTo(adult);
+
+        fixture.AssertSpeakersEqual([ConditionFactory.Create(new IsChildConditionData(), 1)], [childNpc]);
+        fixture.AssertSpeakersEqual([ConditionFactory.Create(new IsChildConditionData(), 0)], [adultNpc]);
+    }
+
+    [Theory, MutagenModAutoData]
+    public void TestUnfiltered(VoiceTypeAssetLookupTestFixture fixture)
+    {
+        var npc1 = fixture.CreateSpeaker("npc1");
+        var npc2 = fixture.CreateSpeaker("npc2");
+
+        // The AllowDefaultDialog flag is not used at runtime
+        npc1.Voice.Resolve<IVoiceType>(fixture.LinkCache).Flags &= ~VoiceType.Flag.AllowDefaultDialog;
+        npc2.Voice.Resolve<IVoiceType>(fixture.LinkCache).Flags &= ~VoiceType.Flag.AllowDefaultDialog;
+        fixture.AssertSpeakersEqual([], [npc1, npc2]);
+    }
+
+    [Theory, MutagenModAutoData]
+    public void TestSceneSpeaker(VoiceTypeAssetLookupTestFixture fixture, uint aliasId)
+    {
+        var npc1 = fixture.CreateSpeaker("npc1");
+        var npc2 = fixture.CreateSpeaker("npc2");
+        fixture.Quest.Aliases.Add(new() { ID = aliasId, UniqueActor = npc1.ToNullableLink() });
+
+        fixture.AssertSceneSpeakersEqual(aliasId, [], [npc1]);
+        fixture.AssertSceneSpeakersEqual(aliasId, [ConditionFactory.Create(ConditionFactory.GetIsId(npc2), 1)], []);
+    }
+
+    [Theory, MutagenModAutoData]
+    public void TestCompareOperators(VoiceTypeAssetLookupTestFixture fixture)
+    {
+        var npc1 = fixture.CreateSpeaker("npc1");
+        var npc2 = fixture.CreateSpeaker("npc2");
+
+        var data = ConditionFactory.GetIsId(npc1);
+        fixture.AssertSpeakersEqual(
+            [ConditionFactory.Create(data, 1, CompareOperator.EqualTo)],
+            [npc1]);
+
+        fixture.AssertSpeakersEqual(
+            [ConditionFactory.Create(data, 1, CompareOperator.NotEqualTo)],
+            [npc2]);
+
+        // Runtime does not use an epsilon when comparing floats
+        fixture.AssertSpeakersEqual(
+            [ConditionFactory.Create(data, 1.001f, CompareOperator.EqualTo)],
+            []);
+
+        // TODO: Should we handle edge cases of comparing a bool with something other than 0 or 1 and == or !=
+        // or leave it as undefined behavior?
+        // Either way, should have an analyser to check this
+
+        false.ShouldBeTrue(); // TODO: Test for globals
+    }
+
+    [Theory, MutagenModAutoData]
+    public void TestGetPaths(VoiceTypeAssetLookupTestFixture fixture, FormKey sharedInfo)
+    {
+        // Smoke test based on response in DialogueGeneric
+        fixture.Quest.EditorID = "DialogueGeneric";
+        fixture.Topic.EditorID = "DialogueGenericHello";
+        var npc = fixture.CreateSpeaker("MaleEvenToned");
+
+        var response = new DialogResponses(FormKey.Factory("0142C2:Skyrim.esm"), SkyrimRelease.SkyrimSE);
+        response.Responses.Add(new() { ResponseNumber = 1 });
+        fixture.Topic.Responses.Add(response);
+        response.Conditions.Add(ConditionFactory.Create(ConditionFactory.GetIsVoice(npc.Voice), 1));
+        response.FormKey.ModKey.ShouldNotBe(fixture.Topic.FormKey.ModKey, "Voice paths depend on the ID of the response, and must be different for this test to cover that edge case");
+        fixture.GetLookup().GetVoiceLineFilePaths(response).ShouldBe([new DataRelativePath("Sound/Voice/Skyrim.esm/MaleEvenToned/DialogueGe_DialogueGeneric_000142C2_1.fuz")]);
+
+        // Should also work for unfiltered response
+        response.Conditions.Clear();
+        fixture.GetLookup().GetVoiceLineFilePaths(response).ShouldBe([new DataRelativePath("Sound/Voice/Skyrim.esm/MaleEvenToned/DialogueGe_DialogueGeneric_000142C2_1.fuz")]);
+
+        // A shared info should have no associated paths
+        response.ResponseData.SetTo(sharedInfo);
+        fixture.GetLookup().GetVoiceLineFilePaths(response).ShouldBeEmpty();
+    }
+
+    [Theory, MutagenModAutoData]
+    public void TestInheritedTraits(
+        VoiceTypeAssetLookupTestFixture fixture)
+    {
+        false.ShouldBe(true); // TODO
+    }
+
+    [Theory, MutagenModAutoData]
+    public void TestInheritedStats(VoiceTypeAssetLookupTestFixture fixture)
+    {
+        false.ShouldBe(true); // TODO
+    }
+
+    [Theory, MutagenModAutoData]
+    public void TestInheritedFactions(VoiceTypeAssetLookupTestFixture fixture)
+    {
+        false.ShouldBe(true); // TODO
+    }
+
+    [Theory, MutagenModAutoData]
     public void TestWinningOverride(
-        SkyrimMod mod1,
-        SkyrimMod mod2,
-        string edid)
+    SkyrimMod mod1,
+    SkyrimMod mod2,
+    string edid)
     {
         var quest = mod1.Quests.AddNew();
         var topic = mod1.DialogTopics.AddNew();
@@ -160,88 +361,6 @@ public class VoiceTypeAssetLookupTestSkyrim
         lookup = new();
         lookup.Prep(loadOrder.ToImmutableLinkCache().CreateImmutableAssetLinkCache());
         lookup.GetSpeakers(response).ShouldBeEmpty();
-    }
-
-    [Theory, MutagenModAutoData]
-    public void TestGetIsId(VoiceTypeAssetLookupTestFixture fixture)
-    {
-        var npc1 = fixture.CreateSpeaker("npc1");
-        var npc2 = fixture.CreateSpeaker("npc2");
-
-        fixture.AssertSpeakersEqual(
-            [ConditionFactory.Create(ConditionFactory.GetIsId(npc1), 1)],
-            [npc1]);
-        fixture.AssertSpeakersEqual(
-            [ConditionFactory.Create(ConditionFactory.GetIsId(npc1), 0)],
-            [npc2]);
-    }
-
-    [Theory, MutagenModAutoData]
-    public void TestSceneSpeaker(VoiceTypeAssetLookupTestFixture fixture, uint aliasId)
-    {
-        var npc1 = fixture.CreateSpeaker("npc1");
-        var npc2 = fixture.CreateSpeaker("npc2");
-        fixture.Quest.Aliases.Add(new() { ID = aliasId, UniqueActor = npc1.ToNullableLink() });
-
-        fixture.AssertSceneSpeakersEqual(aliasId, [], [npc1]);
-        fixture.AssertSceneSpeakersEqual(aliasId, [ConditionFactory.Create(ConditionFactory.GetIsId(npc2), 1)], []);
-    }
-
-    [Theory, MutagenModAutoData]
-    public void TestGetIsVoice(VoiceTypeAssetLookupTestFixture fixture, FormList list)
-    {
-        var npc1 = fixture.CreateSpeaker("npc1");
-        var npc2 = fixture.CreateSpeaker("npc2");
-
-        fixture.AssertSpeakersEqual(
-            [ConditionFactory.Create(ConditionFactory.GetIsVoice(npc1.Voice), 1)],
-            [npc1]);
-
-        list.Items.AddRange(npc1.Voice, npc2.Voice);
-        fixture.AssertSpeakersEqual(
-            [ConditionFactory.Create(ConditionFactory.GetIsVoice(list.ToLink()), 1)],
-            [npc1, npc2]);
-
-        // (Voice1 || Voice2) && !Voice1
-        fixture.AssertSpeakersEqual(
-            [ConditionFactory.Create(ConditionFactory.GetIsVoice(list.ToLink()), 1), ConditionFactory.Create(ConditionFactory.GetIsVoice(npc2.Voice), 0)],
-            [npc1]);
-    }
-
-    [Theory, MutagenModAutoData]
-    public void TestUnfiltered(VoiceTypeAssetLookupTestFixture fixture)
-    {
-        var npc1 = fixture.CreateSpeaker("npc1");
-        var npc2 = fixture.CreateSpeaker("npc2");
-
-        // The AllowDefaultDialog flag is not used at runtime
-        npc1.Voice.Resolve<IVoiceType>(fixture.LinkCache).Flags &= ~VoiceType.Flag.AllowDefaultDialog;
-        npc2.Voice.Resolve<IVoiceType>(fixture.LinkCache).Flags &= ~VoiceType.Flag.AllowDefaultDialog;
-        fixture.AssertSpeakersEqual([], [npc1, npc2]);
-    }
-
-    [Theory, MutagenModAutoData]
-    public void TestGetPaths(VoiceTypeAssetLookupTestFixture fixture, FormKey sharedInfo)
-    {
-        // Smoke test based on response in DialogueGeneric
-        fixture.Quest.EditorID = "DialogueGeneric";
-        fixture.Topic.EditorID = "DialogueGenericHello";
-        var npc = fixture.CreateSpeaker("MaleEvenToned");
-
-        var response = new DialogResponses(FormKey.Factory("0142C2:Skyrim.esm"), SkyrimRelease.SkyrimSE);
-        response.Responses.Add(new() { ResponseNumber = 1 });
-        fixture.Topic.Responses.Add(response);
-        response.Conditions.Add(ConditionFactory.Create(ConditionFactory.GetIsVoice(npc.Voice), 1));
-        response.FormKey.ModKey.ShouldNotBe(fixture.Topic.FormKey.ModKey, "Voice paths depend on the ID of the response, and must be different for this test to cover that edge case");
-        fixture.GetLookup().GetVoiceLineFilePaths(response).ShouldBe([new DataRelativePath("Sound/Voice/Skyrim.esm/MaleEvenToned/DialogueGe_DialogueGeneric_000142C2_1.fuz")]);
-
-        // Should also work for unfiltered response
-        response.Conditions.Clear();
-        fixture.GetLookup().GetVoiceLineFilePaths(response).ShouldBe([new DataRelativePath("Sound/Voice/Skyrim.esm/MaleEvenToned/DialogueGe_DialogueGeneric_000142C2_1.fuz")]);
-
-        // A shared info should have no associated paths
-        response.ResponseData.SetTo(sharedInfo);
-        fixture.GetLookup().GetVoiceLineFilePaths(response).ShouldBeEmpty();
     }
 
     private readonly ILinkCache _linkCache;
@@ -331,7 +450,7 @@ public class VoiceTypeAssetLookupTestSkyrim
     }
 
     [Fact]
-    public void TestGetInFaction()
+    public void TestGetInFactionOLD()
     {
         Assert.True(_linkCache.TryResolve<IDialogResponsesGetter>(FormKey.Factory("0CE3BE:VoiceTypeTestPlugin.esm"), out var responses), "Response not resolved");
         Assert.True(_linkCache.TryResolve<IDialogTopicGetter>(FormKey.Factory("0CE39F:VoiceTypeTestPlugin.esm"), out var topic), "Topic not resolved");

--- a/Mutagen.Bethesda.UnitTests/Plugins/Records/Skyrim/Assets/VoiceTypeAssetLookupTestSkyrim.cs
+++ b/Mutagen.Bethesda.UnitTests/Plugins/Records/Skyrim/Assets/VoiceTypeAssetLookupTestSkyrim.cs
@@ -3,6 +3,7 @@ using Mutagen.Bethesda.Assets;
 using Mutagen.Bethesda.Plugins;
 using Mutagen.Bethesda.Plugins.Assets;
 using Mutagen.Bethesda.Plugins.Cache;
+using Mutagen.Bethesda.Plugins.Order;
 using Mutagen.Bethesda.Skyrim;
 using Mutagen.Bethesda.Skyrim.Records.Assets.VoiceType;
 using Mutagen.Bethesda.Testing;
@@ -108,12 +109,57 @@ public class VoiceTypeAssetLookupTestSkyrim
             return data;
         }
 
+        public static ConditionData GetInFaction(IFactionGetter faction)
+        {
+            var data = new GetInFactionConditionData();
+            data.Faction.Link.SetTo(faction);
+            return data;
+        }
+
         public static ConditionData GetIsVoice(IFormLinkGetter<IVoiceTypeOrListGetter> voice)
         {
             var data = new GetIsVoiceTypeConditionData();
             data.VoiceTypeOrList.Link.SetTo(voice);
             return data;
         }
+    }
+
+    [Theory, MutagenModAutoData]
+    public void TestWinningOverride(
+        SkyrimMod mod1,
+        SkyrimMod mod2,
+        string edid)
+    {
+        var quest = mod1.Quests.AddNew();
+        var topic = mod1.DialogTopics.AddNew();
+        topic.Quest.SetTo(quest);
+        var voice = mod1.VoiceTypes.AddNew();
+        voice.EditorID = edid;
+
+        var npc = mod1.Npcs.AddNew();
+        npc.Voice.SetTo(voice);
+        var faction = mod1.Factions.AddNew();
+        npc.Factions.Add(new() { Faction = faction.ToLink() });
+
+        var response = new DialogResponses(mod1);
+        topic.Responses.Add(response);
+        response.Conditions.Add(ConditionFactory.Create(ConditionFactory.GetInFaction(faction), 1));
+
+        using var loadOrder = new LoadOrder<ISkyrimModGetter> { mod1 };
+
+        // Baseline: Mod1 adds a topic conditioned to NPC1's voice
+        var lookup = new VoiceTypeAssetLookup();
+        lookup.Prep(loadOrder.ToImmutableLinkCache().CreateImmutableAssetLinkCache());
+        lookup.GetSpeakers(response).ShouldBe([npc.ToLink()]);
+
+        // User adds a second mod that removes the NPC from their faction
+        var npcOverride = mod2.Npcs.GetOrAddAsOverride(npc);
+        npcOverride.Factions.Clear();
+
+        loadOrder.Add(mod2);
+        lookup = new();
+        lookup.Prep(loadOrder.ToImmutableLinkCache().CreateImmutableAssetLinkCache());
+        lookup.GetSpeakers(response).ShouldBeEmpty();
     }
 
     [Theory, MutagenModAutoData]

--- a/Mutagen.Bethesda.UnitTests/Plugins/Records/Skyrim/Assets/VoiceTypeAssetLookupTestSkyrim.cs
+++ b/Mutagen.Bethesda.UnitTests/Plugins/Records/Skyrim/Assets/VoiceTypeAssetLookupTestSkyrim.cs
@@ -98,13 +98,14 @@ public class VoiceTypeAssetLookupTestSkyrim
     public static class ConditionFactory
     {
         // TODO: Test for combining with OR and AND
-        public static ConditionFloat Create(ConditionData data, float compareValue, CompareOperator op = CompareOperator.EqualTo)
+        public static ConditionFloat Create(ConditionData data, float compareValue, CompareOperator op = CompareOperator.EqualTo, bool or = false)
         {
             return new ConditionFloat
             {
                 Data = data,
                 ComparisonValue = compareValue,
                 CompareOperator = op,
+                Flags = or ? Condition.Flag.OR : 0,
             };
         }
 
@@ -147,6 +148,13 @@ public class VoiceTypeAssetLookupTestSkyrim
         {
             var data = new GetIsClassConditionData();
             data.Class.Link.SetTo(npcClass);
+            return data;
+        }
+
+        public static ConditionData IsInList(IFormListGetter list)
+        {
+            var data = new IsInListConditionData();
+            data.FormList.Link.SetTo(list);
             return data;
         }
     }
@@ -327,6 +335,29 @@ public class VoiceTypeAssetLookupTestSkyrim
     }
 
     [Theory, MutagenModAutoData]
+    public void TestMultipleConditions(
+        VoiceTypeAssetLookupTestFixture fixture,
+        FormList list)
+    {
+        var npc1 = fixture.CreateSpeaker("npc1");
+        var npc2 = fixture.CreateSpeaker("npc2");
+        var npc3 = fixture.CreateSpeaker("npc3");
+
+        // Multiple OR in a block is combined as a union
+        // npc1 || npc2
+        fixture.AssertSpeakersEqual(
+            [ConditionFactory.Create(ConditionFactory.GetIsId(npc1), 1, or: true), ConditionFactory.Create(ConditionFactory.GetIsId(npc2), 1)],
+            [npc1, npc2]);
+
+        // AND is combined as the intersection
+        // (npc1 || npc2 || npc3) && !npc3
+        list.Items.AddRange(npc1.Voice, npc2.Voice, npc3.Voice);
+        fixture.AssertSpeakersEqual(
+            [ConditionFactory.Create(ConditionFactory.GetIsVoice(list.ToLink()), 1, or: false), ConditionFactory.Create(ConditionFactory.GetIsVoice(npc3.Voice), 0, or: false)],
+            [npc1, npc2]);
+    }
+
+    [Theory, MutagenModAutoData]
     public void TestHasKeyword(
         VoiceTypeAssetLookupTestFixture fixture,
         Keyword actorKeyword,
@@ -394,9 +425,15 @@ public class VoiceTypeAssetLookupTestSkyrim
     }
 
     [Theory, MutagenModAutoData]
-    public void TestIsInList(VoiceTypeAssetLookupTestFixture fixture)
+    public void TestIsInList(VoiceTypeAssetLookupTestFixture fixture, FormList list)
     {
-        false.ShouldBe(true); // TODO
+        var npc1 = fixture.CreateSpeaker("npc1");
+        fixture.CreateSpeaker("dummy");
+
+        list.Items.Add(npc1.ToLink());
+        fixture.AssertSpeakersEqual(
+            [ConditionFactory.Create(ConditionFactory.IsInList(list), 1)],
+            [npc1]);
     }
 
     [Theory, MutagenModAutoData]

--- a/Mutagen.Bethesda.UnitTests/Plugins/Records/Skyrim/Assets/VoiceTypeAssetLookupTestSkyrim.cs
+++ b/Mutagen.Bethesda.UnitTests/Plugins/Records/Skyrim/Assets/VoiceTypeAssetLookupTestSkyrim.cs
@@ -193,7 +193,9 @@ public class VoiceTypeAssetLookupTestSkyrim
         string femaleEdid)
     {
         var male = fixture.CreateSpeaker("male");
+        male.Race.SetTo(race);
         var female = fixture.CreateSpeaker("female");
+        female.Race.SetTo(race);
         female.Configuration.Flags |= NpcConfiguration.Flag.Female;
 
         maleVoice.EditorID = maleEdid;

--- a/Mutagen.Bethesda.UnitTests/Plugins/Records/Skyrim/Assets/VoiceTypeAssetLookupTestSkyrim.cs
+++ b/Mutagen.Bethesda.UnitTests/Plugins/Records/Skyrim/Assets/VoiceTypeAssetLookupTestSkyrim.cs
@@ -222,7 +222,9 @@ public class VoiceTypeAssetLookupTestSkyrim
     [Theory, MutagenModAutoData]
     public void TestGetIsAliasRef(
         VoiceTypeAssetLookupTestFixture fixture,
-        Quest quest,
+        uint locAliasId,
+        uint externalAliasId,
+        uint aliasId,
         Quest externalQuest,
         FormList additionalVoices,
         Cell cell,
@@ -230,7 +232,72 @@ public class VoiceTypeAssetLookupTestSkyrim
         Location location,
         LocationReferenceType refType)
     {
-        false.ShouldBe(true); // TODO. Include each way alias can be filled
+        var npc1 = fixture.CreateSpeaker("npc");
+        var npc2 = fixture.CreateSpeaker("npc2");
+
+        void CheckAlias(QuestAlias alias, IEnumerable<Npc>? speakers = null)
+        {
+            alias.ID = aliasId;
+            fixture.Quest.Aliases.Add(alias);
+            fixture.AssertSpeakersEqual(
+                [ConditionFactory.Create(new GetIsAliasRefConditionData() { ReferenceAliasIndex = (int)aliasId }, 1)],
+                speakers ?? [npc1]);
+            fixture.Quest.Aliases.Clear();
+        }
+
+        CheckAlias(new() { UniqueActor = npc1.ToNullableLink() });
+
+        // Forced ref
+        cell.Flags |= Cell.Flag.IsInteriorCell;
+        fixture.Mod.Cells.AddInteriorCell(cell);
+        placedNpc.Base.SetTo(npc1);
+        cell.Persistent.Add(placedNpc);
+        CheckAlias(new() { ForcedReference = placedNpc.ToNullableLink() });
+
+        // Location alias ref
+        location.LocationRefTypeReferencesAdded = [new()
+        {
+            Ref = placedNpc.ToLink(),
+            LocationRefType = refType.ToLink(),
+        }];
+        fixture.Quest.Aliases.Add(new()
+        {
+            ID = locAliasId,
+            SpecificLocation = location.ToNullableLink(),
+        });
+        CheckAlias(new()
+        {
+            Location = new()
+            {
+                AliasID = (int)locAliasId,
+                RefType = refType.ToNullableLink()
+            }
+        });
+
+        // External alias
+        externalQuest.Aliases.Add(new() { UniqueActor = npc1.ToNullableLink(), ID = externalAliasId });
+        CheckAlias(new() { External = new() { AliasID = (int)externalAliasId, Quest = externalQuest.ToNullableLink() } });
+
+        // Matching ref from event doesn't provide enough context for filtering
+        CheckAlias(new() { FindMatchingRefFromEvent = new() }, [npc1, npc2]);
+        // Matching ref near alias event would require knowing every ref linked to every possible value of the other alias
+        CheckAlias(new() { FindMatchingRefNearAlias = new() }, [npc1, npc2]);
+
+        // If conditions are present, they are applied as an intersection before additional voices
+        CheckAlias(new()
+        {
+            FindMatchingRefFromEvent = new(),
+            Conditions = [ConditionFactory.Create(ConditionFactory.GetIsVoice(npc2.Voice), 1)]
+        }, [npc2]);
+
+        // Additional voices are applied as a union after additional voices
+        additionalVoices.Items.AddRange(npc1.ToLink(), npc2.ToLink());
+        CheckAlias(new()
+        {
+            FindMatchingRefFromEvent = new(),
+            VoiceTypes = additionalVoices.ToNullableLink(),
+            Conditions = [ConditionFactory.Create(ConditionFactory.GetIsVoice(npc2.Voice), 1)]
+        }, [npc1, npc2]);
     }
 
     [Theory, MutagenModAutoData]

--- a/Mutagen.Bethesda.UnitTests/Plugins/Records/Skyrim/Assets/VoiceTypeAssetLookupTestSkyrim.cs
+++ b/Mutagen.Bethesda.UnitTests/Plugins/Records/Skyrim/Assets/VoiceTypeAssetLookupTestSkyrim.cs
@@ -1,4 +1,5 @@
 using AutoFixture;
+using Mutagen.Bethesda.Assets;
 using Mutagen.Bethesda.Plugins;
 using Mutagen.Bethesda.Plugins.Assets;
 using Mutagen.Bethesda.Plugins.Cache;
@@ -6,6 +7,7 @@ using Mutagen.Bethesda.Skyrim;
 using Mutagen.Bethesda.Skyrim.Records.Assets.VoiceType;
 using Mutagen.Bethesda.Testing;
 using Mutagen.Bethesda.Testing.AutoData;
+using Noggog.Testing.Extensions;
 using Shouldly;
 
 namespace Mutagen.Bethesda.UnitTests.Plugins.Records.Skyrim.Assets;
@@ -17,6 +19,14 @@ public class VoiceTypeAssetLookupTestFixture
     public readonly SkyrimMod Mod;
     public readonly Quest Quest;
     public readonly DialogTopic Topic;
+
+    public VoiceTypeAssetLookup GetLookup()
+    {
+        var assetCache = LinkCache.CreateImmutableAssetLinkCache();
+        var lookup = new VoiceTypeAssetLookup();
+        lookup.Prep(assetCache);
+        return lookup;
+    }
 
     public VoiceTypeAssetLookupTestFixture(
         IFixture fixture,
@@ -54,6 +64,7 @@ public class VoiceTypeAssetLookupTestFixture
 
         var response = _fixture.Create<DialogResponses>();
         Topic.Responses.Add(response);
+        Topic.Category = DialogTopic.CategoryEnum.Scene;
         response.Conditions.AddRange(conditions);
 
         AssertSpeakersEqualImpl(response, expectedSpeakers);
@@ -70,12 +81,8 @@ public class VoiceTypeAssetLookupTestFixture
 
     void AssertSpeakersEqualImpl(DialogResponses response, IEnumerable<Npc> expectedSpeakers)
     {
-        var assetCache = LinkCache.CreateImmutableAssetLinkCache();
-        var lookup = new VoiceTypeAssetLookup();
-        lookup.Prep(assetCache);
-
         // We compare against a resolved list to provide more context in errors
-        var actual = lookup.GetSpeakers(response).Select(s => s.Resolve(LinkCache));
+        var actual = GetLookup().GetSpeakers(response).Select(s => s.Resolve(LinkCache));
         actual.ShouldBe(expectedSpeakers, ignoreOrder: true);
     }
 }
@@ -131,7 +138,7 @@ public class VoiceTypeAssetLookupTestSkyrim
         fixture.Quest.Aliases.Add(new() { ID = aliasId, UniqueActor = npc1.ToNullableLink() });
 
         fixture.AssertSceneSpeakersEqual(aliasId, [], [npc1]);
-        fixture.AssertSceneSpeakersEqual(aliasId, [ConditionFactory.Create(ConditionFactory.GetIsId(npc2), 1)], [npc1]);
+        fixture.AssertSceneSpeakersEqual(aliasId, [ConditionFactory.Create(ConditionFactory.GetIsId(npc2), 1)], []);
     }
 
     [Theory, MutagenModAutoData]
@@ -153,6 +160,34 @@ public class VoiceTypeAssetLookupTestSkyrim
         fixture.AssertSpeakersEqual(
             [ConditionFactory.Create(ConditionFactory.GetIsVoice(list.ToLink()), 1), ConditionFactory.Create(ConditionFactory.GetIsVoice(npc2.Voice), 0)],
             [npc1]);
+    }
+
+    [Theory, MutagenModAutoData]
+    public void TestUnfiltered(VoiceTypeAssetLookupTestFixture fixture)
+    {
+        var npc1 = fixture.CreateSpeaker("npc1");
+        var npc2 = fixture.CreateSpeaker("npc2");
+
+        // The AllowDefaultDialog flag is not used at runtime
+        npc1.Voice.Resolve<IVoiceType>(fixture.LinkCache).Flags &= ~VoiceType.Flag.AllowDefaultDialog;
+        npc2.Voice.Resolve<IVoiceType>(fixture.LinkCache).Flags &= ~VoiceType.Flag.AllowDefaultDialog;
+        fixture.AssertSpeakersEqual([], [npc1, npc2]);
+    }
+
+    [Theory, MutagenModAutoData]
+    public void TestGetPaths(VoiceTypeAssetLookupTestFixture fixture)
+    {
+        // Smoke test based on response in DialogueGeneric
+        fixture.Quest.EditorID = "DialogueGeneric";
+        fixture.Topic.EditorID = "DialogueGenericHello";
+        var npc = fixture.CreateSpeaker("MaleEvenToned");
+
+        var response = new DialogResponses(FormKey.Factory("0142C2:Skyrim.esm"), SkyrimRelease.SkyrimSE);
+        response.Responses.Add(new() { ResponseNumber = 1 });
+        fixture.Topic.Responses.Add(response);
+        response.Conditions.Add(ConditionFactory.Create(ConditionFactory.GetIsVoice(npc.Voice), 1));
+        fixture.Mod.ModKey.ShouldNotBe(fixture.Topic.FormKey.ModKey, "Voice paths depend on the ID of the response, and must be different for this test to cover that edge case");
+        fixture.GetLookup().GetVoiceLineFilePaths(response).ShouldBe([new DataRelativePath("Sound/Voice/Skyrim.esm/MaleEvenToned/DialogueGe_DialogueGeneric_000142C2_1.fuz")]);
     }
 
     private readonly ILinkCache _linkCache;


### PR DESCRIPTION
Intentional changes to match runtime behavior:
- Remove handling of `AllowDefaultDialog` flag, this is used by the CK as described on the wiki (https://ck.uesp.net/w/index.php?title=VoiceType&oldid=17877), but has no runtime effect
- Build lookups based on winning overrides only
- Remove epsilon handling when inverting conditions. No such system is used at runtime
- Support filtering on `HasKeyword` conditions
- Group voice types based on FormKey rather than editor ID
- Expose `GetVoices`

Issues resolved:
- Inverting a `GetIsVoiceType` condition would exclude all non default dialog voices, even if they were explicitly included by another condition.
- Voice file paths for responses defined in a different plugin to the topic would use the topics mod key rather than that of the response.

Supersedes #679, but does not include its optimizations to ease review.