### PR TITLE
Fix ScriptStructListProperty/ScriptEntryStructs missing FormLinkConta…

### DIFF
--- a/Mutagen.Bethesda.Fallout4/Records/Common Subrecords/ScriptEntryStructs_Generated.cs
+++ b/Mutagen.Bethesda.Fallout4/Records/Common Subrecords/ScriptEntryStructs_Generated.cs
@@ -424,6 +424,11 @@ namespace Mutagen.Bethesda.Fallout4
         }
         #endregion
 
+        #region Mutagen
+        public IEnumerable<IFormLinkGetter> EnumerateFormLinks(bool iterateNestedRecords = true) => ScriptEntryStructsCommon.Instance.EnumerateFormLinks(this, iterateNestedRecords);
+        public void RemapLinks(IReadOnlyDictionary<FormKey, FormKey> mapping) => ScriptEntryStructsSetterCommon.Instance.RemapLinks(this, mapping);
+        #endregion
+
         #region Binary Translation
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
         protected object BinaryWriteTranslator => ScriptEntryStructsBinaryWriteTranslation.Instance;
@@ -483,6 +488,7 @@ namespace Mutagen.Bethesda.Fallout4
 
     #region Interface
     public partial interface IScriptEntryStructs :
+        IFormLinkContainer,
         ILoquiObjectSetter<IScriptEntryStructs>,
         IScriptEntryStructsGetter
     {
@@ -492,6 +498,7 @@ namespace Mutagen.Bethesda.Fallout4
     public partial interface IScriptEntryStructsGetter :
         ILoquiObject,
         IBinaryItem,
+        IFormLinkContainerGetter,
         ILoquiObject<IScriptEntryStructsGetter>
     {
         [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]

--- a/Mutagen.Bethesda.Fallout4/Records/Common Subrecords/ScriptStructListProperty_Generated.cs
+++ b/Mutagen.Bethesda.Fallout4/Records/Common Subrecords/ScriptStructListProperty_Generated.cs
@@ -424,6 +424,11 @@ namespace Mutagen.Bethesda.Fallout4
         }
         #endregion
 
+        #region Mutagen
+        public override IEnumerable<IFormLinkGetter> EnumerateFormLinks(bool iterateNestedRecords = true) => ScriptStructListPropertyCommon.Instance.EnumerateFormLinks(this, iterateNestedRecords);
+        public override void RemapLinks(IReadOnlyDictionary<FormKey, FormKey> mapping) => ScriptStructListPropertySetterCommon.Instance.RemapLinks(this, mapping);
+        #endregion
+
         #region Binary Translation
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
         protected override object BinaryWriteTranslator => ScriptStructListPropertyBinaryWriteTranslation.Instance;
@@ -481,6 +486,7 @@ namespace Mutagen.Bethesda.Fallout4
 
     #region Interface
     public partial interface IScriptStructListProperty :
+        IFormLinkContainer,
         ILoquiObjectSetter<IScriptStructListProperty>,
         INamedRequired,
         IScriptProperty,
@@ -492,6 +498,7 @@ namespace Mutagen.Bethesda.Fallout4
     public partial interface IScriptStructListPropertyGetter :
         IScriptPropertyGetter,
         IBinaryItem,
+        IFormLinkContainerGetter,
         ILoquiObject<IScriptStructListPropertyGetter>,
         INamedRequiredGetter
     {
@@ -735,6 +742,7 @@ namespace Mutagen.Bethesda.Fallout4
         public void RemapLinks(IScriptStructListProperty obj, IReadOnlyDictionary<FormKey, FormKey> mapping)
         {
             base.RemapLinks(obj, mapping);
+            obj.Structs.RemapLinks(mapping);
         }
         
         #endregion
@@ -925,6 +933,11 @@ namespace Mutagen.Bethesda.Fallout4
             foreach (var item in base.EnumerateFormLinks(obj, iterateNestedRecords))
             {
                 yield return item;
+            }
+            foreach (var item in obj.Structs.WhereCastable<IScriptEntryStructsGetter, IFormLinkContainerGetter>()
+                .SelectMany((f) => f.EnumerateFormLinks(iterateNestedRecords)))
+            {
+                yield return FormLinkInformation.Factory(item);
             }
             yield break;
         }

--- a/Mutagen.Bethesda.Fallout4/Records/Common Subrecords/ScriptStructProperty_Generated.cs
+++ b/Mutagen.Bethesda.Fallout4/Records/Common Subrecords/ScriptStructProperty_Generated.cs
@@ -424,6 +424,11 @@ namespace Mutagen.Bethesda.Fallout4
         }
         #endregion
 
+        #region Mutagen
+        public override IEnumerable<IFormLinkGetter> EnumerateFormLinks(bool iterateNestedRecords = true) => ScriptStructPropertyCommon.Instance.EnumerateFormLinks(this, iterateNestedRecords);
+        public override void RemapLinks(IReadOnlyDictionary<FormKey, FormKey> mapping) => ScriptStructPropertySetterCommon.Instance.RemapLinks(this, mapping);
+        #endregion
+
         #region Binary Translation
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
         protected override object BinaryWriteTranslator => ScriptStructPropertyBinaryWriteTranslation.Instance;
@@ -481,6 +486,7 @@ namespace Mutagen.Bethesda.Fallout4
 
     #region Interface
     public partial interface IScriptStructProperty :
+        IFormLinkContainer,
         ILoquiObjectSetter<IScriptStructProperty>,
         INamedRequired,
         IScriptProperty,
@@ -492,6 +498,7 @@ namespace Mutagen.Bethesda.Fallout4
     public partial interface IScriptStructPropertyGetter :
         IScriptPropertyGetter,
         IBinaryItem,
+        IFormLinkContainerGetter,
         ILoquiObject<IScriptStructPropertyGetter>,
         INamedRequiredGetter
     {

--- a/Mutagen.Bethesda.Generation/Modules/Plugin/AContainedLinksModule.cs
+++ b/Mutagen.Bethesda.Generation/Modules/Plugin/AContainedLinksModule.cs
@@ -6,6 +6,18 @@ namespace Mutagen.Bethesda.Generation.Modules.Plugin;
 public abstract class AContainedLinksModule<TLinkType> : GenerationModule
     where TLinkType : TypeGeneration
 {
+    /// <summary>
+    /// What a circular field (GetFieldData().Circular == true) contributes to its
+    /// containing object's HasLinks determination. We never recurse into a circular
+    /// field's referenced type (that's exactly the generation-time infinite recursion
+    /// the "circular" marker exists to prevent), so this is a static, per-link-kind
+    /// answer to "could this unknown field plausibly contain a link of this kind?" —
+    /// not something derivable from the field itself. Default preserves the original
+    /// behavior (contributes nothing); override where a concrete circular field in the
+    /// XML is known to carry that kind of link (e.g. FormLinks via ScriptEntryStructs.Members).
+    /// </summary>
+    protected virtual Case CircularFieldCase => Case.No;
+
     public virtual async Task<Case> HasLinks(LoquiType loqui, bool includeBaseClass, GenericSpecification? specifications = null)
     {
         if (specifications != null)
@@ -34,7 +46,19 @@ public abstract class AContainedLinksModule<TLinkType> : GenerationModule
         Case bestCase = Case.No;
         foreach (var field in obj.IterateFields(includeBaseClass: includeBaseClass))
         {
-            if (field.GetFieldData().Circular) continue;
+            if (field.GetFieldData().Circular)
+            {
+                // Recursing into a circular field's referenced type risks infinite
+                // generation-time recursion (the type graph loops back to this object).
+                // We can't safely recurse, so subclasses decide what an unknown circular
+                // field contributes (see CircularFieldCase) instead of this shared base
+                // silently excluding it for every link kind.
+                if (CircularFieldCase > bestCase)
+                {
+                    bestCase = CircularFieldCase;
+                }
+                continue;
+            }
             if (field is LoquiType loqui)
             {
                 var subCase = await HasLinks(loqui, includeBaseClass: true, specifications);

--- a/Mutagen.Bethesda.Generation/Modules/Plugin/ContainedFormLinksModule.cs
+++ b/Mutagen.Bethesda.Generation/Modules/Plugin/ContainedFormLinksModule.cs
@@ -14,7 +14,14 @@ namespace Mutagen.Bethesda.Generation.Modules.Plugin;
 public class ContainedFormLinksModule : AContainedLinksModule<FormLinkType>
 {
     public static ContainedFormLinksModule Instance = new();
-    
+
+    // A circular field (e.g. ScriptEntryStructs.Members, RefList<ScriptProperty>) can't be
+    // recursed into at generation time, but its runtime contents can genuinely be a
+    // ScriptObjectProperty carrying a FormLink — so "maybe" here falls back to the existing
+    // runtime WhereCastable<T, IFormLinkContainerGetter> dispatch instead of silently
+    // excluding the field from EnumerateFormLinks (Mutagen-Modding/Mutagen#688).
+    protected override Case CircularFieldCase => Case.Maybe;
+
     public override async IAsyncEnumerable<(LoquiInterfaceType Location, string Interface)> Interfaces(ObjectGeneration obj)
     {
         if (await HasLinks(obj, includeBaseClass: false) != Case.No)

--- a/Mutagen.Bethesda.Starfield/Records/Common Subrecords/ScriptEntryStructs_Generated.cs
+++ b/Mutagen.Bethesda.Starfield/Records/Common Subrecords/ScriptEntryStructs_Generated.cs
@@ -424,6 +424,11 @@ namespace Mutagen.Bethesda.Starfield
         }
         #endregion
 
+        #region Mutagen
+        public IEnumerable<IFormLinkGetter> EnumerateFormLinks(bool iterateNestedRecords = true) => ScriptEntryStructsCommon.Instance.EnumerateFormLinks(this, iterateNestedRecords);
+        public void RemapLinks(IReadOnlyDictionary<FormKey, FormKey> mapping) => ScriptEntryStructsSetterCommon.Instance.RemapLinks(this, mapping);
+        #endregion
+
         #region Binary Translation
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
         protected object BinaryWriteTranslator => ScriptEntryStructsBinaryWriteTranslation.Instance;
@@ -483,6 +488,7 @@ namespace Mutagen.Bethesda.Starfield
 
     #region Interface
     public partial interface IScriptEntryStructs :
+        IFormLinkContainer,
         ILoquiObjectSetter<IScriptEntryStructs>,
         IScriptEntryStructsGetter
     {
@@ -492,6 +498,7 @@ namespace Mutagen.Bethesda.Starfield
     public partial interface IScriptEntryStructsGetter :
         ILoquiObject,
         IBinaryItem,
+        IFormLinkContainerGetter,
         ILoquiObject<IScriptEntryStructsGetter>
     {
         [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]

--- a/Mutagen.Bethesda.Starfield/Records/Common Subrecords/ScriptStructListProperty_Generated.cs
+++ b/Mutagen.Bethesda.Starfield/Records/Common Subrecords/ScriptStructListProperty_Generated.cs
@@ -424,6 +424,11 @@ namespace Mutagen.Bethesda.Starfield
         }
         #endregion
 
+        #region Mutagen
+        public override IEnumerable<IFormLinkGetter> EnumerateFormLinks(bool iterateNestedRecords = true) => ScriptStructListPropertyCommon.Instance.EnumerateFormLinks(this, iterateNestedRecords);
+        public override void RemapLinks(IReadOnlyDictionary<FormKey, FormKey> mapping) => ScriptStructListPropertySetterCommon.Instance.RemapLinks(this, mapping);
+        #endregion
+
         #region Binary Translation
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
         protected override object BinaryWriteTranslator => ScriptStructListPropertyBinaryWriteTranslation.Instance;
@@ -481,6 +486,7 @@ namespace Mutagen.Bethesda.Starfield
 
     #region Interface
     public partial interface IScriptStructListProperty :
+        IFormLinkContainer,
         ILoquiObjectSetter<IScriptStructListProperty>,
         INamedRequired,
         IScriptProperty,
@@ -492,6 +498,7 @@ namespace Mutagen.Bethesda.Starfield
     public partial interface IScriptStructListPropertyGetter :
         IScriptPropertyGetter,
         IBinaryItem,
+        IFormLinkContainerGetter,
         ILoquiObject<IScriptStructListPropertyGetter>,
         INamedRequiredGetter
     {
@@ -735,6 +742,7 @@ namespace Mutagen.Bethesda.Starfield
         public void RemapLinks(IScriptStructListProperty obj, IReadOnlyDictionary<FormKey, FormKey> mapping)
         {
             base.RemapLinks(obj, mapping);
+            obj.Structs.RemapLinks(mapping);
         }
         
         #endregion
@@ -925,6 +933,11 @@ namespace Mutagen.Bethesda.Starfield
             foreach (var item in base.EnumerateFormLinks(obj, iterateNestedRecords))
             {
                 yield return item;
+            }
+            foreach (var item in obj.Structs.WhereCastable<IScriptEntryStructsGetter, IFormLinkContainerGetter>()
+                .SelectMany((f) => f.EnumerateFormLinks(iterateNestedRecords)))
+            {
+                yield return FormLinkInformation.Factory(item);
             }
             yield break;
         }

--- a/Mutagen.Bethesda.Starfield/Records/Common Subrecords/ScriptStructProperty_Generated.cs
+++ b/Mutagen.Bethesda.Starfield/Records/Common Subrecords/ScriptStructProperty_Generated.cs
@@ -424,6 +424,11 @@ namespace Mutagen.Bethesda.Starfield
         }
         #endregion
 
+        #region Mutagen
+        public override IEnumerable<IFormLinkGetter> EnumerateFormLinks(bool iterateNestedRecords = true) => ScriptStructPropertyCommon.Instance.EnumerateFormLinks(this, iterateNestedRecords);
+        public override void RemapLinks(IReadOnlyDictionary<FormKey, FormKey> mapping) => ScriptStructPropertySetterCommon.Instance.RemapLinks(this, mapping);
+        #endregion
+
         #region Binary Translation
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
         protected override object BinaryWriteTranslator => ScriptStructPropertyBinaryWriteTranslation.Instance;
@@ -481,6 +486,7 @@ namespace Mutagen.Bethesda.Starfield
 
     #region Interface
     public partial interface IScriptStructProperty :
+        IFormLinkContainer,
         ILoquiObjectSetter<IScriptStructProperty>,
         INamedRequired,
         IScriptProperty,
@@ -492,6 +498,7 @@ namespace Mutagen.Bethesda.Starfield
     public partial interface IScriptStructPropertyGetter :
         IScriptPropertyGetter,
         IBinaryItem,
+        IFormLinkContainerGetter,
         ILoquiObject<IScriptStructPropertyGetter>,
         INamedRequiredGetter
     {

--- a/Mutagen.Bethesda.UnitTests/Plugins/Records/Fallout4/ScriptStructListPropertyFormLinksTests.cs
+++ b/Mutagen.Bethesda.UnitTests/Plugins/Records/Fallout4/ScriptStructListPropertyFormLinksTests.cs
@@ -1,0 +1,71 @@
+using Shouldly;
+using System.IO.Abstractions;
+using System.Linq;
+using Mutagen.Bethesda.Plugins;
+using Mutagen.Bethesda.Plugins.Binary.Parameters;
+using Mutagen.Bethesda.Fallout4;
+using Mutagen.Bethesda.Testing.AutoData;
+using Noggog;
+using Xunit;
+
+namespace Mutagen.Bethesda.UnitTests.Plugins.Records.Fallout4;
+
+// Mutagen-Modding/Mutagen#688: ScriptStructListProperty.EnumerateFormLinks did not
+// descend into Structs[*].Members, so a master referenced only from a VMAD struct-array
+// property was pruned by MastersListContentOption.Iterate and the write threw
+// UnmappableFormIDException.
+public class ScriptStructListPropertyFormLinksTests
+{
+    private static Quest BuildQuestWithStructListFormLink(Fallout4Mod mod, FormKey linkedKey)
+    {
+        var quest = mod.Quests.AddNew();
+        var adapter = new QuestAdapter();
+        quest.VirtualMachineAdapter = adapter;
+        var entry = new ScriptEntry { Name = "TestScript" };
+        var structListProp = new ScriptStructListProperty { Name = "TestStructListProp" };
+        var entryStruct = new ScriptEntryStructs();
+        var objProp = new ScriptObjectProperty { Name = "TestObjProp" };
+        objProp.Object.SetTo(linkedKey);
+        entryStruct.Members.Add(objProp);
+        structListProp.Structs.Add(entryStruct);
+        entry.Properties.Add(structListProp);
+        adapter.Scripts.Add(entry);
+        return quest;
+    }
+
+    [Fact]
+    public void EnumerateFormLinks_DescendsIntoStructListMembers()
+    {
+        var mod = new Fallout4Mod(ModKey.FromNameAndExtension("Test.esp"), Fallout4Release.Fallout4);
+        var otherKey = FormKey.Factory("123456:Other.esp");
+        var quest = BuildQuestWithStructListFormLink(mod, otherKey);
+
+        quest.EnumerateFormLinks().Select(x => x.FormKey).ShouldContain(otherKey);
+    }
+
+    [Theory, MutagenAutoData]
+    public void Write_WithStructListFormLink_KeepsMasterAndDoesNotThrow(
+        IFileSystem fileSystem,
+        DirectoryPath existingFolder)
+    {
+        var modKey = ModKey.FromNameAndExtension("Test.esp");
+        var otherKey = FormKey.Factory("123456:Other.esp");
+        var mod = new Fallout4Mod(modKey, Fallout4Release.Fallout4);
+        BuildQuestWithStructListFormLink(mod, otherKey);
+
+        var modPath = Path.Combine(existingFolder, modKey.FileName);
+        mod.BeginWrite
+            .ToPath(modPath)
+            .WithNoLoadOrder()
+            .NoModKeySync()
+            .WithMastersListContent(MastersListContentOption.Iterate)
+            .WithFileSystem(fileSystem)
+            .Write();
+
+        using var reimport = Fallout4Mod.Create(Fallout4Release.Fallout4)
+            .FromPath(modPath)
+            .WithFileSystem(fileSystem)
+            .Construct();
+        reimport.ModHeader.MasterReferences.Select(m => m.Master).ShouldContain(otherKey.ModKey);
+    }
+}

--- a/Mutagen.Bethesda.UnitTests/Plugins/Records/Starfield/ScriptStructListPropertyFormLinksTests.cs
+++ b/Mutagen.Bethesda.UnitTests/Plugins/Records/Starfield/ScriptStructListPropertyFormLinksTests.cs
@@ -1,0 +1,78 @@
+using Shouldly;
+using System.IO.Abstractions;
+using System.Linq;
+using Mutagen.Bethesda.Plugins;
+using Mutagen.Bethesda.Plugins.Binary.Parameters;
+using Mutagen.Bethesda.Plugins.Masters;
+using Mutagen.Bethesda.Starfield;
+using Mutagen.Bethesda.Testing.AutoData;
+using Mutagen.Bethesda.UnitTests.Plugins.Masters;
+using Noggog;
+using Xunit;
+
+namespace Mutagen.Bethesda.UnitTests.Plugins.Records.Starfield;
+
+// Mutagen-Modding/Mutagen#688: same gap as the Fallout4 case (see
+// Plugins/Records/Fallout4/ScriptStructListPropertyFormLinksTests.cs) — Starfield defines
+// ScriptStructListProperty/ScriptEntryStructs with the same circular Members shape.
+public class ScriptStructListPropertyFormLinksTests
+{
+    private static Quest BuildQuestWithStructListFormLink(StarfieldMod mod, FormKey linkedKey)
+    {
+        var quest = mod.Quests.AddNew();
+        var adapter = new QuestAdapter();
+        quest.VirtualMachineAdapter = adapter;
+        var entry = new ScriptEntry { Name = "TestScript" };
+        var structListProp = new ScriptStructListProperty { Name = "TestStructListProp" };
+        var entryStruct = new ScriptEntryStructs();
+        var objProp = new ScriptObjectProperty { Name = "TestObjProp" };
+        objProp.Object.SetTo(linkedKey);
+        entryStruct.Members.Add(objProp);
+        structListProp.Structs.Add(entryStruct);
+        entry.Properties.Add(structListProp);
+        adapter.Scripts.Add(entry);
+        return quest;
+    }
+
+    [Fact]
+    public void EnumerateFormLinks_DescendsIntoStructListMembers()
+    {
+        var mod = new StarfieldMod(ModKey.FromNameAndExtension("Test.esp"), StarfieldRelease.Starfield);
+        var otherKey = FormKey.Factory("123456:Other.esp");
+        var quest = BuildQuestWithStructListFormLink(mod, otherKey);
+
+        quest.EnumerateFormLinks().Select(x => x.FormKey).ShouldContain(otherKey);
+    }
+
+    [Theory, MutagenAutoData]
+    public void Write_WithStructListFormLink_KeepsMasterAndDoesNotThrow(
+        IFileSystem fileSystem,
+        DirectoryPath existingFolder)
+    {
+        var modKey = ModKey.FromNameAndExtension("Test.esp");
+        var otherKey = FormKey.Factory("123456:Other.esp");
+        var mod = new StarfieldMod(modKey, StarfieldRelease.Starfield);
+        BuildQuestWithStructListFormLink(mod, otherKey);
+
+        // Starfield separates masters by MasterStyle (full/medium/small), so - unlike
+        // Fallout4 - writing needs a load order that resolves each referenced master's
+        // style, not WithNoLoadOrder().
+        var lo = new[] { MastersTestUtil.GetFlags(otherKey.ModKey, MasterStyle.Full) };
+
+        var modPath = Path.Combine(existingFolder, modKey.FileName);
+        mod.BeginWrite
+            .ToPath(modPath)
+            .WithLoadOrder(lo)
+            .NoModKeySync()
+            .WithMastersListContent(MastersListContentOption.Iterate)
+            .WithFileSystem(fileSystem)
+            .Write();
+
+        using var reimport = StarfieldMod.Create(StarfieldRelease.Starfield)
+            .FromPath(modPath)
+            .WithLoadOrder(lo)
+            .WithFileSystem(fileSystem)
+            .Construct();
+        reimport.ModHeader.MasterReferences.Select(m => m.Master).ShouldContain(otherKey.ModKey);
+    }
+}


### PR DESCRIPTION
…iner (#688)

ScriptStructListProperty.Structs holds ScriptEntryStructs, whose Members (RefList<ScriptProperty>) can contain a ScriptObjectProperty carrying a FormLink. That field is marked Circular in the XML to avoid infinite generation-time recursion, so AContainedLinksModule's shared base previously skipped it entirely for every link kind, meaning EnumerateFormLinks never descended into it. A master referenced only from a VMAD struct-array property was then pruned by
MastersListContentOption.Iterate and the subsequent Write threw UnmappableFormIDException.

Fix is narrow and shared-base-safe:

- AContainedLinksModule gains a virtual CircularFieldCase hook (default Case.No, preserving prior behavior for every existing subclass) that a subclass can override to say what an unknown circular field contributes to HasLinks, instead of the base silently excluding it.
- ContainedFormLinksModule overrides it to Case.Maybe, falling back to the existing runtime WhereCastable<T, IFormLinkContainerGetter> dispatch. ContainedAssetLinksModule is untouched and keeps the original Case.No default, so asset-link behavior is unchanged.
- Regenerated ScriptStructListProperty_Generated.cs / ScriptEntryStructs_Generated.cs for Fallout4 and Starfield, which share this exact circular-Members shape. ScriptProperty_Generated.cs has zero diff in either game, confirming the fix doesn't touch the unrelated ScriptProperty.Type- shadows-System.Type path that regressed a prior attempt.

Adds ScriptStructListPropertyFormLinksTests (Fallout4 + Starfield): one test asserting Quest.EnumerateFormLinks() finds a FormLink buried in a ScriptStructListProperty's Structs, one asserting Write with the default MastersListContentOption.Iterate keeps the master and doesn't throw.

Fixes Mutagen-Modding/Mutagen#688