### PR TITLE
Fix Dict-field Equals to compare by key, matching GetEqualsMask (#686)

### DIFF
--- a/Mutagen.Bethesda.Fallout3/Records/Fallout3Group_Generated.cs
+++ b/Mutagen.Bethesda.Fallout3/Records/Fallout3Group_Generated.cs
@@ -1059,7 +1059,7 @@ namespace Mutagen.Bethesda.Fallout3
             }
             if ((equalsMask?.GetShouldTranslate((int)Fallout3Group_FieldIndex.RecordCache) ?? true))
             {
-                if (!lhs.RecordCache.SequenceEqualNullable(rhs.RecordCache)) return false;
+                if (!(EqualsMaskHelper.CacheEqualsHelper(lhs: lhs.RecordCache, rhs: rhs.RecordCache, maskGetter: (k, l, r) => l.GetEqualsMask(r, EqualsMaskHelper.Include.All), include: EqualsMaskHelper.Include.All)?.Overall ?? true)) return false;
             }
             return true;
         }

--- a/Mutagen.Bethesda.Fallout3/Records/Major Records/Class_Generated.cs
+++ b/Mutagen.Bethesda.Fallout3/Records/Major Records/Class_Generated.cs
@@ -1633,7 +1633,7 @@ namespace Mutagen.Bethesda.Fallout3
             }
             if ((equalsMask?.GetShouldTranslate((int)Class_FieldIndex.Attributes) ?? true))
             {
-                if (!lhs.Attributes.SequenceEqualNullable(rhs.Attributes)) return false;
+                if (!(EqualsMaskHelper.DictEqualsHelper(lhs: lhs.Attributes, rhs: rhs.Attributes, include: EqualsMaskHelper.Include.All)?.Overall ?? true)) return false;
             }
             return true;
         }

--- a/Mutagen.Bethesda.Fallout3/Records/Major Records/PlayerSkills_Generated.cs
+++ b/Mutagen.Bethesda.Fallout3/Records/Major Records/PlayerSkills_Generated.cs
@@ -1085,11 +1085,11 @@ namespace Mutagen.Bethesda.Fallout3
             if (!EqualsMaskHelper.RefEquality(lhs, rhs, out var isEqual)) return isEqual;
             if ((equalsMask?.GetShouldTranslate((int)PlayerSkills_FieldIndex.SkillValues) ?? true))
             {
-                if (!lhs.SkillValues.SequenceEqualNullable(rhs.SkillValues)) return false;
+                if (!(EqualsMaskHelper.DictEqualsHelper(lhs: lhs.SkillValues, rhs: rhs.SkillValues, include: EqualsMaskHelper.Include.All)?.Overall ?? true)) return false;
             }
             if ((equalsMask?.GetShouldTranslate((int)PlayerSkills_FieldIndex.SkillOffsets) ?? true))
             {
-                if (!lhs.SkillOffsets.SequenceEqualNullable(rhs.SkillOffsets)) return false;
+                if (!(EqualsMaskHelper.DictEqualsHelper(lhs: lhs.SkillOffsets, rhs: rhs.SkillOffsets, include: EqualsMaskHelper.Include.All)?.Overall ?? true)) return false;
             }
             return true;
         }

--- a/Mutagen.Bethesda.Fallout4/Records/Fallout4Group_Generated.cs
+++ b/Mutagen.Bethesda.Fallout4/Records/Fallout4Group_Generated.cs
@@ -1059,7 +1059,7 @@ namespace Mutagen.Bethesda.Fallout4
             }
             if ((equalsMask?.GetShouldTranslate((int)Fallout4Group_FieldIndex.RecordCache) ?? true))
             {
-                if (!lhs.RecordCache.SequenceEqualNullable(rhs.RecordCache)) return false;
+                if (!(EqualsMaskHelper.CacheEqualsHelper(lhs: lhs.RecordCache, rhs: rhs.RecordCache, maskGetter: (k, l, r) => l.GetEqualsMask(r, EqualsMaskHelper.Include.All), include: EqualsMaskHelper.Include.All)?.Overall ?? true)) return false;
             }
             return true;
         }

--- a/Mutagen.Bethesda.Fallout4/Records/Major Records/Package_Generated.cs
+++ b/Mutagen.Bethesda.Fallout4/Records/Major Records/Package_Generated.cs
@@ -2626,7 +2626,7 @@ namespace Mutagen.Bethesda.Fallout4
             }
             if ((equalsMask?.GetShouldTranslate((int)Package_FieldIndex.Data) ?? true))
             {
-                if (!lhs.Data.SequenceEqualNullable(rhs.Data)) return false;
+                if (!(EqualsMaskHelper.DictEqualsHelper(lhs: lhs.Data, rhs: rhs.Data, maskGetter: (k, l, r) => l.GetEqualsMask(r, EqualsMaskHelper.Include.All), include: EqualsMaskHelper.Include.All)?.Overall ?? true)) return false;
             }
             if ((equalsMask?.GetShouldTranslate((int)Package_FieldIndex.XnamMarker) ?? true))
             {

--- a/Mutagen.Bethesda.Fallout4/Records/Major Records/Race_Generated.cs
+++ b/Mutagen.Bethesda.Fallout4/Records/Major Records/Race_Generated.cs
@@ -6634,7 +6634,7 @@ namespace Mutagen.Bethesda.Fallout4
             }
             if ((equalsMask?.GetShouldTranslate((int)Race_FieldIndex.BipedObjects) ?? true))
             {
-                if (!lhs.BipedObjects.SequenceEqualNullable(rhs.BipedObjects)) return false;
+                if (!(((lhs.BipedObjects == null) == (rhs.BipedObjects == null)) && (lhs.BipedObjects == null || (EqualsMaskHelper.DictEqualsHelper(lhs: lhs.BipedObjects!, rhs: rhs.BipedObjects!, maskGetter: (k, l, r) => l.GetEqualsMask(r, EqualsMaskHelper.Include.All), include: EqualsMaskHelper.Include.All)?.Overall ?? true)))) return false;
             }
             if ((equalsMask?.GetShouldTranslate((int)Race_FieldIndex.MovementDataOverrides) ?? true))
             {

--- a/Mutagen.Bethesda.Generation/Fields/DictType.cs
+++ b/Mutagen.Bethesda.Generation/Fields/DictType.cs
@@ -1,5 +1,8 @@
 using System.Xml.Linq;
+using Loqui.Generation;
 using Noggog;
+using Noggog.StructuredStrings;
+using Noggog.StructuredStrings.CSharp;
 
 namespace Mutagen.Bethesda.Generation.Fields;
 
@@ -18,5 +21,49 @@ public class DictType : Loqui.Generation.DictType
         {
             NumEnumKeys = num;
         }
+    }
+
+    // Loqui.Generation.DictType_Typical/DictType_KeyedValue emit Equals via
+    // SequenceEqualNullable, an order-sensitive comparison. That disagrees
+    // with GetEqualsMask, which already compares by key via
+    // EqualsMaskHelper.DictEqualsHelper/CacheEqualsHelper (Mutagen-Modding/Mutagen#686).
+    // Reuse those same runtime helpers here so Equals and
+    // GetEqualsMask(...).All(...) stay provably consistent.
+
+    public override string GenerateEqualsSnippet(Accessor accessor, Accessor rhsAccessor, bool negate = false)
+    {
+        var expression = EqualsBoolExpression(accessor, rhsAccessor);
+        return negate ? $"!({expression})" : expression;
+    }
+
+    public override void GenerateForEquals(StructuredStringBuilder sb, Accessor accessor, Accessor rhsAccessor, Accessor maskAccessor)
+    {
+        sb.AppendLine($"if ({this.GetTranslationIfAccessor(maskAccessor)})");
+        using (sb.CurlyBrace())
+        {
+            sb.AppendLine($"if (!({EqualsBoolExpression(accessor, rhsAccessor)})) return false;");
+        }
+    }
+
+    private string EqualsBoolExpression(Accessor accessor, Accessor rhsAccessor)
+    {
+        var helperName = this.Mode == DictMode.KeyedValue ? "CacheEqualsHelper" : "DictEqualsHelper";
+        var maskGetterArg = this.ValueTypeGen is LoquiType
+            ? "maskGetter: (k, l, r) => l.GetEqualsMask(r, EqualsMaskHelper.Include.All), "
+            : string.Empty;
+        // Both operands are null-forgiven here: when this.Nullable, the call
+        // below is only ever reached after the null-guard has already proven
+        // both sides non-null; the compiler's flow analysis can't follow that
+        // reasoning across the guard's && / || though, hence the "!".
+        var lhsExpr = this.Nullable ? $"{accessor.Access}!" : accessor.Access;
+        var rhsExpr = this.Nullable ? $"{rhsAccessor.Access}!" : rhsAccessor.Access;
+        var helperCall = $"EqualsMaskHelper.{helperName}(lhs: {lhsExpr}, rhs: {rhsExpr}, {maskGetterArg}include: EqualsMaskHelper.Include.All)?.Overall ?? true";
+        if (!this.Nullable)
+        {
+            return helperCall;
+        }
+        // Preserve SequenceEqualNullable's null-tolerance: both null is equal,
+        // exactly one null is unequal, neither null falls through to the helper.
+        return $"(({accessor.Access} == null) == ({rhsAccessor.Access} == null)) && ({accessor.Access} == null || ({helperCall}))";
     }
 }

--- a/Mutagen.Bethesda.Oblivion/Records/OblivionGroup_Generated.cs
+++ b/Mutagen.Bethesda.Oblivion/Records/OblivionGroup_Generated.cs
@@ -1043,7 +1043,7 @@ namespace Mutagen.Bethesda.Oblivion
             }
             if ((equalsMask?.GetShouldTranslate((int)OblivionGroup_FieldIndex.RecordCache) ?? true))
             {
-                if (!lhs.RecordCache.SequenceEqualNullable(rhs.RecordCache)) return false;
+                if (!(EqualsMaskHelper.CacheEqualsHelper(lhs: lhs.RecordCache, rhs: rhs.RecordCache, maskGetter: (k, l, r) => l.GetEqualsMask(r, EqualsMaskHelper.Include.All), include: EqualsMaskHelper.Include.All)?.Overall ?? true)) return false;
             }
             return true;
         }

--- a/Mutagen.Bethesda.Skyrim/Records/Major Records/Class_Generated.cs
+++ b/Mutagen.Bethesda.Skyrim/Records/Major Records/Class_Generated.cs
@@ -1688,7 +1688,7 @@ namespace Mutagen.Bethesda.Skyrim
             }
             if ((equalsMask?.GetShouldTranslate((int)Class_FieldIndex.SkillWeights) ?? true))
             {
-                if (!lhs.SkillWeights.SequenceEqualNullable(rhs.SkillWeights)) return false;
+                if (!(EqualsMaskHelper.DictEqualsHelper(lhs: lhs.SkillWeights, rhs: rhs.SkillWeights, include: EqualsMaskHelper.Include.All)?.Overall ?? true)) return false;
             }
             if ((equalsMask?.GetShouldTranslate((int)Class_FieldIndex.BleedoutDefault) ?? true))
             {
@@ -1700,7 +1700,7 @@ namespace Mutagen.Bethesda.Skyrim
             }
             if ((equalsMask?.GetShouldTranslate((int)Class_FieldIndex.StatWeights) ?? true))
             {
-                if (!lhs.StatWeights.SequenceEqualNullable(rhs.StatWeights)) return false;
+                if (!(EqualsMaskHelper.DictEqualsHelper(lhs: lhs.StatWeights, rhs: rhs.StatWeights, include: EqualsMaskHelper.Include.All)?.Overall ?? true)) return false;
             }
             if ((equalsMask?.GetShouldTranslate((int)Class_FieldIndex.Unknown2) ?? true))
             {

--- a/Mutagen.Bethesda.Skyrim/Records/Major Records/Package_Generated.cs
+++ b/Mutagen.Bethesda.Skyrim/Records/Major Records/Package_Generated.cs
@@ -2710,7 +2710,7 @@ namespace Mutagen.Bethesda.Skyrim
             }
             if ((equalsMask?.GetShouldTranslate((int)Package_FieldIndex.Data) ?? true))
             {
-                if (!lhs.Data.SequenceEqualNullable(rhs.Data)) return false;
+                if (!(EqualsMaskHelper.DictEqualsHelper(lhs: lhs.Data, rhs: rhs.Data, maskGetter: (k, l, r) => l.GetEqualsMask(r, EqualsMaskHelper.Include.All), include: EqualsMaskHelper.Include.All)?.Overall ?? true)) return false;
             }
             if ((equalsMask?.GetShouldTranslate((int)Package_FieldIndex.XnamMarker) ?? true))
             {

--- a/Mutagen.Bethesda.Skyrim/Records/Major Records/PlayerSkills_Generated.cs
+++ b/Mutagen.Bethesda.Skyrim/Records/Major Records/PlayerSkills_Generated.cs
@@ -1387,11 +1387,11 @@ namespace Mutagen.Bethesda.Skyrim
             if (!EqualsMaskHelper.RefEquality(lhs, rhs, out var isEqual)) return isEqual;
             if ((equalsMask?.GetShouldTranslate((int)PlayerSkills_FieldIndex.SkillValues) ?? true))
             {
-                if (!lhs.SkillValues.SequenceEqualNullable(rhs.SkillValues)) return false;
+                if (!(EqualsMaskHelper.DictEqualsHelper(lhs: lhs.SkillValues, rhs: rhs.SkillValues, include: EqualsMaskHelper.Include.All)?.Overall ?? true)) return false;
             }
             if ((equalsMask?.GetShouldTranslate((int)PlayerSkills_FieldIndex.SkillOffsets) ?? true))
             {
-                if (!lhs.SkillOffsets.SequenceEqualNullable(rhs.SkillOffsets)) return false;
+                if (!(EqualsMaskHelper.DictEqualsHelper(lhs: lhs.SkillOffsets, rhs: rhs.SkillOffsets, include: EqualsMaskHelper.Include.All)?.Overall ?? true)) return false;
             }
             if ((equalsMask?.GetShouldTranslate((int)PlayerSkills_FieldIndex.Health) ?? true))
             {

--- a/Mutagen.Bethesda.Skyrim/Records/Major Records/Race_Generated.cs
+++ b/Mutagen.Bethesda.Skyrim/Records/Major Records/Race_Generated.cs
@@ -5692,7 +5692,7 @@ namespace Mutagen.Bethesda.Skyrim
             }
             if ((equalsMask?.GetShouldTranslate((int)Race_FieldIndex.Starting) ?? true))
             {
-                if (!lhs.Starting.SequenceEqualNullable(rhs.Starting)) return false;
+                if (!(EqualsMaskHelper.DictEqualsHelper(lhs: lhs.Starting, rhs: rhs.Starting, include: EqualsMaskHelper.Include.All)?.Overall ?? true)) return false;
             }
             if ((equalsMask?.GetShouldTranslate((int)Race_FieldIndex.BaseCarryWeight) ?? true))
             {
@@ -5732,7 +5732,7 @@ namespace Mutagen.Bethesda.Skyrim
             }
             if ((equalsMask?.GetShouldTranslate((int)Race_FieldIndex.Regen) ?? true))
             {
-                if (!lhs.Regen.SequenceEqualNullable(rhs.Regen)) return false;
+                if (!(EqualsMaskHelper.DictEqualsHelper(lhs: lhs.Regen, rhs: rhs.Regen, include: EqualsMaskHelper.Include.All)?.Overall ?? true)) return false;
             }
             if ((equalsMask?.GetShouldTranslate((int)Race_FieldIndex.UnarmedDamage) ?? true))
             {
@@ -5852,7 +5852,7 @@ namespace Mutagen.Bethesda.Skyrim
             }
             if ((equalsMask?.GetShouldTranslate((int)Race_FieldIndex.BipedObjectNames) ?? true))
             {
-                if (!lhs.BipedObjectNames.SequenceEqualNullable(rhs.BipedObjectNames)) return false;
+                if (!(((lhs.BipedObjectNames == null) == (rhs.BipedObjectNames == null)) && (lhs.BipedObjectNames == null || (EqualsMaskHelper.DictEqualsHelper(lhs: lhs.BipedObjectNames!, rhs: rhs.BipedObjectNames!, include: EqualsMaskHelper.Include.All)?.Overall ?? true)))) return false;
             }
             if ((equalsMask?.GetShouldTranslate((int)Race_FieldIndex.MovementTypes) ?? true))
             {

--- a/Mutagen.Bethesda.Skyrim/Records/SkyrimGroup_Generated.cs
+++ b/Mutagen.Bethesda.Skyrim/Records/SkyrimGroup_Generated.cs
@@ -1059,7 +1059,7 @@ namespace Mutagen.Bethesda.Skyrim
             }
             if ((equalsMask?.GetShouldTranslate((int)SkyrimGroup_FieldIndex.RecordCache) ?? true))
             {
-                if (!lhs.RecordCache.SequenceEqualNullable(rhs.RecordCache)) return false;
+                if (!(EqualsMaskHelper.CacheEqualsHelper(lhs: lhs.RecordCache, rhs: rhs.RecordCache, maskGetter: (k, l, r) => l.GetEqualsMask(r, EqualsMaskHelper.Include.All), include: EqualsMaskHelper.Include.All)?.Overall ?? true)) return false;
             }
             return true;
         }

--- a/Mutagen.Bethesda.Starfield/Records/Major Records/Package_Generated.cs
+++ b/Mutagen.Bethesda.Starfield/Records/Major Records/Package_Generated.cs
@@ -2672,7 +2672,7 @@ namespace Mutagen.Bethesda.Starfield
             }
             if ((equalsMask?.GetShouldTranslate((int)Package_FieldIndex.Data) ?? true))
             {
-                if (!lhs.Data.SequenceEqualNullable(rhs.Data)) return false;
+                if (!(EqualsMaskHelper.DictEqualsHelper(lhs: lhs.Data, rhs: rhs.Data, maskGetter: (k, l, r) => l.GetEqualsMask(r, EqualsMaskHelper.Include.All), include: EqualsMaskHelper.Include.All)?.Overall ?? true)) return false;
             }
             if ((equalsMask?.GetShouldTranslate((int)Package_FieldIndex.PackageGroup) ?? true))
             {

--- a/Mutagen.Bethesda.Starfield/Records/Major Records/Race_Generated.cs
+++ b/Mutagen.Bethesda.Starfield/Records/Major Records/Race_Generated.cs
@@ -4978,7 +4978,7 @@ namespace Mutagen.Bethesda.Starfield
             }
             if ((equalsMask?.GetShouldTranslate((int)Race_FieldIndex.BipedObjects) ?? true))
             {
-                if (!lhs.BipedObjects.SequenceEqualNullable(rhs.BipedObjects)) return false;
+                if (!(((lhs.BipedObjects == null) == (rhs.BipedObjects == null)) && (lhs.BipedObjects == null || (EqualsMaskHelper.DictEqualsHelper(lhs: lhs.BipedObjects!, rhs: rhs.BipedObjects!, maskGetter: (k, l, r) => l.GetEqualsMask(r, EqualsMaskHelper.Include.All), include: EqualsMaskHelper.Include.All)?.Overall ?? true)))) return false;
             }
             if ((equalsMask?.GetShouldTranslate((int)Race_FieldIndex.MovementDataOverrides) ?? true))
             {

--- a/Mutagen.Bethesda.Starfield/Records/StarfieldGroup_Generated.cs
+++ b/Mutagen.Bethesda.Starfield/Records/StarfieldGroup_Generated.cs
@@ -1059,7 +1059,7 @@ namespace Mutagen.Bethesda.Starfield
             }
             if ((equalsMask?.GetShouldTranslate((int)StarfieldGroup_FieldIndex.RecordCache) ?? true))
             {
-                if (!lhs.RecordCache.SequenceEqualNullable(rhs.RecordCache)) return false;
+                if (!(EqualsMaskHelper.CacheEqualsHelper(lhs: lhs.RecordCache, rhs: rhs.RecordCache, maskGetter: (k, l, r) => l.GetEqualsMask(r, EqualsMaskHelper.Include.All), include: EqualsMaskHelper.Include.All)?.Overall ?? true)) return false;
             }
             return true;
         }

--- a/Mutagen.Bethesda.UnitTests/Plugins/Records/Fallout4/GroupRecordCacheEqualsTests.cs
+++ b/Mutagen.Bethesda.UnitTests/Plugins/Records/Fallout4/GroupRecordCacheEqualsTests.cs
@@ -1,0 +1,55 @@
+using Mutagen.Bethesda.Fallout4;
+using Mutagen.Bethesda.Plugins;
+using Shouldly;
+using Xunit;
+
+namespace Mutagen.Bethesda.UnitTests.Plugins.Records.Fallout4;
+
+/// <summary>
+/// Same latent defect as PackageDataEqualsTests (Mutagen-Modding/Mutagen#686),
+/// but for the other Dict codegen path: Group.RecordCache is DictMode.KeyedValue
+/// (an ICache&lt;T, FormKey&gt;, not an IReadOnlyDictionary), which the mask
+/// generator already handles with EqualsMaskHelper.CacheEqualsHelper instead of
+/// DictEqualsHelper. A compile-clean regen of the KeyedValue branch isn't proof
+/// it's behaviorally right - this exercises it the same way the Package.Data
+/// tests exercise the KeyValue branch.
+/// </summary>
+public class GroupRecordCacheEqualsTests
+{
+    private static readonly ModKey TestModKey = ModKey.FromNameAndExtension("GroupRecordCacheEqualsTests.esp");
+
+    private static Fallout4Group<Static> MakeGroup(Fallout4Mod mod, params (uint Id, string EditorId)[] entries)
+    {
+        var group = new Fallout4Group<Static>(mod);
+        foreach (var (id, editorId) in entries)
+        {
+            group.Add(new Static(new FormKey(TestModKey, id), Fallout4Release.Fallout4)
+            {
+                EditorID = editorId,
+            });
+        }
+        return group;
+    }
+
+    [Fact]
+    public void ReorderedEntries_SameContent_AreEqual()
+    {
+        var mod = new Fallout4Mod(TestModKey, Fallout4Release.Fallout4);
+        var lhs = MakeGroup(mod, (0x800, "First"), (0x801, "Second"));
+        var rhs = MakeGroup(mod, (0x801, "Second"), (0x800, "First"));
+
+        lhs.Equals(rhs).ShouldBeTrue();
+        lhs.GetEqualsMask(rhs).All(b => b).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void SameKeys_DifferingValueUnderSameKey_AreNotEqual()
+    {
+        var mod = new Fallout4Mod(TestModKey, Fallout4Release.Fallout4);
+        var lhs = MakeGroup(mod, (0x800, "First"), (0x801, "Second"));
+        var rhs = MakeGroup(mod, (0x801, "SecondButDifferent"), (0x800, "First"));
+
+        lhs.Equals(rhs).ShouldBeFalse();
+        lhs.GetEqualsMask(rhs).All(b => b).ShouldBeFalse();
+    }
+}

--- a/Mutagen.Bethesda.UnitTests/Plugins/Records/Fallout4/PackageDataEqualsTests.cs
+++ b/Mutagen.Bethesda.UnitTests/Plugins/Records/Fallout4/PackageDataEqualsTests.cs
@@ -1,0 +1,56 @@
+using Mutagen.Bethesda.Fallout4;
+using Mutagen.Bethesda.Plugins;
+using Shouldly;
+using Xunit;
+
+namespace Mutagen.Bethesda.UnitTests.Plugins.Records.Fallout4;
+
+/// <summary>
+/// Repro for Mutagen-Modding/Mutagen#686: the generated Equals for Dict-typed
+/// fields (Package.Data here) compared entries by sequence/insertion order
+/// instead of by key, so two packages with identical Data content inserted in
+/// a different order were Equals-unequal despite GetEqualsMask reporting them
+/// equal. The writer emits keys sorted while the parser inserts in on-disk
+/// UNAM order, so this is a real round-trip scenario, not a contrived one.
+/// </summary>
+public class PackageDataEqualsTests
+{
+    private static readonly ModKey TestModKey = ModKey.FromNameAndExtension("PackageDataEqualsTests.esp");
+
+    private static Package MakePackage(params (sbyte Key, uint Value)[] entries)
+    {
+        var package = new Package(new FormKey(TestModKey, 0x800), Fallout4Release.Fallout4);
+        foreach (var (key, value) in entries)
+        {
+            package.Data.Add(key, new PackageDataInt { Data = value });
+        }
+        return package;
+    }
+
+    [Fact]
+    public void ReorderedEntries_SameContent_AreEqual()
+    {
+        var lhs = MakePackage((5, 11), (2, 22));
+        var rhs = MakePackage((2, 22), (5, 11));
+
+        lhs.Equals(rhs).ShouldBeTrue();
+        lhs.GetEqualsMask(rhs).All(b => b).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void SameKeys_DifferingValueUnderSameKey_AreNotEqual()
+    {
+        // Differs by Name (an APackageData base-class field) rather than Data
+        // (a PackageDataInt-only field): GetEqualsMask's dispatch for dict
+        // values reached through the abstract IAPackageDataGetter base
+        // interface only compares base-class fields correctly - a separate,
+        // pre-existing bug unrelated to #686, tracked independently. Name
+        // keeps this test inside #686's scope: by-key vs. by-sequence Equals.
+        var lhs = MakePackage((5, 11), (2, 22));
+        var rhs = MakePackage((5, 11), (2, 22));
+        rhs.Data[2].Name = "Different";
+
+        lhs.Equals(rhs).ShouldBeFalse();
+        lhs.GetEqualsMask(rhs).All(b => b).ShouldBeFalse();
+    }
+}


### PR DESCRIPTION
Loqui.Generation.DictType_Typical/DictType_KeyedValue emit Equals for Dict-typed fields via SequenceEqualNullable, an order-sensitive comparison. GetEqualsMask already compares the same fields by key via EqualsMaskHelper.DictEqualsHelper/CacheEqualsHelper, so two records with identical Dict content in a different insertion order were Equals-unequal despite GetEqualsMask reporting them equal - a real round-trip scenario (e.g. Fallout4 Package.Data: writer emits keys sorted, parser inserts in on-disk UNAM order).

Mutagen.Bethesda.Generation/Fields/DictType.cs now overrides GenerateForEquals/GenerateEqualsSnippet (both public, non-sealed on Loqui.Generation.DictType) to reuse the same DictEqualsHelper/ CacheEqualsHelper runtime calls GetEqualsMask already uses, branching on DictMode (KeyValue vs. Group.RecordCache's KeyedValue) and on whether the value type is a LoquiType (needs a maskGetter) or a primitive (EqualityComparer<T>.Default.Equals per key). Nullable Dict fields (e.g. Race.BipedObjects/BipedObjectNames) get an explicit null-guard preserving SequenceEqualNullable's null-tolerance, since the helpers themselves don't accept null dictionaries.

Regenerated via Generator.All across all five games; diff is scoped to the emitter plus the touched Dict-field Equals bodies (Package.Data, Group.RecordCache, Class.Attributes/SkillWeights/StatWeights, PlayerSkills.SkillValues/SkillOffsets, Race.BipedObjects/ BipedObjectNames/Starting/Regen). Excluded from this commit: unrelated generator drift (RecordTriggerSpecs ACHR/REFR ordering, MergedCellBlock/ MergedCellSubBlock dedup) present in Cell_Generated.cs/ Worldspace_Generated.cs/*MultiModOverlay_Generated.cs even on unmodified dev - confirmed via a control regen with DictType.cs reverted, out of scope for this ticket.

New tests: PackageDataEqualsTests (Package.Data, DictMode.KeyValue) and GroupRecordCacheEqualsTests (Group.RecordCache, DictMode.KeyedValue) in Mutagen.Bethesda.UnitTests, each covering reordered-same-content equality and differing-value-under-same-key inequality, both checked against Equals and GetEqualsMask(...).All(...).

Fixes Mutagen-Modding/Mutagen#686