### PR TITLE
Add value equality to GenderedItem<T>

### DIFF
--- a/Mutagen.Bethesda.Core.UnitTests/Plugins/Records/GenderedItemTests.cs
+++ b/Mutagen.Bethesda.Core.UnitTests/Plugins/Records/GenderedItemTests.cs
@@ -1,0 +1,70 @@
+using Mutagen.Bethesda.Plugins.Records;
+using Shouldly;
+using Xunit;
+
+namespace Mutagen.Bethesda.Core.UnitTests.Plugins.Records;
+
+public class GenderedItemTests
+{
+    private sealed record LoquiLike(int Value);
+
+    [Fact]
+    public void Equals_SameMembers_ReturnsTrue()
+    {
+        var g1 = new GenderedItem<byte>(1, 1);
+        var g2 = new GenderedItem<byte>(1, 1);
+        g1.Equals(g2).ShouldBeTrue();
+        g1.Equals((object)g2).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Equals_DifferentMale_ReturnsFalse()
+    {
+        var g1 = new GenderedItem<byte>(1, 1);
+        var g2 = new GenderedItem<byte>(2, 1);
+        g1.Equals(g2).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Equals_DifferentFemale_ReturnsFalse()
+    {
+        var g1 = new GenderedItem<byte>(1, 1);
+        var g2 = new GenderedItem<byte>(1, 2);
+        g1.Equals(g2).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void GetHashCode_SameMembers_ReturnsSameHash()
+    {
+        var g1 = new GenderedItem<byte>(1, 2);
+        var g2 = new GenderedItem<byte>(1, 2);
+        g1.GetHashCode().ShouldBe(g2.GetHashCode());
+    }
+
+    [Fact]
+    public void Equals_LoquiLikeMembers_UsesValueEquality()
+    {
+        var g1 = new GenderedItem<LoquiLike?>(new LoquiLike(1), new LoquiLike(2));
+        var g2 = new GenderedItem<LoquiLike?>(new LoquiLike(1), new LoquiLike(2));
+        var g3 = new GenderedItem<LoquiLike?>(new LoquiLike(1), new LoquiLike(3));
+
+        g1.Equals(g2).ShouldBeTrue();
+        g1.Equals(g3).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Equals_NullMembers_DoesNotThrow()
+    {
+        var g1 = new GenderedItem<LoquiLike?>(null, null);
+        var g2 = new GenderedItem<LoquiLike?>(null, null);
+        g1.Equals(g2).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Equals_Object_NullOrWrongType_ReturnsFalse()
+    {
+        var g1 = new GenderedItem<byte>(1, 1);
+        g1.Equals((object?)null).ShouldBeFalse();
+        g1.Equals("not a gendered item").ShouldBeFalse();
+    }
+}

--- a/Mutagen.Bethesda.Core/Plugins/Records/GenderedItem.cs
+++ b/Mutagen.Bethesda.Core/Plugins/Records/GenderedItem.cs
@@ -50,7 +50,7 @@ namespace Mutagen.Bethesda.Plugins.Records
     /// <summary>
     /// An object exposing data in a gendered format
     /// </summary>
-    public sealed class GenderedItem<T> : IGenderedItem<T>
+    public sealed class GenderedItem<T> : IGenderedItem<T>, IEquatable<GenderedItem<T>>
     {
         /// <summary>
         /// Male item
@@ -107,6 +107,21 @@ namespace Mutagen.Bethesda.Plugins.Records
         {
             GenderedItem.Print(this, sb, name);
         }
+
+        /// <inheritdoc />
+        public override bool Equals(object? obj) => Equals(obj as GenderedItem<T>);
+
+        /// <inheritdoc />
+        public bool Equals(GenderedItem<T>? other)
+        {
+            if (other is null) return false;
+            if (ReferenceEquals(this, other)) return true;
+            return EqualityComparer<T>.Default.Equals(Male, other.Male)
+                && EqualityComparer<T>.Default.Equals(Female, other.Female);
+        }
+
+        /// <inheritdoc />
+        public override int GetHashCode() => HashCode.Combine(Male, Female);
     }
 
     internal static class GenderedItem

--- a/Mutagen.Bethesda.UnitTests/Plugins/Records/Fallout4/ArmorAddonEqualityTests.cs
+++ b/Mutagen.Bethesda.UnitTests/Plugins/Records/Fallout4/ArmorAddonEqualityTests.cs
@@ -1,0 +1,47 @@
+using Mutagen.Bethesda.Fallout4;
+using Mutagen.Bethesda.Plugins;
+using Shouldly;
+using Xunit;
+
+namespace Mutagen.Bethesda.UnitTests.Plugins.Records.Fallout4;
+
+public class ArmorAddonEqualityTests
+{
+    private static ArmorAddon GetSomeArmorAddon()
+    {
+        return new ArmorAddon(FormKey.Null, Fallout4Release.Fallout4)
+        {
+            Priority = new Mutagen.Bethesda.Plugins.Records.GenderedItem<byte>(1, 2),
+            WeightSliderEnabled = new Mutagen.Bethesda.Plugins.Records.GenderedItem<bool>(true, false),
+            WorldModel = new Mutagen.Bethesda.Plugins.Records.GenderedItem<Model?>(
+                new Model { File = "male.nif" },
+                new Model { File = "female.nif" }),
+        };
+    }
+
+    [Fact]
+    public void DeepCopyEquals()
+    {
+        var armorAddon = GetSomeArmorAddon();
+        var other = armorAddon.DeepCopy();
+
+        armorAddon.Equals(other).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void DeepCopyEqualsMaskAgrees()
+    {
+        var armorAddon = GetSomeArmorAddon();
+        var other = armorAddon.DeepCopy();
+
+        var mask = armorAddon.GetEqualsMask(other);
+
+        mask.Priority.Male.ShouldBeTrue();
+        mask.Priority.Female.ShouldBeTrue();
+        mask.WeightSliderEnabled.Male.ShouldBeTrue();
+        mask.WeightSliderEnabled.Female.ShouldBeTrue();
+        mask.WorldModel!.Overall.ShouldBeTrue();
+
+        armorAddon.Equals(other).ShouldBeTrue();
+    }
+}


### PR DESCRIPTION
GenderedItem<T> previously relied on reference equality (inherited from object), so generated record Equals()/GetEqualsMask() comparisons that delegate to it (e.g. ArmorAddon.Priority) returned false/mismatched for two distinct instances holding identical Male/Female values — including armorAddon.Equals(armorAddon.DeepCopy()).

Implements IEquatable<GenderedItem<T>>: Equals(object), Equals(GenderedItem<T>), and GetHashCode(), comparing Male/Female via EqualityComparer<T>.Default so it works for both value types and loqui-object T.

Adds Core unit tests (GenderedItemTests) covering equal/unequal members, hash consistency, loqui-like T, null members, and Equals(object) null/wrong-type cases; adds a Fallout4 records-level test (ArmorAddonEqualityTests) verifying DeepCopy equality and GetEqualsMask agreement.

Fixes Mutagen-Modding/Mutagen#685