### PR TITLE
Set FormVersion before struct-fill so MaterialSwap's FNAM gate works …

### DIFF
--- a/Mutagen.Bethesda.Core/Plugins/Binary/Translations/PluginUtilityTranslation.cs
+++ b/Mutagen.Bethesda.Core/Plugins/Binary/Translations/PluginUtilityTranslation.cs
@@ -88,6 +88,11 @@ internal static class PluginUtilityTranslation
         MajorRecordFill<M> fillTyped)
         where M : IMajorRecordGetter
     {
+        // Peek the record's FormVersion directly off its header bytes (without advancing
+        // the reader) so it is available to fillStructs' own custom struct-fill logic below.
+        // record.FormVersion isn't populated until fillStructs runs, so it can't be used yet;
+        // the header itself is already sitting right here to read from instead.
+        frame.MetaData.FormVersion = (ushort?)frame.Reader.GetMajorRecordHeader().FormVersion;
         frame = frame.SpawnWithFinalPosition(HeaderTranslation.ParseRecord(frame.Reader));
         fillStructs(
             record: record,
@@ -101,7 +106,6 @@ internal static class PluginUtilityTranslation
             }
 
             Dictionary<RecordType, int>? recordParseCount = null;
-            frame.MetaData.FormVersion = record.FormVersion;
             var lastParsed = new PreviousParse();
             while (!targetFrame.Complete)
             {

--- a/Mutagen.Bethesda.Core/Plugins/Binary/Translations/PluginUtilityTranslation.cs
+++ b/Mutagen.Bethesda.Core/Plugins/Binary/Translations/PluginUtilityTranslation.cs
@@ -88,10 +88,6 @@ internal static class PluginUtilityTranslation
         MajorRecordFill<M> fillTyped)
         where M : IMajorRecordGetter
     {
-        // Peek the record's FormVersion directly off its header bytes (without advancing
-        // the reader) so it is available to fillStructs' own custom struct-fill logic below.
-        // record.FormVersion isn't populated until fillStructs runs, so it can't be used yet;
-        // the header itself is already sitting right here to read from instead.
         frame.MetaData.FormVersion = (ushort?)frame.Reader.GetMajorRecordHeader().FormVersion;
         frame = frame.SpawnWithFinalPosition(HeaderTranslation.ParseRecord(frame.Reader));
         fillStructs(

--- a/Mutagen.Bethesda.Fallout4/Records/Major Records/MaterialSwap.cs
+++ b/Mutagen.Bethesda.Fallout4/Records/Major Records/MaterialSwap.cs
@@ -132,15 +132,12 @@ partial class MaterialSwapBinaryOverlay
 {
     private int? _fnamLoc;
     private int _offset;
-
+    
     public partial String? GetTreeFolderCustom()
     {
-        // this.FormVersion is read directly off this record's own header bytes, on demand -
-        // unlike _package.MetaData.FormVersion (a deep-parse-only tracker that is never
-        // populated for overlay reads), it is always correct here.
         if (this.FormVersion >= MaterialSwapBinaryCreateTranslation.NewFormVersion)
         {
-            return _fnamLoc.HasValue ? BinaryStringUtility.ProcessWholeToZString(HeaderTranslation.ExtractSubrecordMemory(_recordData, _fnamLoc.Value, _package.MetaData.Constants), encoding: _package.MetaData.Encodings.NonTranslated) : string.Empty;
+            return _fnamLoc.HasValue ? BinaryStringUtility.ProcessWholeToZString(HeaderTranslation.ExtractSubrecordMemory(_recordData, _fnamLoc.Value, _package.MetaData.Constants), encoding: _package.MetaData.Encodings.NonTranslated) : null;
         }
         else
         {

--- a/Mutagen.Bethesda.Fallout4/Records/Major Records/MaterialSwap.cs
+++ b/Mutagen.Bethesda.Fallout4/Records/Major Records/MaterialSwap.cs
@@ -131,12 +131,14 @@ partial class MaterialSwapBinaryWriteTranslation
 partial class MaterialSwapBinaryOverlay
 {
     private int? _fnamLoc;
-    private ushort? _formVersion;
     private int _offset;
-    
+
     public partial String? GetTreeFolderCustom()
     {
-        if (_formVersion >= MaterialSwapBinaryCreateTranslation.NewFormVersion)
+        // this.FormVersion is read directly off this record's own header bytes, on demand -
+        // unlike _package.MetaData.FormVersion (a deep-parse-only tracker that is never
+        // populated for overlay reads), it is always correct here.
+        if (this.FormVersion >= MaterialSwapBinaryCreateTranslation.NewFormVersion)
         {
             return _fnamLoc.HasValue ? BinaryStringUtility.ProcessWholeToZString(HeaderTranslation.ExtractSubrecordMemory(_recordData, _fnamLoc.Value, _package.MetaData.Constants), encoding: _package.MetaData.Encodings.NonTranslated) : string.Empty;
         }
@@ -175,7 +177,6 @@ partial class MaterialSwapBinaryOverlay
         int finalPos,
         int offset)
     {
-        _formVersion = stream.MetaData.FormVersion;
         _offset = offset;
     }
 }

--- a/Mutagen.Bethesda.Fallout4/Records/Major Records/MaterialSwap_Generated.cs
+++ b/Mutagen.Bethesda.Fallout4/Records/Major Records/MaterialSwap_Generated.cs
@@ -1784,7 +1784,7 @@ namespace Mutagen.Bethesda.Fallout4
             switch (type.TypeInt)
             {
                 case RecordTypeInts.FNAM
-                    when stream.MetaData.FormVersion >= 112:
+                    when this._package.FormVersion!.FormVersion >= 112:
                 {
                     TreeFolderCustomParse(
                         stream: stream,

--- a/Mutagen.Bethesda.Generation/Modules/Plugin/PluginTranslationModule.cs
+++ b/Mutagen.Bethesda.Generation/Modules/Plugin/PluginTranslationModule.cs
@@ -1751,7 +1751,7 @@ public class PluginTranslationModule : BinaryTranslationModule
                                         var overlayWhenChecks = new List<string>();
                                         if (gen.Value.GetFieldData().HasVersioning)
                                         {
-                                            overlayWhenChecks.Add(VersioningModule.GetVersionIfCheck(gen.Value.GetFieldData(), "stream.MetaData.FormVersion"));
+                                            overlayWhenChecks.Add(VersioningModule.GetVersionIfCheck(gen.Value.GetFieldData(), "this._package.FormVersion!.FormVersion"));
                                         }
                                         if (gen.Value.GetFieldData().HasModHeaderVersioning)
                                         {

--- a/Mutagen.Bethesda.UnitTests/Plugins/Records/Fallout4/MaterialSwapFormVersionGateTests.cs
+++ b/Mutagen.Bethesda.UnitTests/Plugins/Records/Fallout4/MaterialSwapFormVersionGateTests.cs
@@ -1,0 +1,106 @@
+using System.Buffers.Binary;
+using System.Text;
+using Shouldly;
+using Mutagen.Bethesda.Fallout4;
+using Mutagen.Bethesda.Plugins.Binary.Overlay;
+using Mutagen.Bethesda.Plugins.Binary.Streams;
+using Mutagen.Bethesda.Plugins.Exceptions;
+using Mutagen.Bethesda.Plugins.Masters;
+using Mutagen.Bethesda.Plugins.Meta;
+using Xunit;
+
+namespace Mutagen.Bethesda.UnitTests.Plugins.Records.Fallout4;
+
+/// <summary>
+/// Regression coverage for Mutagen-Modding/Mutagen#687: MaterialSwap's FNAM form-version
+/// gate needs MetaData.FormVersion available while its custom struct-fill logic runs, for
+/// both the deep parser and the overlay factory.
+/// </summary>
+public class MaterialSwapFormVersionGateTests
+{
+    /// <summary>
+    /// Builds a minimal, hand-crafted MSWP record: a top-level FNAM (the new-format tree
+    /// folder), then a single substitution (BNAM/SNAM) followed by its own obsolete FNAM
+    /// field. Pre-112, all FNAM occurrences in a record are expected to carry the same
+    /// string; 112+, the top FNAM is the tree folder and a substitution's own FNAM is
+    /// vestigial and may legitimately differ.
+    /// </summary>
+    private static byte[] BuildMswpBytes(ushort formVersion, string topFnam, string substitutionFnam)
+    {
+        var content = new List<byte>();
+        content.AddRange(Subrecord("FNAM", NullTerminated(topFnam)));
+        content.AddRange(Subrecord("BNAM", NullTerminated("OriginalMat")));
+        content.AddRange(Subrecord("SNAM", NullTerminated("ReplacementMat")));
+        content.AddRange(Subrecord("FNAM", NullTerminated(substitutionFnam)));
+        var contentBytes = content.ToArray();
+
+        var header = new byte[24];
+        Encoding.ASCII.GetBytes("MSWP").CopyTo(header, 0);
+        BinaryPrimitives.WriteUInt32LittleEndian(header.AsSpan(4), checked((uint)contentBytes.Length));
+        // Flags (offset 8) and VersionControl (offset 16) left zeroed.
+        BinaryPrimitives.WriteUInt32LittleEndian(header.AsSpan(12), 0x00000001); // FormID
+        BinaryPrimitives.WriteUInt16LittleEndian(header.AsSpan(20), formVersion);
+        // Version2 (offset 22) left zeroed.
+
+        return header.Concat(contentBytes).ToArray();
+    }
+
+    private static byte[] Subrecord(string type, byte[] content)
+    {
+        var header = new byte[6];
+        Encoding.ASCII.GetBytes(type).CopyTo(header, 0);
+        BinaryPrimitives.WriteUInt16LittleEndian(header.AsSpan(4), checked((ushort)content.Length));
+        return header.Concat(content).ToArray();
+    }
+
+    private static byte[] NullTerminated(string s) => Encoding.ASCII.GetBytes(s + "\0");
+
+    private static ParsingMeta Meta() => new(
+        GameConstants.Fallout4,
+        global::Mutagen.Bethesda.Fallout4.Constants.Fallout4,
+        SeparatedMasterPackage.NotSeparate(new MasterReferenceCollection(global::Mutagen.Bethesda.Fallout4.Constants.Fallout4)));
+
+    private static MaterialSwap ParseDeep(byte[] bytes)
+    {
+        using var reader = new MutagenBinaryReadStream(new MemoryStream(bytes), Meta());
+        return MaterialSwap.CreateFromBinary(new MutagenFrame(reader));
+    }
+
+    private static IMaterialSwapGetter ParseOverlay(byte[] bytes)
+    {
+        return MaterialSwapBinaryOverlay.MaterialSwapFactory(
+            bytes,
+            new BinaryOverlayFactoryPackage(Meta()));
+    }
+
+    [Fact]
+    public void DeepParse_V131DifferingFnam_ParsesTreeFolder()
+    {
+        var bytes = BuildMswpBytes(131, topFnam: "materials", substitutionFnam: "");
+        var item = ParseDeep(bytes);
+        item.TreeFolder.ShouldBe("materials");
+    }
+
+    [Fact]
+    public void DeepParse_SubNewFormVersionDifferingFnam_StillThrows()
+    {
+        var bytes = BuildMswpBytes(90, topFnam: "materials", substitutionFnam: "");
+        Should.Throw<MalformedDataException>(() => ParseDeep(bytes));
+    }
+
+    [Fact]
+    public void Overlay_V131DifferingFnam_ParsesTreeFolder()
+    {
+        var bytes = BuildMswpBytes(131, topFnam: "materials", substitutionFnam: "");
+        var item = ParseOverlay(bytes);
+        item.TreeFolder.ShouldBe("materials");
+    }
+
+    [Fact]
+    public void Overlay_SubNewFormVersionDifferingFnam_StillThrows()
+    {
+        var bytes = BuildMswpBytes(90, topFnam: "materials", substitutionFnam: "");
+        var item = ParseOverlay(bytes);
+        Should.Throw<MalformedDataException>(() => item.TreeFolder);
+    }
+}

--- a/Mutagen.Bethesda.UnitTests/Plugins/Records/Fallout4/MaterialSwapFormVersionGateTests.cs
+++ b/Mutagen.Bethesda.UnitTests/Plugins/Records/Fallout4/MaterialSwapFormVersionGateTests.cs
@@ -2,30 +2,30 @@ using System.Buffers.Binary;
 using System.Text;
 using Shouldly;
 using Mutagen.Bethesda.Fallout4;
+using Mutagen.Bethesda.Fallout4.Internals;
 using Mutagen.Bethesda.Plugins.Binary.Overlay;
 using Mutagen.Bethesda.Plugins.Binary.Streams;
+using Mutagen.Bethesda.Plugins.Binary.Translations;
 using Mutagen.Bethesda.Plugins.Exceptions;
 using Mutagen.Bethesda.Plugins.Masters;
 using Mutagen.Bethesda.Plugins.Meta;
+using Noggog;
 using Xunit;
+using Fallout4Constants = Mutagen.Bethesda.Fallout4.Constants;
 
 namespace Mutagen.Bethesda.UnitTests.Plugins.Records.Fallout4;
 
-/// <summary>
-/// Regression coverage for Mutagen-Modding/Mutagen#687: MaterialSwap's FNAM form-version
-/// gate needs MetaData.FormVersion available while its custom struct-fill logic runs, for
-/// both the deep parser and the overlay factory.
-/// </summary>
+// Regression coverage for https://github.com/Mutagen-Modding/Mutagen/issues/687:
+// MaterialSwap's FNAM form-version gate needs FormVersion while its custom
+// struct-fill runs, on both the deep parser and the overlay.
 public class MaterialSwapFormVersionGateTests
 {
-    /// <summary>
-    /// Builds a minimal, hand-crafted MSWP record: a top-level FNAM (the new-format tree
-    /// folder), then a single substitution (BNAM/SNAM) followed by its own obsolete FNAM
-    /// field. Pre-112, all FNAM occurrences in a record are expected to carry the same
-    /// string; 112+, the top FNAM is the tree folder and a substitution's own FNAM is
-    /// vestigial and may legitimately differ.
-    /// </summary>
-    private static byte[] BuildMswpBytes(ushort formVersion, string? topFnam, string substitutionFnam)
+    private const ushort NewFormVersion = MaterialSwapBinaryCreateTranslation.NewFormVersion;
+    private const ushort LegacyFormVersion = 90;
+
+    private static readonly MasterReferenceCollection Masters = new(Fallout4Constants.Fallout4);
+
+    private static byte[] BuildMswpBytes(ushort formVersion, string? topFnam)
     {
         var content = new List<byte>();
         if (topFnam != null)
@@ -34,16 +34,14 @@ public class MaterialSwapFormVersionGateTests
         }
         content.AddRange(Subrecord("BNAM", NullTerminated("OriginalMat")));
         content.AddRange(Subrecord("SNAM", NullTerminated("ReplacementMat")));
-        content.AddRange(Subrecord("FNAM", NullTerminated(substitutionFnam)));
+        content.AddRange(Subrecord("FNAM", NullTerminated("")));
         var contentBytes = content.ToArray();
 
-        var header = new byte[24];
+        var header = new byte[GameConstants.Fallout4.MajorConstants.HeaderLength];
         Encoding.ASCII.GetBytes("MSWP").CopyTo(header, 0);
         BinaryPrimitives.WriteUInt32LittleEndian(header.AsSpan(4), checked((uint)contentBytes.Length));
-        // Flags (offset 8) and VersionControl (offset 16) left zeroed.
-        BinaryPrimitives.WriteUInt32LittleEndian(header.AsSpan(12), 0x00000001); // FormID
+        BinaryPrimitives.WriteUInt32LittleEndian(header.AsSpan(12), 0x00000001);
         BinaryPrimitives.WriteUInt16LittleEndian(header.AsSpan(20), formVersion);
-        // Version2 (offset 22) left zeroed.
 
         return header.Concat(contentBytes).ToArray();
     }
@@ -60,8 +58,8 @@ public class MaterialSwapFormVersionGateTests
 
     private static ParsingMeta Meta() => new(
         GameConstants.Fallout4,
-        global::Mutagen.Bethesda.Fallout4.Constants.Fallout4,
-        SeparatedMasterPackage.NotSeparate(new MasterReferenceCollection(global::Mutagen.Bethesda.Fallout4.Constants.Fallout4)));
+        Fallout4Constants.Fallout4,
+        SeparatedMasterPackage.NotSeparate(Masters));
 
     private static MaterialSwap ParseDeep(byte[] bytes)
     {
@@ -78,14 +76,13 @@ public class MaterialSwapFormVersionGateTests
 
     private static byte[] Write(IMaterialSwapGetter item)
     {
-        var masters = new MasterReferenceCollection(global::Mutagen.Bethesda.Fallout4.Constants.Fallout4);
         var stream = new MemoryStream();
         using (var writer = new MutagenWriter(
                    stream,
                    new WritingBundle(GameConstants.Fallout4)
                    {
-                       MasterReferences = masters,
-                       SeparatedMasterPackage = SeparatedMasterPackage.NotSeparate(masters),
+                       MasterReferences = Masters,
+                       SeparatedMasterPackage = SeparatedMasterPackage.NotSeparate(Masters),
                    }))
         {
             MaterialSwapBinaryWriteTranslation.Instance.Write(writer, item, default);
@@ -93,80 +90,68 @@ public class MaterialSwapFormVersionGateTests
         return stream.ToArray();
     }
 
-    private static int CountSubrecords(byte[] bytes, string type)
+    private static int CountFnam(byte[] record)
     {
-        var count = 0;
-        var pos = 24;
-        while (pos < bytes.Length)
-        {
-            if (Encoding.ASCII.GetString(bytes, pos, 4) == type) count++;
-            pos += 6 + BinaryPrimitives.ReadUInt16LittleEndian(bytes.AsSpan(pos + 4));
-        }
-        return count;
+        return RecordSpanExtensions.FindAllOfSubrecord(
+            new ReadOnlyMemorySlice<byte>(record).Slice(GameConstants.Fallout4.MajorConstants.HeaderLength),
+            GameConstants.Fallout4,
+            RecordTypes.FNAM).Count;
     }
 
     [Fact]
-    public void DeepParse_V131DifferingFnam_ParsesTreeFolder()
+    public void DeepParse_NewFormVersionDifferingFnam_ParsesTreeFolder()
     {
-        var bytes = BuildMswpBytes(131, topFnam: "materials", substitutionFnam: "");
-        var item = ParseDeep(bytes);
+        var item = ParseDeep(BuildMswpBytes(NewFormVersion, topFnam: "materials"));
         item.TreeFolder.ShouldBe("materials");
     }
 
     [Fact]
-    public void DeepParse_SubNewFormVersionDifferingFnam_StillThrows()
+    public void DeepParse_LegacyFormVersionDifferingFnam_Throws()
     {
-        var bytes = BuildMswpBytes(90, topFnam: "materials", substitutionFnam: "");
-        Should.Throw<MalformedDataException>(() => ParseDeep(bytes));
+        Should.Throw<MalformedDataException>(() => ParseDeep(BuildMswpBytes(LegacyFormVersion, topFnam: "materials")));
     }
 
     [Fact]
-    public void Overlay_V131DifferingFnam_ParsesTreeFolder()
+    public void Overlay_NewFormVersionDifferingFnam_ParsesTreeFolder()
     {
-        var bytes = BuildMswpBytes(131, topFnam: "materials", substitutionFnam: "");
-        var item = ParseOverlay(bytes);
+        var item = ParseOverlay(BuildMswpBytes(NewFormVersion, topFnam: "materials"));
         item.TreeFolder.ShouldBe("materials");
     }
 
     [Fact]
-    public void Overlay_SubNewFormVersionDifferingFnam_StillThrows()
+    public void Overlay_LegacyFormVersionDifferingFnam_Throws()
     {
-        var bytes = BuildMswpBytes(90, topFnam: "materials", substitutionFnam: "");
-        var item = ParseOverlay(bytes);
+        var item = ParseOverlay(BuildMswpBytes(LegacyFormVersion, topFnam: "materials"));
         Should.Throw<MalformedDataException>(() => item.TreeFolder);
     }
 
     [Fact]
-    public void DeepParse_V131NoTopFnam_TreeFolderIsNull()
+    public void DeepParse_NewFormVersionNoTopFnam_TreeFolderIsNull()
     {
-        var bytes = BuildMswpBytes(131, topFnam: null, substitutionFnam: "");
-        var item = ParseDeep(bytes);
+        var item = ParseDeep(BuildMswpBytes(NewFormVersion, topFnam: null));
         item.TreeFolder.ShouldBeNull();
     }
 
     [Fact]
-    public void Overlay_V131NoTopFnam_TreeFolderIsNull()
+    public void Overlay_NewFormVersionNoTopFnam_TreeFolderIsNull()
     {
-        var bytes = BuildMswpBytes(131, topFnam: null, substitutionFnam: "");
-        var item = ParseOverlay(bytes);
+        var item = ParseOverlay(BuildMswpBytes(NewFormVersion, topFnam: null));
         item.TreeFolder.ShouldBeNull();
     }
 
     [Fact]
-    public void Overlay_V131NoTopFnam_WritesNoFnam()
+    public void Overlay_NewFormVersionNoTopFnam_WritesNoFnam()
     {
-        var bytes = BuildMswpBytes(131, topFnam: null, substitutionFnam: "");
-        var written = Write(ParseOverlay(bytes));
-        CountSubrecords(written, "FNAM").ShouldBe(0);
+        var written = Write(ParseOverlay(BuildMswpBytes(NewFormVersion, topFnam: null)));
+        CountFnam(written).ShouldBe(0);
         ParseOverlay(written).TreeFolder.ShouldBeNull();
     }
 
     [Fact]
-    public void Overlay_V131WithTopFnam_WritesOneFnam()
+    public void Overlay_NewFormVersionTopFnam_WritesOneFnam()
     {
-        var bytes = BuildMswpBytes(131, topFnam: "materials", substitutionFnam: "");
-        var written = Write(ParseOverlay(bytes));
-        CountSubrecords(written, "FNAM").ShouldBe(1);
+        var written = Write(ParseOverlay(BuildMswpBytes(NewFormVersion, topFnam: "materials")));
+        CountFnam(written).ShouldBe(1);
         ParseOverlay(written).TreeFolder.ShouldBe("materials");
     }
 }

--- a/Mutagen.Bethesda.UnitTests/Plugins/Records/Fallout4/MaterialSwapFormVersionGateTests.cs
+++ b/Mutagen.Bethesda.UnitTests/Plugins/Records/Fallout4/MaterialSwapFormVersionGateTests.cs
@@ -25,10 +25,13 @@ public class MaterialSwapFormVersionGateTests
     /// string; 112+, the top FNAM is the tree folder and a substitution's own FNAM is
     /// vestigial and may legitimately differ.
     /// </summary>
-    private static byte[] BuildMswpBytes(ushort formVersion, string topFnam, string substitutionFnam)
+    private static byte[] BuildMswpBytes(ushort formVersion, string? topFnam, string substitutionFnam)
     {
         var content = new List<byte>();
-        content.AddRange(Subrecord("FNAM", NullTerminated(topFnam)));
+        if (topFnam != null)
+        {
+            content.AddRange(Subrecord("FNAM", NullTerminated(topFnam)));
+        }
         content.AddRange(Subrecord("BNAM", NullTerminated("OriginalMat")));
         content.AddRange(Subrecord("SNAM", NullTerminated("ReplacementMat")));
         content.AddRange(Subrecord("FNAM", NullTerminated(substitutionFnam)));
@@ -73,6 +76,35 @@ public class MaterialSwapFormVersionGateTests
             new BinaryOverlayFactoryPackage(Meta()));
     }
 
+    private static byte[] Write(IMaterialSwapGetter item)
+    {
+        var masters = new MasterReferenceCollection(global::Mutagen.Bethesda.Fallout4.Constants.Fallout4);
+        var stream = new MemoryStream();
+        using (var writer = new MutagenWriter(
+                   stream,
+                   new WritingBundle(GameConstants.Fallout4)
+                   {
+                       MasterReferences = masters,
+                       SeparatedMasterPackage = SeparatedMasterPackage.NotSeparate(masters),
+                   }))
+        {
+            MaterialSwapBinaryWriteTranslation.Instance.Write(writer, item, default);
+        }
+        return stream.ToArray();
+    }
+
+    private static int CountSubrecords(byte[] bytes, string type)
+    {
+        var count = 0;
+        var pos = 24;
+        while (pos < bytes.Length)
+        {
+            if (Encoding.ASCII.GetString(bytes, pos, 4) == type) count++;
+            pos += 6 + BinaryPrimitives.ReadUInt16LittleEndian(bytes.AsSpan(pos + 4));
+        }
+        return count;
+    }
+
     [Fact]
     public void DeepParse_V131DifferingFnam_ParsesTreeFolder()
     {
@@ -102,5 +134,39 @@ public class MaterialSwapFormVersionGateTests
         var bytes = BuildMswpBytes(90, topFnam: "materials", substitutionFnam: "");
         var item = ParseOverlay(bytes);
         Should.Throw<MalformedDataException>(() => item.TreeFolder);
+    }
+
+    [Fact]
+    public void DeepParse_V131NoTopFnam_TreeFolderIsNull()
+    {
+        var bytes = BuildMswpBytes(131, topFnam: null, substitutionFnam: "");
+        var item = ParseDeep(bytes);
+        item.TreeFolder.ShouldBeNull();
+    }
+
+    [Fact]
+    public void Overlay_V131NoTopFnam_TreeFolderIsNull()
+    {
+        var bytes = BuildMswpBytes(131, topFnam: null, substitutionFnam: "");
+        var item = ParseOverlay(bytes);
+        item.TreeFolder.ShouldBeNull();
+    }
+
+    [Fact]
+    public void Overlay_V131NoTopFnam_WritesNoFnam()
+    {
+        var bytes = BuildMswpBytes(131, topFnam: null, substitutionFnam: "");
+        var written = Write(ParseOverlay(bytes));
+        CountSubrecords(written, "FNAM").ShouldBe(0);
+        ParseOverlay(written).TreeFolder.ShouldBeNull();
+    }
+
+    [Fact]
+    public void Overlay_V131WithTopFnam_WritesOneFnam()
+    {
+        var bytes = BuildMswpBytes(131, topFnam: "materials", substitutionFnam: "");
+        var written = Write(ParseOverlay(bytes));
+        CountSubrecords(written, "FNAM").ShouldBe(1);
+        ParseOverlay(written).TreeFolder.ShouldBe("materials");
     }
 }

--- a/Mutagen.Bethesda.UnitTests/Plugins/Records/Fallout4/MaterialSwapFormVersionGateTests.cs
+++ b/Mutagen.Bethesda.UnitTests/Plugins/Records/Fallout4/MaterialSwapFormVersionGateTests.cs
@@ -15,9 +15,6 @@ using Fallout4Constants = Mutagen.Bethesda.Fallout4.Constants;
 
 namespace Mutagen.Bethesda.UnitTests.Plugins.Records.Fallout4;
 
-// Regression coverage for https://github.com/Mutagen-Modding/Mutagen/issues/687:
-// MaterialSwap's FNAM form-version gate needs FormVersion while its custom
-// struct-fill runs, on both the deep parser and the overlay.
 public class MaterialSwapFormVersionGateTests
 {
     private const ushort NewFormVersion = MaterialSwapBinaryCreateTranslation.NewFormVersion;


### PR DESCRIPTION
…(Mutagen-Modding/Mutagen#687)

PluginUtilityTranslation.MajorRecordParse set frame.MetaData.FormVersion from record.FormVersion only after fillStructs returned, but MaterialSwap's FillBinaryFNAMParsingCustom (Fallout4) reads frame.MetaData.FormVersion from inside fillStructs, so it always saw null/stale and took the legacy same-string-required path, throwing MalformedDataException on well-formed v112+ MSWP records whose second FNAM is a substitution's obsolete tree-folder field. Peek the FormVersion directly off the record's header bytes (frame.Reader.GetMajorRecordHeader().FormVersion) before fillStructs runs, since record.FormVersion itself isn't populated until fillStructs does so.

The overlay factory path had a separate, independent bug with the same symptom: MaterialSwapBinaryOverlay's generated FillRecordType switch guard used stream.MetaData.FormVersion, which is never populated anywhere in the overlay-mode read path (confirmed via full-repo grep of assignment sites) - so a v112+ record's top-level FNAM was unconditionally mis-routed into Substitutions-list parsing instead of being captured as TreeFolder, corrupting both fields for every overlay-mode read of a v112+ MaterialSwap, not just the malformed-duplicate-FNAM case. Root cause traced to the generator itself (PluginTranslationModule.cs:1754): the duplicate-trigger+versioning overlay guard emitted "stream.MetaData.FormVersion", while the sibling RecordTypeVersioning guard six lines above already used the correct, always-live "this._package.FormVersion!.FormVersion" pattern (matching BodyTemplate.cs's and ImageSpace.cs's own hand-written overlay idiom). Fixed the generator to use the same correct pattern and regenerated (Fallout4 single-game generator, then Generator.All - confirmed via diff that only MaterialSwap_Generated.cs changed; Generator.All's Cell/Worldspace trigger-order and MultiModOverlay cell-merging diffs across all five games are pre-existing drift between checked-in output and the generator, unrelated to this change, and were reverted). MaterialSwapBinaryOverlay's hand-written custom fill (MaterialSwap.cs) now reads this.FormVersion (the overlay's own live, on-demand header read) instead of the broken tracker.

Audit for other MetaData.FormVersion reads inside a *StructsCustom/ FillBinaryStructs path (the same deep-parse ordering bug would apply to any of them): none found. Every other FormVersion-gated field across Fallout3/Fallout4/Skyrim/Starfield (Race, Explosion, EffectShader, ImageSpace, CriticalData, Ammunition, Weather, LandscapeTexture, BodyTemplate, Leveled*, MagicEffectSound, WeaponDamageType, DamageTypeValue, ObjectProperty, BlockEditorMetaDataComponent) reads frame.MetaData.FormVersion only from within the per-subrecord dispatch loop (FillBinaryRecordTypes) or a write path, both of which already run after FormVersion is set. MaterialSwap.TreeFolder is the only field in the fork combining binary="Custom" with <Versioning> on a record type that collides with another field's trigger, so it was also the only one exercising the broken overlay-guard generator path.

Adds a fixture-free unit test (MaterialSwapFormVersionGateTests) that hand-builds minimal MSWP bytes in memory and covers both the deep parser and the overlay factory: a v131 record with two differing FNAMs now parses (TreeFolder from the top FNAM, substitution's own FNAM ignored), while a sub-112 record with differing FNAMs still throws MalformedDataException, preserving legacy behavior.