### PR TITLE
Fix GlobalBool binary writer FLTV length mismatch

### DIFF
--- a/Mutagen.Bethesda.Fallout4/Records/Major Records/GlobalBool.cs
+++ b/Mutagen.Bethesda.Fallout4/Records/Major Records/GlobalBool.cs
@@ -42,7 +42,7 @@ partial class GlobalBoolBinaryWriteTranslation
         if (item.Data is not {} data) return;
         using (HeaderExport.Subrecord(writer, RecordTypes.FLTV))
         {
-            writer.Write(data);
+            writer.Write(data ? 1f : 0f);
         }
     }
 }

--- a/Mutagen.Bethesda.UnitTests/Plugins/Records/Fallout4/GlobalBoolRoundTripTests.cs
+++ b/Mutagen.Bethesda.UnitTests/Plugins/Records/Fallout4/GlobalBoolRoundTripTests.cs
@@ -1,0 +1,65 @@
+using Mutagen.Bethesda.Fallout4;
+using Mutagen.Bethesda.Plugins;
+using Shouldly;
+using Xunit;
+using TempFile = Noggog.IO.TempFile;
+
+namespace Mutagen.Bethesda.UnitTests.Plugins.Records.Fallout4;
+
+// Regression coverage for https://github.com/Mutagen-Modding/Mutagen/issues/538:
+// GlobalBool's binary writer wrote its FLTV subrecord as a raw 1-byte bool instead
+// of the 4-byte float every other Global subtype (and both readers) expect, so a
+// GlobalBool written by Mutagen's own writer could not be read back by Mutagen's
+// own reader.
+public class GlobalBoolRoundTripTests
+{
+    private static Fallout4Mod WriteModWithGlobalBool(TempFile tmp, bool value, out FormKey formKey)
+    {
+        var mod = new Fallout4Mod(ModKey.FromNameAndExtension("GlobalBoolRoundTrip.esp"), Fallout4Release.Fallout4);
+        var glob = new GlobalBool(mod.GetNextFormKey(), Fallout4Release.Fallout4)
+        {
+            Data = value,
+            EditorID = "GlobalBoolRoundTrip",
+        };
+        mod.Globals.Add(glob);
+        formKey = glob.FormKey;
+
+        var path = new ModPath(mod.ModKey, tmp.File.Path);
+        mod.BeginWrite
+            .ToPath(path)
+            .WithNoLoadOrder()
+            .NoModKeySync()
+            .Write();
+        return mod;
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void WriteThenReadBinary_RoundTripsData(bool value)
+    {
+        using var tmp = new TempFile(extraDirectoryPaths: TestPathing.TempFolderPath, suffix: ".esp");
+        var written = WriteModWithGlobalBool(tmp, value, out var formKey);
+        var path = new ModPath(written.ModKey, tmp.File.Path);
+
+        var reloaded = Fallout4Mod.CreateFromBinary(path, Fallout4Release.Fallout4);
+        var reloadedGlob = (GlobalBool)reloaded.Globals.Records.First(g => g.FormKey == formKey);
+
+        reloadedGlob.Data.ShouldBe(value);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void WriteThenReadBinaryOverlay_RoundTripsData(bool value)
+    {
+        using var tmp = new TempFile(extraDirectoryPaths: TestPathing.TempFolderPath, suffix: ".esp");
+        var written = WriteModWithGlobalBool(tmp, value, out var formKey);
+        var path = new ModPath(written.ModKey, tmp.File.Path);
+
+        using var reloaded = Fallout4Mod.CreateFromBinaryOverlay(path, Fallout4Release.Fallout4);
+        var reloadedGlob = (IGlobalBoolGetter)reloaded.Globals.Records.First(g => g.FormKey == formKey);
+
+        reloadedGlob.Data.ShouldBe(value);
+    }
+}


### PR DESCRIPTION
GlobalBool.WriteBinaryDataCustom wrote its FLTV subrecord as a raw 1-byte bool (writer.Write(data)) instead of the 4-byte float every other Global subtype uses. GLOB's FLTV payload is always a 4-byte float on disk regardless of declared subtype (FNAM is a display-type
hint only) — proven by the read side: GlobalCustomParsing.Create<T>
unconditionally reads FLTV via fltv.AsFloat() for every Global subtype, and GlobalBoolBinaryOverlay.GetDataCustom() independently also expects 4 bytes. GlobalShort/GlobalInt's own custom writers already cast to float before writing; GlobalBool's writer forgot to.

Net effect: a GlobalBool written by Mutagen's own writer could not be read back by either of Mutagen's own readers —
Fallout4Mod.CreateFromBinary threw "FLTV Subrecord frame had unexpected length: 1 != 4", and CreateFromBinaryOverlay threw ArgumentOutOfRangeException in Noggog.SpanExt.Float.

Fix: write data ? 1f : 0f instead of the raw bool, mirroring GlobalShort's cast pattern.

Adds GlobalBoolRoundTripTests (Mutagen.Bethesda.UnitTests, Fallout4) covering both the mutable CreateFromBinary path and the CreateFromBinaryOverlay path, true and false — fixture-free, red on dev, green with this fix.